### PR TITLE
Feature/ope 43 convex compliance phase 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,677 @@ Do not edit generated files in `convex/_generated/` by hand.
 - Vitest is the default test runner.
 - Name tests `*.test.ts` or `*.test.tsx` and keep them close to the code they cover.
 - Prioritize coverage for booking logic, snapshot generation, authz helpers, webhook handling, and telemetry redaction.
+- For Convex behavior, follow the official Convex testing guidance and prefer `convex-test` with the real schema over ad hoc mocked `ctx.db` chains.
+- Put Convex-backed regression tests in `packages/testing/src/` unless they are pure helper tests that naturally belong next to a package module.
+- Use the `edge-runtime` Vitest environment for `convex-test`, and pass an explicit module map such as `import.meta.glob("../../../convex/**/*.ts")` when creating the test harness in this repo.
+- Keep pure data and string helpers as normal Vitest unit tests, but test index-dependent reads, auth-sensitive flows, and Convex document mutations against the in-memory Convex backend.
 - Before opening a PR, run `pnpm typecheck`, `pnpm build`, and `pnpm test`.
 
 ## Architecture Guardrails
 - `convex/` is the main backend. Do not move durable business logic into the voice gateway.
 - For live calls, fetch the business context snapshot once at call start; avoid per-turn backend round-trips for common replies.
+
+# Convex guidelines
+## Function guidelines
+### Http endpoint syntax
+- HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
+```typescript
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+const http = httpRouter();
+http.route({
+    path: "/echo",
+    method: "POST",
+    handler: httpAction(async (ctx, req) => {
+    const body = await req.bytes();
+    return new Response(body, { status: 200 });
+    }),
+});
+```
+- HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
+
+### Validators
+- Below is an example of an array validator:
+```typescript
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export default mutation({
+args: {
+    simpleArray: v.array(v.union(v.string(), v.number())),
+},
+handler: async (ctx, args) => {
+    //...
+},
+});
+```
+- Below is an example of a schema with validators that codify a discriminated union type:
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+    results: defineTable(
+        v.union(
+            v.object({
+                kind: v.literal("error"),
+                errorMessage: v.string(),
+            }),
+            v.object({
+                kind: v.literal("success"),
+                value: v.number(),
+            }),
+        ),
+    )
+});
+```
+- Here are the valid Convex types along with their respective validators:
+Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
+| ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Id          | string      | `doc._id`              | `v.id(tableName)`                              |                                                                                                                                                                                                       |
+| Null        | null        | `null`                 | `v.null()`                                     | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead.                             |
+| Int64       | bigint      | `3n`                   | `v.int64()`                                    | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers.                                                                                              |
+| Float64     | number      | `3.1`                  | `v.number()`                                   | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings.                                                                      |
+| Boolean     | boolean     | `true`                 | `v.boolean()`                                  |
+| String      | string      | `"abc"`                | `v.string()`                                   | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8.                                                         |
+| Bytes       | ArrayBuffer | `new ArrayBuffer(8)`   | `v.bytes()`                                    | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types.                                                     |
+| Array       | Array       | `[1, 3.2, "abc"]`      | `v.array(values)`                              | Arrays can have at most 8192 values.                                                                                                                                                                  |
+| Object      | Object      | `{a: "abc"}`           | `v.object({property: value})`                  | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
+| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "_".                                                               |
+
+### Function registration
+- Use `internalQuery`, `internalMutation`, and `internalAction` to register internal functions. These functions are private and aren't part of an app's API. They can only be called by other Convex functions. These functions are always imported from `./_generated/server`.
+- Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private.
+- You CANNOT register a function through the `api` or `internal` objects.
+- ALWAYS include argument validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`.
+
+### Function calling
+- Use `ctx.runQuery` to call a query from a query, mutation, or action.
+- Use `ctx.runMutation` to call a mutation from a mutation or action.
+- Use `ctx.runAction` to call an action from an action.
+- ONLY call an action from another action if you need to cross runtimes (e.g. from V8 to Node). Otherwise, pull out the shared code into a helper async function and call that directly instead.
+- Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
+- All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
+- When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
+```
+export const f = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    return "Hello " + args.name;
+  },
+});
+
+export const g = query({
+  args: {},
+  handler: async (ctx, args) => {
+    const result: string = await ctx.runQuery(api.example.f, { name: "Bob" });
+    return null;
+  },
+});
+```
+
+### Function references
+- Use the `api` object defined by the framework in `convex/_generated/api.ts` to call public functions registered with `query`, `mutation`, or `action`.
+- Use the `internal` object defined by the framework in `convex/_generated/api.ts` to call internal (or private) functions registered with `internalQuery`, `internalMutation`, or `internalAction`.
+- Convex uses file-based routing, so a public function defined in `convex/example.ts` named `f` has a function reference of `api.example.f`.
+- A private function defined in `convex/example.ts` named `g` has a function reference of `internal.example.g`.
+- Functions can also registered within directories nested within the `convex/` folder. For example, a public function `h` defined in `convex/messages/access.ts` has a function reference of `api.messages.access.h`.
+
+### Pagination
+- Define pagination using the following syntax:
+
+```ts
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { paginationOptsValidator } from "convex/server";
+export const listWithExtraArg = query({
+    args: { paginationOpts: paginationOptsValidator, author: v.string() },
+    handler: async (ctx, args) => {
+        return await ctx.db
+        .query("messages")
+        .withIndex("by_author", (q) => q.eq("author", args.author))
+        .order("desc")
+        .paginate(args.paginationOpts);
+    },
+});
+```
+Note: `paginationOpts` is an object with the following properties:
+- `numItems`: the maximum number of documents to return (the validator is `v.number()`)
+- `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
+- A query that ends in `.paginate()` returns an object that has the following properties:
+- page (contains an array of documents that you fetches)
+- isDone (a boolean that represents whether or not this is the last page of documents)
+- continueCursor (a string that represents the cursor to use to fetch the next page of documents)
+
+
+## Schema guidelines
+- Always define your schema in `convex/schema.ts`.
+- Always import the schema definition functions from `convex/server`.
+- System fields are automatically added to all documents and are prefixed with an underscore. The two system fields that are automatically added to all documents are `_creationTime` which has the validator `v.number()` and `_id` which has the validator `v.id(tableName)`.
+- Always include all index fields in the index name. For example, if an index is defined as `["field1", "field2"]`, the index name should be "by_field1_and_field2".
+- Index fields must be queried in the same order they are defined. If you want to be able to query by "field1" then "field2" and by "field2" then "field1", you must create separate indexes.
+
+## Authentication guidelines
+- Convex supports JWT-based authentication through `convex/auth.config.ts`. ALWAYS create this file when using authentication. Without it, `ctx.auth.getUserIdentity()` will always return `null`.
+- Example `convex/auth.config.ts`:
+```typescript
+export default {
+  providers: [
+    {
+      domain: "https://your-auth-provider.com",
+      applicationID: "convex",
+    },
+  ],
+};
+```
+The `domain` must be the issuer URL of the JWT provider. Convex fetches `{domain}/.well-known/openid-configuration` to discover the JWKS endpoint. The `applicationID` is checked against the JWT `aud` (audience) claim.
+- Use `ctx.auth.getUserIdentity()` to get the authenticated user's identity in any query, mutation, or action. This returns `null` if the user is not authenticated, or a `UserIdentity` object with fields like `subject`, `issuer`, `name`, `email`, etc. The `subject` field is the unique user identifier.
+- NEVER accept a `userId` or any user identifier as a function argument for authorization purposes. Always derive the user identity server-side via `ctx.auth.getUserIdentity()`.
+- When using an external auth provider with Convex on the client, use `ConvexProviderWithAuth` instead of `ConvexProvider`:
+```tsx
+import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
+
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+function App({ children }: { children: React.ReactNode }) {
+  return (
+    <ConvexProviderWithAuth client={convex} useAuth={useYourAuthHook}>
+      {children}
+    </ConvexProviderWithAuth>
+  );
+}
+```
+The `useAuth` prop must return `{ isLoading, isAuthenticated, fetchAccessToken }`. Do NOT use plain `ConvexProvider` when authentication is needed — it will not send tokens with requests.
+
+## Typescript guidelines
+- You can use the helper typescript type `Id` imported from './_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
+- Use `Doc<"tableName">` from `./_generated/dataModel` to get the full document type for a table.
+- Use `QueryCtx`, `MutationCtx`, `ActionCtx` from `./_generated/server` for typing function contexts. NEVER use `any` for ctx parameters — always use the proper context type.
+- If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
+```ts
+import { query } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
+
+export const exampleQuery = query({
+    args: { userIds: v.array(v.id("users")) },
+    handler: async (ctx, args) => {
+        const idToUsername: Record<Id<"users">, string> = {};
+        for (const userId of args.userIds) {
+            const user = await ctx.db.get("users", userId);
+            if (user) {
+                idToUsername[user._id] = user.username;
+            }
+        }
+
+        return idToUsername;
+    },
+});
+```
+- Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`.
+
+## Full text search guidelines
+- A query for "10 messages in channel '#general' that best match the query 'hello hi' in their body" would look like:
+
+const messages = await ctx.db
+  .query("messages")
+  .withSearchIndex("search_body", (q) =>
+    q.search("body", "hello hi").eq("channel", "#general"),
+  )
+  .take(10);
+
+## Query guidelines
+- Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead.
+- Convex queries do NOT support `.delete()`. Instead, `.collect()` the results, iterate over them, and call `ctx.db.delete(row._id)` on each result.
+- Use `.unique()` to get a single document from a query. This method will throw an error if there are multiple documents that match the query.
+- When using async iteration, don't use `.collect()` or `.take(n)` on the result of a query. Instead, use the `for await (const row of query)` syntax.
+### Ordering
+- By default Convex always returns documents in ascending `_creationTime` order.
+- You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
+- Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
+
+
+## Mutation guidelines
+- Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace('tasks', taskId, { name: 'Buy milk', completed: false })`
+- Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch('tasks', taskId, { completed: true })`
+
+## Action guidelines
+- Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
+- Never add `"use node";` to a file that also exports queries or mutations. Only actions can run in the Node.js runtime; queries and mutations must stay in the default Convex runtime. If you need Node.js built-ins alongside queries or mutations, put the action in a separate file.
+- `fetch()` is available in the default Convex runtime. You do NOT need `"use node";` just to use `fetch()`.
+- Never use `ctx.db` inside of an action. Actions don't have access to the database.
+- Below is an example of the syntax for an action:
+```ts
+import { action } from "./_generated/server";
+
+export const exampleAction = action({
+    args: {},
+    handler: async (ctx, args) => {
+        console.log("This action does not return anything");
+        return null;
+    },
+});
+```
+
+## Scheduling guidelines
+### Cron guidelines
+- Only use the `crons.interval` or `crons.cron` methods to schedule cron jobs. Do NOT use the `crons.hourly`, `crons.daily`, or `crons.weekly` helpers.
+- Both cron methods take in a FunctionReference. Do NOT try to pass the function directly into one of these methods.
+- Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
+```ts
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
+
+const empty = internalAction({
+  args: {},
+  handler: async (ctx, args) => {
+    console.log("empty");
+  },
+});
+
+const crons = cronJobs();
+
+// Run `internal.crons.empty` every two hours.
+crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
+
+export default crons;
+```
+- You can register Convex functions within `crons.ts` just like any other file.
+- If a cron calls an internal function, always import the `internal` object from '_generated/api', even if the internal function is registered in the same file.
+
+
+## File storage guidelines
+- The `ctx.storage.getUrl()` method returns a signed URL for a given file. It returns `null` if the file doesn't exist.
+- Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
+
+Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
+```
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+type FileMetadata = {
+    _id: Id<"_storage">;
+    _creationTime: number;
+    contentType?: string;
+    sha256: string;
+    size: number;
+}
+
+export const exampleQuery = query({
+    args: { fileId: v.id("_storage") },
+    handler: async (ctx, args) => {
+        const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
+        console.log(metadata);
+        return null;
+    },
+});
+```
+- Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage.
+
+
+# Examples:
+## Example: chat-app
+
+### Task
+```
+Create a real-time chat application backend with AI responses. The app should:
+- Allow creating users with names
+- Support multiple chat channels
+- Enable users to send messages to channels
+- Automatically generate AI responses to user messages
+- Show recent message history
+
+The backend should provide APIs for:
+1. User management (creation)
+2. Channel management (creation)
+3. Message operations (sending, listing)
+4. AI response generation using OpenAI's GPT-4
+
+Messages should be stored with their channel, author, and content. The system should maintain message order
+and limit history display to the 10 most recent messages per channel.
+
+```
+
+### Analysis
+1. Task Requirements Summary:
+- Build a real-time chat backend with AI integration
+- Support user creation
+- Enable channel-based conversations
+- Store and retrieve messages with proper ordering
+- Generate AI responses automatically
+
+2. Main Components Needed:
+- Database tables: users, channels, messages
+- Public APIs for user/channel management
+- Message handling functions
+- Internal AI response generation system
+- Context loading for AI responses
+
+3. Public API and Internal Functions Design:
+Public Mutations:
+- createUser:
+  - file path: convex/index.ts
+  - arguments: {name: v.string()}
+  - returns: v.object({userId: v.id("users")})
+  - purpose: Create a new user with a given name
+- createChannel:
+  - file path: convex/index.ts
+  - arguments: {name: v.string()}
+  - returns: v.object({channelId: v.id("channels")})
+  - purpose: Create a new channel with a given name
+- sendMessage:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels"), authorId: v.id("users"), content: v.string()}
+  - returns: v.null()
+  - purpose: Send a message to a channel and schedule a response from the AI
+
+Public Queries:
+- listMessages:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels")}
+  - returns: v.array(v.object({
+    _id: v.id("messages"),
+    _creationTime: v.number(),
+    channelId: v.id("channels"),
+    authorId: v.optional(v.id("users")),
+    content: v.string(),
+    }))
+  - purpose: List the 10 most recent messages from a channel in descending creation order
+
+Internal Functions:
+- generateResponse:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels")}
+  - returns: v.null()
+  - purpose: Generate a response from the AI for a given channel
+- loadContext:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels")}
+  - returns: v.array(v.object({
+    _id: v.id("messages"),
+    _creationTime: v.number(),
+    channelId: v.id("channels"),
+    authorId: v.optional(v.id("users")),
+    content: v.string(),
+  }))
+- writeAgentResponse:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels"), content: v.string()}
+  - returns: v.null()
+  - purpose: Write an AI response to a given channel
+
+4. Schema Design:
+- users
+  - validator: { name: v.string() }
+  - indexes: <none>
+- channels
+  - validator: { name: v.string() }
+  - indexes: <none>
+- messages
+  - validator: { channelId: v.id("channels"), authorId: v.optional(v.id("users")), content: v.string() }
+  - indexes
+    - by_channel: ["channelId"]
+
+5. Background Processing:
+- AI response generation runs asynchronously after each user message
+- Uses OpenAI's GPT-4 to generate contextual responses
+- Maintains conversation context using recent message history
+
+
+### Implementation
+
+#### package.json
+```typescript
+{
+  "name": "chat-app",
+  "description": "This example shows how to build a chat app without authentication.",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "^1.31.2",
+    "openai": "^6.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  }
+}
+```
+
+#### tsconfig.json
+```typescript
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "exclude": ["convex"],
+  "include": ["**/src/**/*.tsx", "**/src/**/*.ts", "vite.config.ts"]
+}
+```
+
+#### convex/index.ts
+```typescript
+import {
+  query,
+  mutation,
+  internalQuery,
+  internalMutation,
+  internalAction,
+} from "./_generated/server";
+import { v } from "convex/values";
+import OpenAI from "openai";
+import { internal } from "./_generated/api";
+
+/**
+ * Create a user with a given name.
+ */
+export const createUser = mutation({
+  args: {
+    name: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("users", { name: args.name });
+  },
+});
+
+/**
+ * Create a channel with a given name.
+ */
+export const createChannel = mutation({
+  args: {
+    name: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("channels", { name: args.name });
+  },
+});
+
+/**
+ * List the 10 most recent messages from a channel in descending creation order.
+ */
+export const listMessages = query({
+  args: {
+    channelId: v.id("channels"),
+  },
+  handler: async (ctx, args) => {
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .order("desc")
+      .take(10);
+    return messages;
+  },
+});
+
+/**
+ * Send a message to a channel and schedule a response from the AI.
+ */
+export const sendMessage = mutation({
+  args: {
+    channelId: v.id("channels"),
+    authorId: v.id("users"),
+    content: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    const user = await ctx.db.get(args.authorId);
+    if (!user) {
+      throw new Error("User not found");
+    }
+    await ctx.db.insert("messages", {
+      channelId: args.channelId,
+      authorId: args.authorId,
+      content: args.content,
+    });
+    await ctx.scheduler.runAfter(0, internal.index.generateResponse, {
+      channelId: args.channelId,
+    });
+    return null;
+  },
+});
+
+const openai = new OpenAI();
+
+export const generateResponse = internalAction({
+  args: {
+    channelId: v.id("channels"),
+  },
+  handler: async (ctx, args) => {
+    const context = await ctx.runQuery(internal.index.loadContext, {
+      channelId: args.channelId,
+    });
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: context,
+    });
+    const content = response.choices[0].message.content;
+    if (!content) {
+      throw new Error("No content in response");
+    }
+    await ctx.runMutation(internal.index.writeAgentResponse, {
+      channelId: args.channelId,
+      content,
+    });
+    return null;
+  },
+});
+
+export const loadContext = internalQuery({
+  args: {
+    channelId: v.id("channels"),
+  },
+  handler: async (ctx, args) => {
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .order("desc")
+      .take(10);
+
+    const result = [];
+    for (const message of messages) {
+      if (message.authorId) {
+        const user = await ctx.db.get(message.authorId);
+        if (!user) {
+          throw new Error("User not found");
+        }
+        result.push({
+          role: "user" as const,
+          content: `${user.name}: ${message.content}`,
+        });
+      } else {
+        result.push({ role: "assistant" as const, content: message.content });
+      }
+    }
+    return result;
+  },
+});
+
+export const writeAgentResponse = internalMutation({
+  args: {
+    channelId: v.id("channels"),
+    content: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("messages", {
+      channelId: args.channelId,
+      content: args.content,
+    });
+    return null;
+  },
+});
+```
+
+#### convex/schema.ts
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  channels: defineTable({
+    name: v.string(),
+  }),
+
+  users: defineTable({
+    name: v.string(),
+  }),
+
+  messages: defineTable({
+    channelId: v.id("channels"),
+    authorId: v.optional(v.id("users")),
+    content: v.string(),
+  }).index("by_channel", ["channelId"]),
+});
+```
+
+#### convex/tsconfig.json
+```typescript
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}
+```
+
+#### src/App.tsx
+```typescript
+export default function App() {
+  return <div>Hello World</div>;
+}
+```

--- a/apps/voice-gateway/vitest.config.ts
+++ b/apps/voice-gateway/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@ai-receptionist/ai": path.resolve(__dirname, "../../packages/ai/src/index.ts"),
+      "@ai-receptionist/config": path.resolve(__dirname, "../../packages/config/src/index.ts"),
+      "@ai-receptionist/shared": path.resolve(__dirname, "../../packages/shared/src/index.ts"),
+      "@ai-receptionist/testing": path.resolve(__dirname, "../../packages/testing/src/index.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@ai-receptionist/shared": path.resolve(__dirname, "../../packages/shared/src/index.ts"),
+      "@ai-receptionist/testing": path.resolve(__dirname, "../../packages/testing/src/index.ts"),
     },
   },
   server: {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as integrations_calendar from "../integrations/calendar.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_availability from "../lib/availability.js";
 import type * as lib_components from "../lib/components.js";
+import type * as lib_indexedQueries from "../lib/indexedQueries.js";
 import type * as lib_snapshot from "../lib/snapshot.js";
 import type * as lib_twilioSecurity from "../lib/twilioSecurity.js";
 import type * as lib_voiceCallStatus from "../lib/voiceCallStatus.js";
@@ -54,6 +55,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/availability": typeof lib_availability;
   "lib/components": typeof lib_components;
+  "lib/indexedQueries": typeof lib_indexedQueries;
   "lib/snapshot": typeof lib_snapshot;
   "lib/twilioSecurity": typeof lib_twilioSecurity;
   "lib/voiceCallStatus": typeof lib_voiceCallStatus;

--- a/convex/ai/context/knowledge.ts
+++ b/convex/ai/context/knowledge.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { createThread } from "@convex-dev/agent";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
@@ -9,8 +8,12 @@ import {
   internalQuery,
   mutation,
   query,
+  type ActionCtx,
+  type MutationCtx,
+  type QueryCtx,
 } from "../../_generated/server";
 import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
 import { requireIdentity, requireMembership } from "../../lib/auth";
 import {
   bulkWorkpool,
@@ -21,11 +24,246 @@ import {
 } from "../../lib/components";
 import { scheduleSnapshotRefresh } from "../../businesses/admin";
 
+type KnowledgeSearchResult = Array<{ title?: string; text: string }>;
+type PreviewKnowledgeAnswer = { text: string; threadId: string };
+type BusinessIdArgs = { businessId: Id<"businesses"> };
+type SearchKnowledgeArgs = {
+  businessId: Id<"businesses">;
+  query: string;
+  limit?: number;
+};
+type PreviewKnowledgeArgs = {
+  businessId: Id<"businesses">;
+  prompt: string;
+};
+type DocumentIdArgs = { documentId: Id<"knowledge_documents"> };
+type SnippetIdArgs = { snippetId: Id<"knowledge_snippets"> };
+type MarkDocumentIndexedArgs = {
+  documentId: Id<"knowledge_documents">;
+  status: string;
+  indexedEntryId?: string;
+  indexVersion?: string;
+  error?: string;
+};
+type MarkSnippetIndexedArgs = {
+  snippetId: Id<"knowledge_snippets">;
+  indexedEntryId?: string;
+  indexVersion?: string;
+  error?: string;
+};
+type UpsertKnowledgeSnippetArgs = {
+  businessId: Id<"businesses">;
+  snippetId?: Id<"knowledge_snippets">;
+  title: string;
+  content: string;
+  tags: Array<string>;
+  priority: number;
+  active: boolean;
+};
+type CreateKnowledgeDocumentArgs = {
+  businessId: Id<"businesses">;
+  sourceType: string;
+  title: string;
+  mimeType?: string;
+  textContent?: string;
+  tags: Array<string>;
+  importance: number;
+  contentHash?: string;
+};
+type KnowledgeReindexState = {
+  documentIds: Array<Id<"knowledge_documents">>;
+  snippetIds: Array<Id<"knowledge_snippets">>;
+};
+
+async function requireKnowledgeAccess(
+  ctx: ActionCtx,
+  businessId: Id<"businesses">,
+): Promise<void> {
+  const identity = await requireIdentity(ctx);
+  const authUserId = await getAuthUserId(ctx);
+  const userId = await ctx.runQuery(internal.users.resolveAuthenticatedUserForBusiness, {
+    businessId,
+    authSubject: identity.subject,
+    ...(authUserId !== null ? { authUserId } : {}),
+  });
+  if (!userId) {
+    throw new Error("User profile not initialized.");
+  }
+  const membership = await ctx.runQuery(internal.ai.agents.runtime.requireMembershipByUserId, {
+    businessId,
+    userId,
+  });
+
+  if (!membership) {
+    throw new Error("Unauthorized.");
+  }
+}
+
+async function indexKnowledgeDocumentById(
+  ctx: ActionCtx,
+  documentId: Id<"knowledge_documents">,
+): Promise<null> {
+  const document = await ctx.runQuery(internal.ai.context.knowledge.getDocumentForIndexing, {
+    documentId,
+  });
+
+  if (!document || !document.textContent) {
+    await ctx.runMutation(internal.ai.context.knowledge.markDocumentIndexed, {
+      documentId,
+      status: "error",
+      error: "No text content available for indexing.",
+    });
+    return null;
+  }
+
+  const result = await rag.add(ctx, {
+    namespace: getKnowledgeNamespace(String(document.businessId)),
+    title: document.title,
+    text: document.textContent,
+    key: `document:${String(documentId)}`,
+    contentHash: document.contentHash,
+    filterValues: [
+      { name: "businessId", value: String(document.businessId) },
+      { name: "sourceType", value: document.sourceType },
+      {
+        name: "businessAndSource",
+        value: {
+          businessId: String(document.businessId),
+          sourceType: document.sourceType,
+        },
+      },
+    ],
+  });
+
+  await ctx.runMutation(internal.ai.context.knowledge.markDocumentIndexed, {
+    documentId,
+    status: result.status === "ready" ? "indexed" : "indexing",
+    indexedEntryId: String(result.entryId),
+    indexVersion: KNOWLEDGE_INDEX_VERSION,
+  });
+  await ctx.runMutation(internal.ai.context.snapshots.refreshSnapshot, {
+    businessId: document.businessId,
+  });
+  return null;
+}
+
+async function indexKnowledgeSnippetById(
+  ctx: ActionCtx,
+  snippetId: Id<"knowledge_snippets">,
+): Promise<string | null> {
+  const snippet = await ctx.runQuery(internal.ai.context.knowledge.getSnippetForIndexing, {
+    snippetId,
+  });
+
+  if (!snippet || !snippet.active) {
+    return null;
+  }
+
+  const result = await rag.add(ctx, {
+    namespace: getKnowledgeNamespace(String(snippet.businessId)),
+    title: snippet.title,
+    text: snippet.content,
+    key: `snippet:${String(snippetId)}`,
+    contentHash: `${snippet._creationTime}:${snippet.priority}:${snippet.active}`,
+    filterValues: [
+      { name: "businessId", value: String(snippet.businessId) },
+      { name: "sourceType", value: "faq" },
+      {
+        name: "businessAndSource",
+        value: {
+          businessId: String(snippet.businessId),
+          sourceType: "faq",
+        },
+      },
+    ],
+  });
+
+  await ctx.runMutation(internal.ai.context.knowledge.markSnippetIndexed, {
+    snippetId,
+    indexedEntryId: String(result.entryId),
+    indexVersion: KNOWLEDGE_INDEX_VERSION,
+  });
+  await ctx.runMutation(internal.ai.context.snapshots.refreshSnapshot, {
+    businessId: snippet.businessId,
+  });
+  return String(result.entryId);
+}
+
+async function searchKnowledge(
+  ctx: ActionCtx,
+  args: SearchKnowledgeArgs,
+): Promise<KnowledgeSearchResult> {
+  const staleEntries: KnowledgeReindexState = await ctx.runQuery(
+    internal.ai.context.knowledge.getKnowledgeEntriesNeedingReindex,
+    {
+      businessId: args.businessId,
+    },
+  );
+
+  for (const documentId of staleEntries.documentIds) {
+    await indexKnowledgeDocumentById(ctx, documentId);
+  }
+
+  for (const snippetId of staleEntries.snippetIds) {
+    await indexKnowledgeSnippetById(ctx, snippetId);
+  }
+
+  const { entries } = await rag.search(ctx, {
+    namespace: getKnowledgeNamespace(String(args.businessId)),
+    query: args.query,
+    limit: args.limit ?? 5,
+  });
+
+  return entries.map((entry) => ({
+    ...(entry.title !== undefined ? { title: entry.title } : {}),
+    text: entry.text,
+  }));
+}
+
+async function generatePreviewAnswer(
+  ctx: ActionCtx,
+  args: PreviewKnowledgeArgs,
+): Promise<PreviewKnowledgeAnswer> {
+  const snapshot = await ctx.runQuery(internal.ai.context.snapshots.getByBusinessId, {
+    businessId: args.businessId,
+  });
+  if (!snapshot) {
+    throw new Error("Snapshot not ready.");
+  }
+
+  const context = await searchKnowledge(ctx, {
+    businessId: args.businessId,
+    query: args.prompt,
+    limit: 4,
+  });
+
+  const threadId = await createThread(ctx, receptionistAgent.component, {
+    title: `Preview for ${snapshot.displayName}`,
+    summary: "Admin-side receptionist preview thread",
+  });
+
+  const result = await receptionistAgent.generateText(
+    ctx,
+    { threadId },
+    {
+      prompt: [
+        `Business snapshot summary: ${snapshot.summary}`,
+        `Booking policy: ${snapshot.bookingPolicy}`,
+        `Knowledge digest: ${snapshot.knowledgeDigest || "No long-form knowledge configured."}`,
+        `Relevant knowledge: ${context.map((entry) => entry.text).join("\n---\n")}`,
+        `User prompt: ${args.prompt}`,
+      ].join("\n\n"),
+    } as any,
+  );
+
+  return { text: result.text, threadId };
+}
+
 export const getDocumentForIndexing = internalQuery({
   args: {
     documentId: v.id("knowledge_documents"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: DocumentIdArgs) => {
     return await ctx.db.get(args.documentId);
   },
 });
@@ -38,7 +276,7 @@ export const markDocumentIndexed = internalMutation({
     indexVersion: v.optional(v.string()),
     error: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: MarkDocumentIndexedArgs) => {
     await ctx.db.patch(args.documentId, {
       status: args.status,
       indexedEntryId: args.indexedEntryId,
@@ -57,7 +295,7 @@ export const markSnippetIndexed = internalMutation({
     indexVersion: v.optional(v.string()),
     error: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: MarkSnippetIndexedArgs) => {
     await ctx.db.patch(args.snippetId, {
       indexedEntryId: args.indexedEntryId,
       indexVersion: args.indexVersion,
@@ -78,7 +316,7 @@ export const upsertKnowledgeSnippet = mutation({
     priority: v.number(),
     active: v.boolean(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: UpsertKnowledgeSnippetArgs) => {
     await requireMembership(ctx, args.businessId);
 
     const snippetId =
@@ -104,7 +342,7 @@ export const upsertKnowledgeSnippet = mutation({
 
     await bulkWorkpool.enqueueAction(
       ctx,
-      internal["ai/context/knowledge"].indexKnowledgeSnippet,
+      internal.ai.context.knowledge.indexKnowledgeSnippet,
       {
         snippetId,
       },
@@ -125,23 +363,23 @@ export const createKnowledgeDocument = mutation({
     importance: v.number(),
     contentHash: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: CreateKnowledgeDocumentArgs) => {
     await requireMembership(ctx, args.businessId);
     const documentId = await ctx.db.insert("knowledge_documents", {
       businessId: args.businessId,
       sourceType: args.sourceType,
       title: args.title,
-      mimeType: args.mimeType,
-      textContent: args.textContent,
+      ...(args.mimeType !== undefined ? { mimeType: args.mimeType } : {}),
+      ...(args.textContent !== undefined ? { textContent: args.textContent } : {}),
       status: "queued",
       tags: args.tags,
       importance: args.importance,
-      contentHash: args.contentHash,
+      ...(args.contentHash !== undefined ? { contentHash: args.contentHash } : {}),
     });
 
     await bulkWorkpool.enqueueAction(
       ctx,
-      internal["ai/context/knowledge"].indexKnowledgeDocument,
+      internal.ai.context.knowledge.indexKnowledgeDocument,
       { documentId },
     );
     return { documentId };
@@ -152,7 +390,7 @@ export const listKnowledge = query({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: BusinessIdArgs) => {
     await requireMembership(ctx, args.businessId);
     const [documents, snippets] = await Promise.all([
       ctx.db
@@ -175,36 +413,8 @@ export const searchKnowledgeInternal = internalAction({
     query: v.string(),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
-    const staleEntries = await ctx.runQuery(
-      internal["ai/context/knowledge"].getKnowledgeEntriesNeedingReindex,
-      {
-        businessId: args.businessId,
-      },
-    );
-
-    for (const documentId of staleEntries.documentIds) {
-      await ctx.runAction(internal["ai/context/knowledge"].indexKnowledgeDocument, {
-        documentId,
-      });
-    }
-
-    for (const snippetId of staleEntries.snippetIds) {
-      await ctx.runAction(internal["ai/context/knowledge"].indexKnowledgeSnippet, {
-        snippetId,
-      });
-    }
-
-    const { entries } = await rag.search(ctx, {
-      namespace: getKnowledgeNamespace(String(args.businessId)),
-      query: args.query,
-      limit: args.limit ?? 5,
-    });
-
-    return entries.map((entry) => ({
-      title: entry.title,
-      text: entry.text,
-    }));
+  handler: async (ctx: ActionCtx, args: SearchKnowledgeArgs): Promise<KnowledgeSearchResult> => {
+    return await searchKnowledge(ctx, args);
   },
 });
 
@@ -214,30 +424,9 @@ export const searchKnowledgeForDashboard = action({
     query: v.string(),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args): Promise<Array<{ title?: string; text: string }>> => {
-    const identity = await requireIdentity(ctx);
-    const authUserId = await getAuthUserId(ctx);
-    const userId = await ctx.runQuery(internal.users.resolveAuthenticatedUserForBusiness, {
-      businessId: args.businessId,
-      authSubject: identity.subject,
-      ...(authUserId !== null ? { authUserId } : {}),
-    });
-    if (!userId) {
-      throw new Error("User profile not initialized.");
-    }
-    const membership = await ctx.runQuery(
-      internal["ai/agents/runtime"].requireMembershipByUserId,
-      {
-        businessId: args.businessId,
-        userId,
-      },
-    );
-
-    if (!membership) {
-      throw new Error("Unauthorized.");
-    }
-
-    return await ctx.runAction(internal["ai/context/knowledge"].searchKnowledgeInternal, args);
+  handler: async (ctx: ActionCtx, args: SearchKnowledgeArgs): Promise<KnowledgeSearchResult> => {
+    await requireKnowledgeAccess(ctx, args.businessId);
+    return await searchKnowledge(ctx, args);
   },
 });
 
@@ -245,50 +434,8 @@ export const indexKnowledgeDocument = internalAction({
   args: {
     documentId: v.id("knowledge_documents"),
   },
-  handler: async (ctx, args) => {
-    const document = await ctx.runQuery(
-      internal["ai/context/knowledge"].getDocumentForIndexing,
-      { documentId: args.documentId },
-    );
-
-    if (!document || !document.textContent) {
-      await ctx.runMutation(internal["ai/context/knowledge"].markDocumentIndexed, {
-        documentId: args.documentId,
-        status: "error",
-        error: "No text content available for indexing.",
-      });
-      return null;
-    }
-
-    const result = await rag.add(ctx, {
-      namespace: getKnowledgeNamespace(String(document.businessId)),
-      title: document.title,
-      text: document.textContent,
-      key: `document:${String(args.documentId)}`,
-      contentHash: document.contentHash,
-      filterValues: [
-        { name: "businessId", value: String(document.businessId) },
-        { name: "sourceType", value: document.sourceType },
-        {
-          name: "businessAndSource",
-          value: {
-            businessId: String(document.businessId),
-            sourceType: document.sourceType,
-          },
-        },
-      ],
-    });
-
-    await ctx.runMutation(internal["ai/context/knowledge"].markDocumentIndexed, {
-      documentId: args.documentId,
-      status: result.status === "ready" ? "indexed" : "indexing",
-      indexedEntryId: String(result.entryId),
-      indexVersion: KNOWLEDGE_INDEX_VERSION,
-    });
-    await ctx.runMutation(internal["ai/context/snapshots"].refreshSnapshot, {
-      businessId: document.businessId,
-    });
-    return null;
+  handler: async (ctx: ActionCtx, args: DocumentIdArgs) => {
+    return await indexKnowledgeDocumentById(ctx, args.documentId);
   },
 });
 
@@ -296,43 +443,8 @@ export const indexKnowledgeSnippet = internalAction({
   args: {
     snippetId: v.id("knowledge_snippets"),
   },
-  handler: async (ctx, args) => {
-    const snippet = await ctx.runQuery(internal["ai/context/knowledge"].getSnippetForIndexing, {
-      snippetId: args.snippetId,
-    });
-
-    if (!snippet || !snippet.active) {
-      return null;
-    }
-
-    const result = await rag.add(ctx, {
-      namespace: getKnowledgeNamespace(String(snippet.businessId)),
-      title: snippet.title,
-      text: snippet.content,
-      key: `snippet:${String(args.snippetId)}`,
-      contentHash: `${snippet._creationTime}:${snippet.priority}:${snippet.active}`,
-      filterValues: [
-        { name: "businessId", value: String(snippet.businessId) },
-        { name: "sourceType", value: "faq" },
-        {
-          name: "businessAndSource",
-          value: {
-            businessId: String(snippet.businessId),
-            sourceType: "faq",
-          },
-        },
-      ],
-    });
-
-    await ctx.runMutation(internal["ai/context/knowledge"].markSnippetIndexed, {
-      snippetId: args.snippetId,
-      indexedEntryId: String(result.entryId),
-      indexVersion: KNOWLEDGE_INDEX_VERSION,
-    });
-    await ctx.runMutation(internal["ai/context/snapshots"].refreshSnapshot, {
-      businessId: snippet.businessId,
-    });
-    return String(result.entryId);
+  handler: async (ctx: ActionCtx, args: SnippetIdArgs) => {
+    return await indexKnowledgeSnippetById(ctx, args.snippetId);
   },
 });
 
@@ -340,7 +452,7 @@ export const getSnippetForIndexing = internalQuery({
   args: {
     snippetId: v.id("knowledge_snippets"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: SnippetIdArgs) => {
     return await ctx.db.get(args.snippetId);
   },
 });
@@ -349,7 +461,7 @@ export const getKnowledgeEntriesNeedingReindex = internalQuery({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: BusinessIdArgs): Promise<KnowledgeReindexState> => {
     const [documents, snippets] = await Promise.all([
       ctx.db
         .query("knowledge_documents")
@@ -387,43 +499,8 @@ export const generatePreviewKnowledgeAnswer = internalAction({
     businessId: v.id("businesses"),
     prompt: v.string(),
   },
-  handler: async (ctx, args): Promise<{ text: string; threadId: string }> => {
-    const snapshot = await ctx.runQuery(internal["ai/context/snapshots"].getByBusinessId, {
-      businessId: args.businessId,
-    });
-    if (!snapshot) {
-      throw new Error("Snapshot not ready.");
-    }
-
-    const context: Array<{ title?: string; text: string }> = await ctx.runAction(
-      internal["ai/context/knowledge"].searchKnowledgeInternal,
-      {
-        businessId: args.businessId,
-        query: args.prompt,
-        limit: 4,
-      },
-    );
-
-    const threadId = await createThread(ctx, receptionistAgent.component, {
-      title: `Preview for ${snapshot.displayName}`,
-      summary: "Admin-side receptionist preview thread",
-    });
-
-    const result = await receptionistAgent.generateText(
-      ctx,
-      { threadId },
-      {
-        prompt: [
-          `Business snapshot summary: ${snapshot.summary}`,
-          `Booking policy: ${snapshot.bookingPolicy}`,
-          `Knowledge digest: ${snapshot.knowledgeDigest || "No long-form knowledge configured."}`,
-          `Relevant knowledge: ${context.map((entry) => entry.text).join("\n---\n")}`,
-          `User prompt: ${args.prompt}`,
-        ].join("\n\n"),
-      } as any,
-    );
-
-    return { text: result.text, threadId };
+  handler: async (ctx: ActionCtx, args: PreviewKnowledgeArgs): Promise<PreviewKnowledgeAnswer> => {
+    return await generatePreviewAnswer(ctx, args);
   },
 });
 
@@ -432,32 +509,8 @@ export const previewKnowledgeAnswer = action({
     businessId: v.id("businesses"),
     prompt: v.string(),
   },
-  handler: async (ctx, args): Promise<{ text: string; threadId: string }> => {
-    const identity = await requireIdentity(ctx);
-    const authUserId = await getAuthUserId(ctx);
-    const userId = await ctx.runQuery(internal.users.resolveAuthenticatedUserForBusiness, {
-      businessId: args.businessId,
-      authSubject: identity.subject,
-      ...(authUserId !== null ? { authUserId } : {}),
-    });
-    if (!userId) {
-      throw new Error("User profile not initialized.");
-    }
-    const membership = await ctx.runQuery(
-      internal["ai/agents/runtime"].requireMembershipByUserId,
-      {
-        businessId: args.businessId,
-        userId,
-      },
-    );
-
-    if (!membership) {
-      throw new Error("Unauthorized.");
-    }
-
-    return await ctx.runAction(internal["ai/context/knowledge"].generatePreviewKnowledgeAnswer, {
-      businessId: args.businessId,
-      prompt: args.prompt,
-    });
+  handler: async (ctx: ActionCtx, args: PreviewKnowledgeArgs): Promise<PreviewKnowledgeAnswer> => {
+    await requireKnowledgeAccess(ctx, args.businessId);
+    return await generatePreviewAnswer(ctx, args);
   },
 });

--- a/convex/ai/context/snapshots.ts
+++ b/convex/ai/context/snapshots.ts
@@ -1,17 +1,33 @@
-// @ts-nocheck
 import { v } from "convex/values";
-import { internalMutation, internalQuery, mutation, query } from "../../_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { requireMembership } from "../../lib/auth";
 import { scheduleSnapshotRefresh } from "../../businesses/admin";
 import { buildBusinessContextSnapshot } from "../../lib/snapshot";
 
+type SnapshotBuilderInput = Parameters<typeof buildBusinessContextSnapshot>[0];
+type BusinessIdArgs = { businessId: Id<"businesses"> };
+type UpdateReceptionistProfileArgs = {
+  businessId: Id<"businesses">;
+  greeting: string;
+  tone: string;
+  summary: string;
+  bookingPolicy: string;
+  voiceInstructions?: string;
+  smsInstructions?: string;
+  transferMode: string;
+  transferNumber?: string;
+};
+
 function buildKnowledgeDigest(
-  documents: Array<{
-    title: string;
-    textContent?: string;
-    importance: number;
-    status: string;
-  }>,
+  documents: Array<Pick<Doc<"knowledge_documents">, "title" | "textContent" | "importance" | "status">>,
 ): string {
   const ranked = documents
     .filter((document) => document.status !== "error" && document.textContent)
@@ -34,7 +50,7 @@ export const getByBusinessId = internalQuery({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: BusinessIdArgs) => {
     return await ctx.db
       .query("business_context_snapshots")
       .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
@@ -46,7 +62,7 @@ export const getForDashboard = query({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: BusinessIdArgs) => {
     await requireMembership(ctx, args.businessId);
     return await ctx.db
       .query("business_context_snapshots")
@@ -67,7 +83,7 @@ export const updateReceptionistProfile = mutation({
     transferMode: v.string(),
     transferNumber: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: UpdateReceptionistProfileArgs) => {
     await requireMembership(ctx, args.businessId);
     const existing = await ctx.db
       .query("receptionist_profiles")
@@ -86,7 +102,21 @@ export const updateReceptionistProfile = mutation({
         transferNumber: args.transferNumber,
       });
     } else {
-      await ctx.db.insert("receptionist_profiles", args);
+      await ctx.db.insert("receptionist_profiles", {
+        businessId: args.businessId,
+        greeting: args.greeting,
+        tone: args.tone,
+        summary: args.summary,
+        bookingPolicy: args.bookingPolicy,
+        ...(args.voiceInstructions !== undefined
+          ? { voiceInstructions: args.voiceInstructions }
+          : {}),
+        ...(args.smsInstructions !== undefined
+          ? { smsInstructions: args.smsInstructions }
+          : {}),
+        transferMode: args.transferMode,
+        ...(args.transferNumber !== undefined ? { transferNumber: args.transferNumber } : {}),
+      });
     }
 
     await scheduleSnapshotRefresh(ctx, args.businessId);
@@ -101,7 +131,7 @@ export const refreshSnapshot = internalMutation({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: BusinessIdArgs) => {
     const business = await ctx.db.get(args.businessId);
     if (!business) {
       throw new Error("Business not found.");
@@ -164,17 +194,16 @@ export const refreshSnapshot = internalMutation({
       generatedAt: new Date().toISOString(),
       displayName: business.name,
       timezone: business.timezone,
-      businessType: business.businessType as
-        | "clinic"
-        | "repair_shop"
-        | "salon"
-        | "service_company"
-        | "other",
+      businessType: business.businessType as SnapshotBuilderInput["businessType"],
       greeting: profile.greeting,
       tone: profile.tone,
       bookingPolicy: profile.bookingPolicy,
-      voiceInstructions: profile.voiceInstructions,
-      smsInstructions: profile.smsInstructions,
+      ...(profile.voiceInstructions !== undefined
+        ? { voiceInstructions: profile.voiceInstructions }
+        : {}),
+      ...(profile.smsInstructions !== undefined
+        ? { smsInstructions: profile.smsInstructions }
+        : {}),
       summary: profile.summary,
       knowledgeDigest: buildKnowledgeDigest(documents),
       hours: hours.map((row) => ({
@@ -193,7 +222,7 @@ export const refreshSnapshot = internalMutation({
           id: String(row._id),
           name: row.name,
           durationMinutes: row.durationMinutes,
-          description: row.description,
+          ...(row.description !== undefined ? { description: row.description } : {}),
         })),
       snippets: snippets.map((row) => ({
         id: String(row._id),
@@ -203,16 +232,13 @@ export const refreshSnapshot = internalMutation({
         priority: row.priority,
       })),
       transferPolicy: {
-        mode: profile.transferMode as
-          | "never"
-          | "always"
-          | "on_request"
-          | "on_urgent"
-          | "during_business_hours",
-        transferNumber: profile.transferNumber,
+        mode: profile.transferMode as SnapshotBuilderInput["transferPolicy"]["mode"],
+        ...(profile.transferNumber !== undefined
+          ? { transferNumber: profile.transferNumber }
+          : {}),
       },
-      phoneNumber: primaryPhone?.e164,
-      smsNumber: primarySms?.e164,
+      ...(primaryPhone?.e164 !== undefined ? { phoneNumber: primaryPhone.e164 } : {}),
+      ...(primarySms?.e164 !== undefined ? { smsNumber: primarySms.e164 } : {}),
     });
     const { businessId: _unusedBusinessId, ...snapshot } = snapshotPayload;
 

--- a/convex/appointments/booking.ts
+++ b/convex/appointments/booking.ts
@@ -1,7 +1,13 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import { DateTime } from "luxon";
-import { internalMutation, internalQuery, mutation, query, type MutationCtx } from "../_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { ensureCurrentUser, requireMembership } from "../lib/auth";
@@ -92,7 +98,7 @@ function buildCandidateSlotOrder(input: {
 }
 
 async function loadBookingContext(
-  ctx: { db: MutationCtx["db"] },
+  ctx: Pick<MutationCtx, "db"> | Pick<QueryCtx, "db">,
   args: {
     businessId: Id<"businesses">;
     serviceId: Id<"services">;
@@ -301,8 +307,8 @@ export const findAvailabilityForBusiness = internalQuery({
       dayStart,
       dayWindows,
       serviceDurationMinutes: context.serviceDurationMinutes,
-      preferredHour24: args.preferredHour24,
-      preferredMinute: args.preferredMinute,
+      ...(args.preferredHour24 !== undefined ? { preferredHour24: args.preferredHour24 } : {}),
+      ...(args.preferredMinute !== undefined ? { preferredMinute: args.preferredMinute } : {}),
     });
     const ranked: Array<{
       startsAt: string;
@@ -337,6 +343,9 @@ export const findAvailabilityForBusiness = internalQuery({
       }
 
       const slot = result[0];
+      if (!slot) {
+        continue;
+      }
       ranked.push({
         startsAt: slot.startsAt,
         endsAt: slot.endsAt,

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -1,6 +1,10 @@
 import { v } from "convex/values";
 import { internalQuery, mutation, query } from "../_generated/server";
 import { requireMembership } from "../lib/auth";
+import {
+  listStaffServiceAssignmentsForBusiness,
+  replaceBusinessStaffServiceAssignments,
+} from "../lib/indexedQueries";
 import { scheduleSnapshotRefresh } from "./admin";
 
 export const resolveBusinessByPhoneNumber = internalQuery({
@@ -54,7 +58,7 @@ export const getBusinessConfiguration = query({
           .query("staff")
           .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
           .collect(),
-        ctx.db.query("staff_service_assignments").collect(),
+        listStaffServiceAssignmentsForBusiness(ctx, args.businessId),
         ctx.db
           .query("business_hours")
           .withIndex("by_business_id_and_day_of_week", (q) =>
@@ -78,7 +82,7 @@ export const getBusinessConfiguration = query({
       profile,
       services,
       staff,
-      assignments: assignments.filter((row) => row.businessId === args.businessId),
+      assignments,
       hours,
       closures,
       phoneNumbers,
@@ -249,21 +253,10 @@ export const replaceStaffServiceAssignments = mutation({
   },
   handler: async (ctx, args) => {
     await requireMembership(ctx, args.businessId);
-    const existing = await ctx.db.query("staff_service_assignments").collect();
-
-    for (const row of existing) {
-      if (row.businessId === args.businessId) {
-        await ctx.db.delete(row._id);
-      }
-    }
-
-    for (const assignment of args.assignments) {
-      await ctx.db.insert("staff_service_assignments", {
-        businessId: args.businessId,
-        staffId: assignment.staffId,
-        serviceId: assignment.serviceId,
-      });
-    }
+    await replaceBusinessStaffServiceAssignments(ctx, {
+      businessId: args.businessId,
+      assignments: args.assignments,
+    });
 
     await scheduleSnapshotRefresh(ctx, args.businessId);
     return null;

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -1,17 +1,73 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import {
+  type ActionCtx,
+  type MutationCtx,
+  type QueryCtx,
   internalAction,
   internalMutation,
   internalQuery,
 } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import { getOpenConversationForContact } from "../lib/indexedQueries";
+
+function asConversationId(value: string): Id<"conversations"> {
+  return value as Id<"conversations">;
+}
+
+type ConversationIdArgs = { conversationId: Id<"conversations"> };
+type ClaimInboundMessageSidArgs = { scope: string; key: string };
+type ClaimInboundMessageSidResult =
+  | { claimed: false; existing: Doc<"idempotency_keys"> }
+  | { claimed: true; id: Id<"idempotency_keys"> };
+type LinkIdempotencyKeyArgs = {
+  idempotencyKeyId: Id<"idempotency_keys">;
+  resourceTable: string;
+  resourceId: string;
+  status: string;
+};
+type ConversationForContactArgs = {
+  businessId: Id<"businesses">;
+  contactId: Id<"contacts">;
+  channel: string;
+};
+type GetOrCreateContactArgs = {
+  businessId: Id<"businesses">;
+  phone: string;
+};
+type StoreInboundMessageArgs = {
+  businessId: Id<"businesses">;
+  contactId: Id<"contacts">;
+  channel: string;
+  body: string;
+  providerMessageSid?: string;
+};
+type StoreOutboundMessageArgs = {
+  businessId: Id<"businesses">;
+  conversationId: Id<"conversations">;
+  channel: string;
+  body: string;
+};
+type HandleTwilioSmsInboundArgs = {
+  from: string;
+  to: string;
+  body: string;
+  messageSid?: string;
+};
+type HandleTwilioSmsInboundResult = {
+  businessId: Id<"businesses">;
+  conversationId: Id<"conversations">;
+  reply: string;
+};
 
 export const getLatestOutboundReply = internalQuery({
   args: {
     conversationId: v.id("conversations"),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: QueryCtx,
+    args: ConversationIdArgs,
+  ): Promise<Doc<"messages"> | null> => {
     const messages = await ctx.db
       .query("messages")
       .withIndex("by_conversation_id", (q) => q.eq("conversationId", args.conversationId))
@@ -28,7 +84,10 @@ export const claimInboundMessageSid = internalMutation({
     scope: v.string(),
     key: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: MutationCtx,
+    args: ClaimInboundMessageSidArgs,
+  ): Promise<ClaimInboundMessageSidResult> => {
     const existing = await ctx.db
       .query("idempotency_keys")
       .withIndex("by_scope_and_key", (q) => q.eq("scope", args.scope).eq("key", args.key))
@@ -53,7 +112,7 @@ export const findIdempotencyKey = internalQuery({
     scope: v.string(),
     key: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: ClaimInboundMessageSidArgs) => {
     return await ctx.db
       .query("idempotency_keys")
       .withIndex("by_scope_and_key", (q) => q.eq("scope", args.scope).eq("key", args.key))
@@ -68,7 +127,7 @@ export const linkIdempotencyKey = internalMutation({
     resourceId: v.string(),
     status: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: LinkIdempotencyKeyArgs) => {
     await ctx.db.patch(args.idempotencyKeyId, {
       resourceTable: args.resourceTable,
       resourceId: args.resourceId,
@@ -82,7 +141,7 @@ export const getConversationById = internalQuery({
   args: {
     conversationId: v.id("conversations"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: ConversationIdArgs) => {
     return await ctx.db.get(args.conversationId);
   },
 });
@@ -93,17 +152,11 @@ export const getConversationForContact = internalQuery({
     contactId: v.id("contacts"),
     channel: v.string(),
   },
-  handler: async (ctx, args) => {
-    const conversations = await ctx.db
-      .query("conversations")
-      .withIndex("by_business_id_and_contact_id", (q) =>
-        q.eq("businessId", args.businessId).eq("contactId", args.contactId),
-      )
-      .collect();
-
-    return conversations.find(
-      (conversation) => conversation.channel === args.channel && conversation.status === "open",
-    ) ?? null;
+  handler: async (
+    ctx: QueryCtx,
+    args: ConversationForContactArgs,
+  ): Promise<Doc<"conversations"> | null> => {
+    return await getOpenConversationForContact(ctx, args);
   },
 });
 
@@ -112,7 +165,7 @@ export const getOrCreateContact = internalMutation({
     businessId: v.id("businesses"),
     phone: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: GetOrCreateContactArgs): Promise<Id<"contacts">> => {
     const existing = await ctx.db
       .query("contacts")
       .withIndex("by_business_id_and_phone", (q) =>
@@ -138,8 +191,11 @@ export const storeInboundMessage = internalMutation({
     body: v.string(),
     providerMessageSid: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
-    const existing = await ctx.runQuery(
+  handler: async (
+    ctx: MutationCtx,
+    args: StoreInboundMessageArgs,
+  ): Promise<{ conversationId: Id<"conversations"> }> => {
+    const existing: Doc<"conversations"> | null = await ctx.runQuery(
       internal.conversations.webhooks.getConversationForContact,
       {
         businessId: args.businessId,
@@ -148,7 +204,7 @@ export const storeInboundMessage = internalMutation({
       },
     );
 
-    const conversationId =
+    const conversationId: Id<"conversations"> =
       existing?._id ??
       (await ctx.db.insert("conversations", {
         businessId: args.businessId,
@@ -162,7 +218,9 @@ export const storeInboundMessage = internalMutation({
       conversationId,
       direction: "inbound",
       channel: args.channel,
-      providerMessageSid: args.providerMessageSid,
+      ...(args.providerMessageSid !== undefined
+        ? { providerMessageSid: args.providerMessageSid }
+        : {}),
       body: args.body,
       status: "received",
       aiGenerated: false,
@@ -179,7 +237,7 @@ export const storeOutboundMessage = internalMutation({
     channel: v.string(),
     body: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: StoreOutboundMessageArgs): Promise<Id<"messages">> => {
     return await ctx.db.insert("messages", {
       businessId: args.businessId,
       conversationId: args.conversationId,
@@ -199,8 +257,11 @@ export const handleTwilioSmsInbound = internalAction({
     body: v.string(),
     messageSid: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
-    const phoneNumber = await ctx.runQuery(
+  handler: async (
+    ctx: ActionCtx,
+    args: HandleTwilioSmsInboundArgs,
+  ): Promise<HandleTwilioSmsInboundResult> => {
+    const phoneNumber: Doc<"phone_numbers"> | null = await ctx.runQuery(
       internal.businesses.catalog.resolveBusinessByPhoneNumber,
       { e164: args.to, channel: "sms" },
     );
@@ -210,7 +271,7 @@ export const handleTwilioSmsInbound = internalAction({
     }
 
     if (args.messageSid) {
-      const claim = await ctx.runMutation(
+      const claim: ClaimInboundMessageSidResult = await ctx.runMutation(
         internal.conversations.webhooks.claimInboundMessageSid,
         {
           scope: "twilio_sms_inbound",
@@ -223,16 +284,16 @@ export const handleTwilioSmsInbound = internalAction({
           claim.existing.resourceTable === "conversations" &&
           claim.existing.resourceId
         ) {
-          const conversation = await ctx.runQuery(
+          const conversation: Doc<"conversations"> | null = await ctx.runQuery(
             internal.conversations.webhooks.getConversationById,
             {
-              conversationId: claim.existing.resourceId as any,
+              conversationId: asConversationId(claim.existing.resourceId),
             },
           );
-          const latestReply = await ctx.runQuery(
+          const latestReply: Doc<"messages"> | null = await ctx.runQuery(
             internal.conversations.webhooks.getLatestOutboundReply,
             {
-              conversationId: claim.existing.resourceId as any,
+              conversationId: asConversationId(claim.existing.resourceId),
             },
           );
           if (conversation) {
@@ -246,7 +307,7 @@ export const handleTwilioSmsInbound = internalAction({
       }
     }
 
-    const contactId = await ctx.runMutation(
+    const contactId: Id<"contacts"> = await ctx.runMutation(
       internal.conversations.webhooks.getOrCreateContact,
       {
         businessId: phoneNumber.businessId,
@@ -254,7 +315,7 @@ export const handleTwilioSmsInbound = internalAction({
       },
     );
 
-    const { conversationId } = await ctx.runMutation(
+    const { conversationId }: { conversationId: Id<"conversations"> } = await ctx.runMutation(
       internal.conversations.webhooks.storeInboundMessage,
       {
         businessId: phoneNumber.businessId,
@@ -265,7 +326,7 @@ export const handleTwilioSmsInbound = internalAction({
       },
     );
 
-    const reply = await ctx.runAction(internal["ai/agents/runtime"].generateSmsReply, {
+    const reply: string = await ctx.runAction(internal.ai.agents.runtime.generateSmsReply, {
       businessId: phoneNumber.businessId,
       conversationId,
       prompt: args.body,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,4 +1,5 @@
 import { httpRouter } from "convex/server";
+import { z } from "zod";
 import {
   escapeXmlText,
   normalizeTwilioFormFields,
@@ -11,6 +12,161 @@ import { auth } from "./auth";
 import { streamPreviewResponse } from "./ai/preview/stream";
 
 const http = httpRouter();
+
+type ParseResult<T> = { ok: true; data: T } | { ok: false; response: Response };
+
+const twilioSmsInboundSchema = z.object({
+  From: z.string().min(1),
+  To: z.string().min(1),
+  Body: z.string(),
+  MessageSid: z.string().min(1).optional(),
+});
+
+const voiceContextSchema = z.object({
+  phoneNumber: z.string().min(1),
+  channel: z.enum(["voice", "sms"]).optional(),
+});
+
+const startCallSchema = z.object({
+  businessId: z.string().min(1),
+  twilioCallSid: z.string().min(1),
+  gatewaySessionId: z.string().min(1).optional(),
+  from: z.string().min(1),
+  to: z.string().min(1),
+  startedAt: z.string().min(1),
+});
+
+const appendTranscriptSchema = z.object({
+  businessId: z.string().min(1),
+  callId: z.string().min(1),
+  sequence: z.number(),
+  speaker: z.string().min(1),
+  text: z.string(),
+  final: z.boolean(),
+  confidence: z.number().optional(),
+});
+
+const transferStateSchema = z.object({
+  callId: z.string().min(1),
+  transferState: z.string().min(1),
+});
+
+const completeCallSchema = z.object({
+  callId: z.string().min(1),
+  status: z.string().min(1),
+  endedAt: z.string().min(1),
+  disposition: z.string().min(1).optional(),
+});
+
+const reconcileStatusSchema = z.object({
+  twilioCallSid: z.string().min(1),
+  callStatus: z.string().min(1),
+  sequenceNumber: z.number().optional(),
+  callbackSource: z.string().min(1).optional(),
+  providerUpdatedAt: z.string().min(1),
+  providerDurationSeconds: z.number().optional(),
+});
+
+const recordingQuerySchema = z.object({
+  callId: z.string().min(1),
+  durationMs: z.coerce.number().optional(),
+});
+
+const findAvailabilitySchema = z.object({
+  businessId: z.string().min(1),
+  serviceName: z.string().min(1),
+  date: z.string().min(1),
+  timezone: z.string().min(1),
+  preferredStaffId: z.string().min(1).optional(),
+  preferredHour24: z.number().optional(),
+  preferredMinute: z.number().optional(),
+  limit: z.number().optional(),
+});
+
+const checkAvailabilitySchema = z.object({
+  businessId: z.string().min(1),
+  serviceName: z.string().min(1),
+  startsAt: z.string().min(1),
+  timezone: z.string().min(1),
+  preferredStaffId: z.string().min(1).optional(),
+});
+
+const bookAppointmentSchema = z.object({
+  businessId: z.string().min(1),
+  serviceName: z.string().min(1),
+  startsAt: z.string().min(1),
+  timezone: z.string().min(1),
+  preferredStaffId: z.string().min(1).optional(),
+  contactName: z.string().min(1).optional(),
+  contactPhone: z.string().min(1),
+});
+
+const takeMessageSchema = z.object({
+  businessId: z.string().min(1),
+  callId: z.string().min(1),
+  conversationId: z.string().min(1).optional(),
+  callerName: z.string().min(1).optional(),
+  callbackPhone: z.string().min(1).optional(),
+  message: z.string().min(1),
+  urgency: z.string().min(1).optional(),
+  callbackWindow: z.string().min(1).optional(),
+});
+
+function badRequest(message: string): Response {
+  return new Response(message, { status: 400 });
+}
+
+function asId<TableName extends keyof IdFieldMap>(_table: TableName, value: string): Id<TableName> {
+  return value as Id<TableName>;
+}
+
+type IdFieldMap = {
+  _storage: "_storage";
+  appointments: "appointments";
+  businesses: "businesses";
+  calls: "calls";
+  contacts: "contacts";
+  conversations: "conversations";
+  staff: "staff";
+};
+
+async function parseJsonBody<TSchema extends z.ZodTypeAny>(
+  request: Request,
+  schema: TSchema,
+): Promise<ParseResult<z.infer<TSchema>>> {
+  try {
+    const parsed = schema.safeParse(await request.json());
+    if (!parsed.success) {
+      return { ok: false, response: badRequest("Invalid JSON body") };
+    }
+    return { ok: true, data: parsed.data };
+  } catch {
+    return { ok: false, response: badRequest("Invalid JSON body") };
+  }
+}
+
+async function parseNormalizedForm(request: Request): Promise<ParseResult<Record<string, string>>> {
+  try {
+    const form = await request.formData();
+    return {
+      ok: true,
+      data: normalizeTwilioFormFields(form.entries()),
+    };
+  } catch {
+    return { ok: false, response: badRequest("Invalid form body") };
+  }
+}
+
+function parseSearchParams<TSchema extends z.ZodTypeAny>(
+  url: URL,
+  schema: TSchema,
+): ParseResult<z.infer<TSchema>> {
+  const parsed = schema.safeParse(Object.fromEntries(url.searchParams.entries()));
+  if (!parsed.success) {
+    return { ok: false, response: badRequest("Invalid query parameters") };
+  }
+  return { ok: true, data: parsed.data };
+}
 
 async function requireTwilioSignature(
   request: Request,
@@ -46,18 +202,25 @@ http.route({
   path: "/twilio/sms/inbound",
   method: "POST",
   handler: httpAction(async (ctx, request) => {
-    const form = await request.formData();
-    const payload = normalizeTwilioFormFields(form.entries());
+    const parsedForm = await parseNormalizedForm(request);
+    if (!parsedForm.ok) {
+      return parsedForm.response;
+    }
+    const payload = parsedForm.data;
     const invalidSignature = await requireTwilioSignature(request, payload);
     if (invalidSignature) {
       return invalidSignature;
     }
+    const parsedPayload = twilioSmsInboundSchema.safeParse(payload);
+    if (!parsedPayload.success) {
+      return badRequest("Invalid Twilio SMS payload");
+    }
 
     const result = await ctx.runAction(internal.conversations.webhooks.handleTwilioSmsInbound, {
-      from: payload.From ?? "",
-      to: payload.To ?? "",
-      body: payload.Body ?? "",
-      messageSid: payload.MessageSid ?? "",
+      from: parsedPayload.data.From,
+      to: parsedPayload.data.To,
+      body: parsedPayload.data.Body,
+      messageSid: parsedPayload.data.MessageSid,
     });
 
     const twiml = [
@@ -89,15 +252,15 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      phoneNumber: string;
-      channel?: "voice" | "sms";
-    };
+    const body = await parseJsonBody(request, voiceContextSchema);
+    if (!body.ok) {
+      return body.response;
+    }
     const phoneNumber = await ctx.runQuery(
       internal.businesses.catalog.resolveBusinessByPhoneNumber,
       {
-        e164: body.phoneNumber,
-        channel: body.channel ?? "voice",
+        e164: body.data.phoneNumber,
+        channel: body.data.channel ?? "voice",
       },
     );
 
@@ -129,24 +292,20 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      businessId: string;
-      twilioCallSid: string;
-      gatewaySessionId?: string;
-      from: string;
-      to: string;
-      startedAt: string;
-    };
+    const body = await parseJsonBody(request, startCallSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const result = await ctx.runMutation(internal.voice.runtime.startCall, {
-      businessId: body.businessId as Id<"businesses">,
-      twilioCallSid: body.twilioCallSid,
-      ...(body.gatewaySessionId !== undefined
-        ? { gatewaySessionId: body.gatewaySessionId }
+      businessId: asId("businesses", body.data.businessId),
+      twilioCallSid: body.data.twilioCallSid,
+      ...(body.data.gatewaySessionId !== undefined
+        ? { gatewaySessionId: body.data.gatewaySessionId }
         : {}),
-      from: body.from,
-      to: body.to,
-      startedAt: body.startedAt,
+      from: body.data.from,
+      to: body.data.to,
+      startedAt: body.data.startedAt,
     });
 
     return Response.json(result);
@@ -162,24 +321,19 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      businessId: string;
-      callId: string;
-      sequence: number;
-      speaker: string;
-      text: string;
-      final: boolean;
-      confidence?: number;
-    };
+    const body = await parseJsonBody(request, appendTranscriptSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const transcriptId = await ctx.runMutation(internal.voice.runtime.appendTranscriptSegment, {
-      businessId: body.businessId as Id<"businesses">,
-      callId: body.callId as Id<"calls">,
-      sequence: body.sequence,
-      speaker: body.speaker,
-      text: body.text,
-      final: body.final,
-      ...(body.confidence !== undefined ? { confidence: body.confidence } : {}),
+      businessId: asId("businesses", body.data.businessId),
+      callId: asId("calls", body.data.callId),
+      sequence: body.data.sequence,
+      speaker: body.data.speaker,
+      text: body.data.text,
+      final: body.data.final,
+      ...(body.data.confidence !== undefined ? { confidence: body.data.confidence } : {}),
     });
 
     return Response.json({ transcriptId });
@@ -195,14 +349,14 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      callId: string;
-      transferState: string;
-    };
+    const body = await parseJsonBody(request, transferStateSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     await ctx.runMutation(internal.voice.runtime.setTransferState, {
-      callId: body.callId as Id<"calls">,
-      transferState: body.transferState,
+      callId: asId("calls", body.data.callId),
+      transferState: body.data.transferState,
     });
 
     return Response.json({ ok: true });
@@ -218,18 +372,16 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      callId: string;
-      status: string;
-      endedAt: string;
-      disposition?: string;
-    };
+    const body = await parseJsonBody(request, completeCallSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     await ctx.runMutation(internal.voice.runtime.completeCall, {
-      callId: body.callId as Id<"calls">,
-      status: body.status,
-      endedAt: body.endedAt,
-      ...(body.disposition !== undefined ? { disposition: body.disposition } : {}),
+      callId: asId("calls", body.data.callId),
+      status: body.data.status,
+      endedAt: body.data.endedAt,
+      ...(body.data.disposition !== undefined ? { disposition: body.data.disposition } : {}),
     });
 
     return Response.json({ ok: true });
@@ -245,27 +397,23 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      twilioCallSid: string;
-      callStatus: string;
-      sequenceNumber?: number;
-      callbackSource?: string;
-      providerUpdatedAt: string;
-      providerDurationSeconds?: number;
-    };
+    const body = await parseJsonBody(request, reconcileStatusSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const result = await ctx.runMutation(internal.voice.runtime.reconcileTwilioCallStatus, {
-      twilioCallSid: body.twilioCallSid,
-      callStatus: body.callStatus,
-      providerUpdatedAt: body.providerUpdatedAt,
-      ...(body.sequenceNumber !== undefined
-        ? { sequenceNumber: body.sequenceNumber }
+      twilioCallSid: body.data.twilioCallSid,
+      callStatus: body.data.callStatus,
+      providerUpdatedAt: body.data.providerUpdatedAt,
+      ...(body.data.sequenceNumber !== undefined
+        ? { sequenceNumber: body.data.sequenceNumber }
         : {}),
-      ...(body.callbackSource !== undefined
-        ? { callbackSource: body.callbackSource }
+      ...(body.data.callbackSource !== undefined
+        ? { callbackSource: body.data.callbackSource }
         : {}),
-      ...(body.providerDurationSeconds !== undefined
-        ? { providerDurationSeconds: body.providerDurationSeconds }
+      ...(body.data.providerDurationSeconds !== undefined
+        ? { providerDurationSeconds: body.data.providerDurationSeconds }
         : {}),
     });
 
@@ -283,22 +431,22 @@ http.route({
     }
 
     const url = new URL(request.url);
-    const callId = url.searchParams.get("callId");
-    const durationMs = url.searchParams.get("durationMs");
-
-    if (!callId) {
-      return new Response("Missing callId", { status: 400 });
+    const query = parseSearchParams(url, recordingQuerySchema);
+    if (!query.ok) {
+      return query.response;
     }
 
     const blob = await request.blob();
     const recordingStorageId = await ctx.storage.store(blob);
 
     await ctx.runMutation(internal.voice.runtime.attachCallRecording, {
-      callId: callId as Id<"calls">,
+      callId: asId("calls", query.data.callId),
       recordingStorageId,
       recordingContentType: blob.type || "audio/wav",
       recordingByteLength: blob.size,
-      ...(durationMs ? { recordingDurationMs: Number(durationMs) } : {}),
+      ...(query.data.durationMs !== undefined
+        ? { recordingDurationMs: query.data.durationMs }
+        : {}),
     });
 
     return Response.json({
@@ -316,32 +464,26 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      businessId: string;
-      serviceName: string;
-      date: string;
-      timezone: string;
-      preferredStaffId?: string;
-      preferredHour24?: number;
-      preferredMinute?: number;
-      limit?: number;
-    };
+    const body = await parseJsonBody(request, findAvailabilitySchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const result = await ctx.runAction(internal.voice.runtime.findAvailabilityForVoice, {
-      businessId: body.businessId as Id<"businesses">,
-      serviceName: body.serviceName,
-      date: body.date,
-      timezone: body.timezone,
-      ...(body.preferredStaffId !== undefined
-        ? { preferredStaffId: body.preferredStaffId as Id<"staff"> }
+      businessId: asId("businesses", body.data.businessId),
+      serviceName: body.data.serviceName,
+      date: body.data.date,
+      timezone: body.data.timezone,
+      ...(body.data.preferredStaffId !== undefined
+        ? { preferredStaffId: asId("staff", body.data.preferredStaffId) }
         : {}),
-      ...(body.preferredHour24 !== undefined
-        ? { preferredHour24: body.preferredHour24 }
+      ...(body.data.preferredHour24 !== undefined
+        ? { preferredHour24: body.data.preferredHour24 }
         : {}),
-      ...(body.preferredMinute !== undefined
-        ? { preferredMinute: body.preferredMinute }
+      ...(body.data.preferredMinute !== undefined
+        ? { preferredMinute: body.data.preferredMinute }
         : {}),
-      ...(body.limit !== undefined ? { limit: body.limit } : {}),
+      ...(body.data.limit !== undefined ? { limit: body.data.limit } : {}),
     });
 
     return Response.json(result);
@@ -357,21 +499,18 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      businessId: string;
-      serviceName: string;
-      startsAt: string;
-      timezone: string;
-      preferredStaffId?: string;
-    };
+    const body = await parseJsonBody(request, checkAvailabilitySchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const result = await ctx.runAction(internal.voice.runtime.checkAvailabilityForVoice, {
-      businessId: body.businessId as Id<"businesses">,
-      serviceName: body.serviceName,
-      startsAt: body.startsAt,
-      timezone: body.timezone,
-      ...(body.preferredStaffId !== undefined
-        ? { preferredStaffId: body.preferredStaffId as Id<"staff"> }
+      businessId: asId("businesses", body.data.businessId),
+      serviceName: body.data.serviceName,
+      startsAt: body.data.startsAt,
+      timezone: body.data.timezone,
+      ...(body.data.preferredStaffId !== undefined
+        ? { preferredStaffId: asId("staff", body.data.preferredStaffId) }
         : {}),
     });
 
@@ -388,26 +527,21 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      businessId: string;
-      serviceName: string;
-      startsAt: string;
-      timezone: string;
-      preferredStaffId?: string;
-      contactName?: string;
-      contactPhone: string;
-    };
+    const body = await parseJsonBody(request, bookAppointmentSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const result = await ctx.runAction(internal.voice.runtime.bookAppointmentForVoice, {
-      businessId: body.businessId as Id<"businesses">,
-      serviceName: body.serviceName,
-      startsAt: body.startsAt,
-      timezone: body.timezone,
-      ...(body.preferredStaffId !== undefined
-        ? { preferredStaffId: body.preferredStaffId as Id<"staff"> }
+      businessId: asId("businesses", body.data.businessId),
+      serviceName: body.data.serviceName,
+      startsAt: body.data.startsAt,
+      timezone: body.data.timezone,
+      ...(body.data.preferredStaffId !== undefined
+        ? { preferredStaffId: asId("staff", body.data.preferredStaffId) }
         : {}),
-      ...(body.contactName !== undefined ? { contactName: body.contactName } : {}),
-      contactPhone: body.contactPhone,
+      ...(body.data.contactName !== undefined ? { contactName: body.data.contactName } : {}),
+      contactPhone: body.data.contactPhone,
     });
 
     return Response.json(result);
@@ -423,31 +557,25 @@ http.route({
       return unauthorized;
     }
 
-    const body = (await request.json()) as {
-      businessId: string;
-      callId: string;
-      conversationId?: string;
-      callerName?: string;
-      callbackPhone?: string;
-      message: string;
-      urgency?: string;
-      callbackWindow?: string;
-    };
+    const body = await parseJsonBody(request, takeMessageSchema);
+    if (!body.ok) {
+      return body.response;
+    }
 
     const result = await ctx.runMutation(internal.voice.runtime.takeMessageForVoice, {
-      businessId: body.businessId as Id<"businesses">,
-      callId: body.callId as Id<"calls">,
-      ...(body.conversationId !== undefined
-        ? { conversationId: body.conversationId as Id<"conversations"> }
+      businessId: asId("businesses", body.data.businessId),
+      callId: asId("calls", body.data.callId),
+      ...(body.data.conversationId !== undefined
+        ? { conversationId: asId("conversations", body.data.conversationId) }
         : {}),
-      ...(body.callerName !== undefined ? { callerName: body.callerName } : {}),
-      ...(body.callbackPhone !== undefined
-        ? { callbackPhone: body.callbackPhone }
+      ...(body.data.callerName !== undefined ? { callerName: body.data.callerName } : {}),
+      ...(body.data.callbackPhone !== undefined
+        ? { callbackPhone: body.data.callbackPhone }
         : {}),
-      message: body.message,
-      ...(body.urgency !== undefined ? { urgency: body.urgency } : {}),
-      ...(body.callbackWindow !== undefined
-        ? { callbackWindow: body.callbackWindow }
+      message: body.data.message,
+      ...(body.data.urgency !== undefined ? { urgency: body.data.urgency } : {}),
+      ...(body.data.callbackWindow !== undefined
+        ? { callbackWindow: body.data.callbackWindow }
         : {}),
     });
 

--- a/convex/integrations/calendar.ts
+++ b/convex/integrations/calendar.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import {
   action,

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,7 +1,9 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
-import type { MutationCtx, QueryCtx } from "../_generated/server";
+import type { ActionCtx, MutationCtx, QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
+import { reassignPreviewSessions } from "./indexedQueries";
 
+type AuthContext = Pick<QueryCtx, "auth"> | Pick<MutationCtx, "auth"> | Pick<ActionCtx, "auth">;
 type Identity = NonNullable<Awaited<ReturnType<QueryCtx["auth"]["getUserIdentity"]>>>;
 
 type ReaderAuthContext = Pick<QueryCtx, "auth" | "db"> | Pick<MutationCtx, "auth" | "db">;
@@ -109,12 +111,10 @@ async function migrateLegacyUser(
     await ctx.db.patch(membership._id, { userId: current._id });
   }
 
-  const previewSessions = await ctx.db.query("preview_sessions").collect();
-  for (const previewSession of previewSessions) {
-    if (previewSession.userId === legacy._id) {
-      await ctx.db.patch(previewSession._id, { userId: current._id });
-    }
-  }
+  await reassignPreviewSessions(ctx, {
+    fromUserId: legacy._id,
+    toUserId: current._id,
+  });
 
   const patch = buildUserPatch({ identity, current, legacy });
   if (Object.keys(patch).length > 0) {
@@ -128,7 +128,7 @@ async function migrateLegacyUser(
   return (await ctx.db.get(current._id)) ?? current;
 }
 
-export async function requireIdentity(ctx: ReaderAuthContext): Promise<Identity> {
+export async function requireIdentity(ctx: AuthContext): Promise<Identity> {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
     throw new Error("Authentication required.");

--- a/convex/lib/indexedQueries.ts
+++ b/convex/lib/indexedQueries.ts
@@ -1,0 +1,81 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+type DbReader = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type DbWriter = Pick<MutationCtx, "db">;
+
+export async function listStaffServiceAssignmentsForBusiness(
+  ctx: DbReader,
+  businessId: Id<"businesses">,
+): Promise<Array<Doc<"staff_service_assignments">>> {
+  return await ctx.db
+    .query("staff_service_assignments")
+    .withIndex("by_business_id", (q) => q.eq("businessId", businessId))
+    .collect();
+}
+
+export async function replaceBusinessStaffServiceAssignments(
+  ctx: DbWriter,
+  input: {
+    businessId: Id<"businesses">;
+    assignments: Array<{
+      staffId: Id<"staff">;
+      serviceId: Id<"services">;
+    }>;
+  },
+): Promise<void> {
+  const existing = await listStaffServiceAssignmentsForBusiness(ctx, input.businessId);
+
+  for (const row of existing) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const assignment of input.assignments) {
+    await ctx.db.insert("staff_service_assignments", {
+      businessId: input.businessId,
+      staffId: assignment.staffId,
+      serviceId: assignment.serviceId,
+    });
+  }
+}
+
+export async function reassignPreviewSessions(
+  ctx: DbWriter,
+  input: {
+    fromUserId: Id<"users">;
+    toUserId: Id<"users">;
+  },
+): Promise<void> {
+  const previewSessions = await ctx.db
+    .query("preview_sessions")
+    .withIndex("by_user_id", (q) => q.eq("userId", input.fromUserId))
+    .collect();
+
+  for (const previewSession of previewSessions) {
+    if (previewSession.userId !== input.fromUserId) {
+      continue;
+    }
+
+    await ctx.db.patch(previewSession._id, { userId: input.toUserId });
+  }
+}
+
+export async function getOpenConversationForContact(
+  ctx: DbReader,
+  input: {
+    businessId: Id<"businesses">;
+    contactId: Id<"contacts">;
+    channel: string;
+  },
+): Promise<Doc<"conversations"> | null> {
+  return await ctx.db
+    .query("conversations")
+    .withIndex("by_business_id_and_contact_id_and_channel_and_status", (q) =>
+      q
+        .eq("businessId", input.businessId)
+        .eq("contactId", input.contactId)
+        .eq("channel", input.channel)
+        .eq("status", "open"),
+    )
+    .unique();
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -94,6 +94,7 @@ export default defineSchema({
     staffId: v.id("staff"),
     serviceId: v.id("services"),
   })
+    .index("by_business_id", ["businessId"])
     .index("by_staff_id_and_service_id", ["staffId", "serviceId"])
     .index("by_service_id_and_staff_id", ["serviceId", "staffId"]),
 
@@ -216,7 +217,13 @@ export default defineSchema({
   })
     .index("by_business_id_and_status", ["businessId", "status"])
     .index("by_business_id_and_channel", ["businessId", "channel"])
-    .index("by_business_id_and_contact_id", ["businessId", "contactId"]),
+    .index("by_business_id_and_contact_id", ["businessId", "contactId"])
+    .index("by_business_id_and_contact_id_and_channel_and_status", [
+      "businessId",
+      "contactId",
+      "channel",
+      "status",
+    ]),
 
   conversation_ai_state: defineTable({
     businessId: v.id("businesses"),
@@ -379,5 +386,6 @@ export default defineSchema({
     response: v.optional(v.string()),
   })
     .index("by_business_id_and_user_id", ["businessId", "userId"])
+    .index("by_user_id", ["userId"])
     .index("by_stream_id", ["streamId"]),
 });

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   getTerminalTwilioCallReconciliationFields,
   isTerminalTwilioCallStatus,
@@ -6,9 +5,149 @@ import {
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
-import { internalAction, internalMutation, internalQuery, query } from "../_generated/server";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+  query,
+  type ActionCtx,
+  type MutationCtx,
+  type QueryCtx,
+} from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
+import { getOpenConversationForContact } from "../lib/indexedQueries";
+
+type BusinessIdArgs = { businessId: Id<"businesses"> };
+type ServicesForBusinessArgs = BusinessIdArgs;
+type StaffAssignmentsForServiceArgs = {
+  businessId: Id<"businesses">;
+  serviceId: Id<"services">;
+};
+type StartCallArgs = {
+  businessId: Id<"businesses">;
+  twilioCallSid: string;
+  gatewaySessionId?: string;
+  from: string;
+  to: string;
+  startedAt: string;
+};
+type StartCallResult = {
+  callId: Id<"calls">;
+  conversationId: Id<"conversations">;
+  contactId: Id<"contacts">;
+};
+type AppendTranscriptArgs = {
+  businessId: Id<"businesses">;
+  callId: Id<"calls">;
+  sequence: number;
+  speaker: string;
+  text: string;
+  final: boolean;
+  confidence?: number;
+};
+type SetTransferStateArgs = {
+  callId: Id<"calls">;
+  transferState: string;
+};
+type TakeMessageForVoiceArgs = {
+  businessId: Id<"businesses">;
+  callId: Id<"calls">;
+  conversationId?: Id<"conversations">;
+  callerName?: string;
+  callbackPhone?: string;
+  message: string;
+  urgency?: string;
+  callbackWindow?: string;
+};
+type AttachCallRecordingArgs = {
+  callId: Id<"calls">;
+  recordingStorageId: Id<"_storage">;
+  recordingContentType: string;
+  recordingByteLength: number;
+  recordingDurationMs?: number;
+};
+type CompleteCallArgs = {
+  callId: Id<"calls">;
+  status: string;
+  endedAt: string;
+  disposition?: string;
+};
+type ReconcileTwilioCallStatusArgs = {
+  twilioCallSid: string;
+  callStatus: string;
+  sequenceNumber?: number;
+  callbackSource?: string;
+  providerUpdatedAt: string;
+  providerDurationSeconds?: number;
+};
+type ReconcileTwilioCallStatusResult =
+  | { ignored: true; reason: "unknown_call" | "missing_sequence" | "stale_sequence" }
+  | { ignored: false; callId: Id<"calls"> };
+type CheckAvailabilityForVoiceArgs = {
+  businessId: Id<"businesses">;
+  serviceName: string;
+  startsAt: string;
+  timezone: string;
+  preferredStaffId?: Id<"staff">;
+};
+type CheckAvailabilityForVoiceResult = {
+  serviceId: Id<"services">;
+  serviceName: string;
+  setupIssue: string | null;
+  availability: Array<{
+    staffId: string;
+    serviceId: string;
+    startsAt: string;
+    endsAt: string;
+  }>;
+};
+type FindAvailabilityForVoiceArgs = {
+  businessId: Id<"businesses">;
+  serviceName: string;
+  date: string;
+  timezone: string;
+  preferredStaffId?: Id<"staff">;
+  preferredHour24?: number;
+  preferredMinute?: number;
+  limit?: number;
+};
+type FindAvailabilityForVoiceResult = {
+  serviceId: Id<"services">;
+  serviceName: string;
+  timezone: string;
+  date: string;
+  slots: Array<{
+    startsAt: string;
+    endsAt: string;
+    displayTime: string;
+  }>;
+  setupIssue: string | null;
+  summary: string;
+};
+type BookAppointmentForVoiceArgs = {
+  businessId: Id<"businesses">;
+  serviceName: string;
+  startsAt: string;
+  timezone: string;
+  preferredStaffId?: Id<"staff">;
+  contactName?: string;
+  contactPhone: string;
+};
+type BookAppointmentForVoiceResult = {
+  appointmentId: Id<"appointments">;
+  contactId: Id<"contacts">;
+  serviceId: Id<"services">;
+  serviceName: string;
+};
+type ListRecentCallsArgs = {
+  businessId: Id<"businesses">;
+  limit?: number;
+};
+type GetCallTranscriptArgs = {
+  businessId: Id<"businesses">;
+  callId: Id<"calls">;
+};
 
 function normalizeComparable(value: string): string {
   return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ");
@@ -52,12 +191,7 @@ function scoreServiceMatch(service: Doc<"services">, serviceName: string): numbe
 }
 
 async function resolveServiceDocument(
-  ctx: Parameters<typeof internalQuery>[0]["handler"] extends never ? never : {
-    runQuery: <T>(
-      reference: typeof internal.voice.runtime.getActiveServicesForBusiness,
-      args: { businessId: Id<"businesses"> },
-    ) => Promise<T>;
-  },
+  ctx: Pick<ActionCtx, "runQuery">,
   businessId: Id<"businesses">,
   serviceName: string,
 ): Promise<Doc<"services"> | null> {
@@ -80,7 +214,10 @@ export const getActiveServicesForBusiness = internalQuery({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: QueryCtx,
+    args: ServicesForBusinessArgs,
+  ): Promise<Array<Doc<"services">>> => {
     return await ctx.db
       .query("services")
       .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
@@ -93,7 +230,10 @@ export const getActiveStaffAssignmentsForService = internalQuery({
     businessId: v.id("businesses"),
     serviceId: v.id("services"),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: QueryCtx,
+    args: StaffAssignmentsForServiceArgs,
+  ): Promise<{ activeStaffCount: number; assignmentCount: number }> => {
     const [staff, assignments] = await Promise.all([
       ctx.db
         .query("staff")
@@ -130,8 +270,8 @@ export const startCall = internalMutation({
     to: v.string(),
     startedAt: v.string(),
   },
-  handler: async (ctx, args) => {
-    let contact = await ctx.db
+  handler: async (ctx: MutationCtx, args: StartCallArgs): Promise<StartCallResult> => {
+    let contact: Doc<"contacts"> | null = await ctx.db
       .query("contacts")
       .withIndex("by_business_id_and_phone", (q) =>
         q.eq("businessId", args.businessId).eq("phone", args.from),
@@ -150,17 +290,14 @@ export const startCall = internalMutation({
       throw new Error("Failed to initialize contact for call.");
     }
 
-    const existingConversation = await ctx.db
-      .query("conversations")
-      .withIndex("by_business_id_and_contact_id", (q) =>
-        q.eq("businessId", args.businessId).eq("contactId", contact._id),
-      )
-      .collect();
-
-    const openConversation =
-      existingConversation.find(
-        (conversation) => conversation.channel === "voice" && conversation.status === "open",
-      ) ?? null;
+    const openConversation: Doc<"conversations"> | null = await getOpenConversationForContact(
+      ctx,
+      {
+        businessId: args.businessId,
+        contactId: contact._id,
+        channel: "voice",
+      },
+    );
 
     const conversationId =
       openConversation?._id ??
@@ -171,7 +308,7 @@ export const startCall = internalMutation({
         status: "open",
       }));
 
-    const existingCall = await ctx.db
+    const existingCall: Doc<"calls"> | null = await ctx.db
       .query("calls")
       .withIndex("by_twilio_call_sid", (q) => q.eq("twilioCallSid", args.twilioCallSid))
       .unique();
@@ -220,7 +357,7 @@ export const appendTranscriptSegment = internalMutation({
     final: v.boolean(),
     confidence: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: AppendTranscriptArgs): Promise<Id<"transcripts">> => {
     const existing = await ctx.db
       .query("transcripts")
       .withIndex("by_call_id_and_sequence", (q) =>
@@ -255,7 +392,7 @@ export const setTransferState = internalMutation({
     callId: v.id("calls"),
     transferState: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: SetTransferStateArgs) => {
     await ctx.db.patch(args.callId, {
       transferState: args.transferState,
     });
@@ -263,6 +400,7 @@ export const setTransferState = internalMutation({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex mutation builder.
 export const takeMessageForVoice = internalMutation({
   args: {
     businessId: v.id("businesses"),
@@ -274,7 +412,10 @@ export const takeMessageForVoice = internalMutation({
     urgency: v.optional(v.string()),
     callbackWindow: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: MutationCtx,
+    args: TakeMessageForVoiceArgs,
+  ): Promise<{ inboxItemId: Id<"inbox_items"> }> => {
     const title = args.callerName
       ? `Voice message from ${args.callerName}`
       : `Voice message from ${args.callbackPhone ?? "unknown caller"}`;
@@ -317,6 +458,7 @@ export const takeMessageForVoice = internalMutation({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex mutation builder.
 export const attachCallRecording = internalMutation({
   args: {
     callId: v.id("calls"),
@@ -325,7 +467,7 @@ export const attachCallRecording = internalMutation({
     recordingByteLength: v.number(),
     recordingDurationMs: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: MutationCtx, args: AttachCallRecordingArgs) => {
     await ctx.db.patch(args.callId, {
       recordingStorageId: args.recordingStorageId,
       recordingContentType: args.recordingContentType,
@@ -338,6 +480,7 @@ export const attachCallRecording = internalMutation({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex mutation builder.
 export const completeCall = internalMutation({
   args: {
     callId: v.id("calls"),
@@ -345,8 +488,8 @@ export const completeCall = internalMutation({
     endedAt: v.string(),
     disposition: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
-    const call = await ctx.db.get(args.callId);
+  handler: async (ctx: MutationCtx, args: CompleteCallArgs) => {
+    const call: Doc<"calls"> | null = await ctx.db.get(args.callId);
     if (!call) {
       throw new Error("Call not found.");
     }
@@ -374,6 +517,7 @@ export const completeCall = internalMutation({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex mutation builder.
 export const reconcileTwilioCallStatus = internalMutation({
   args: {
     twilioCallSid: v.string(),
@@ -383,8 +527,11 @@ export const reconcileTwilioCallStatus = internalMutation({
     providerUpdatedAt: v.string(),
     providerDurationSeconds: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
-    const call = await ctx.db
+  handler: async (
+    ctx: MutationCtx,
+    args: ReconcileTwilioCallStatusArgs,
+  ): Promise<ReconcileTwilioCallStatusResult> => {
+    const call: Doc<"calls"> | null = await ctx.db
       .query("calls")
       .withIndex("by_twilio_call_sid", (q) => q.eq("twilioCallSid", args.twilioCallSid))
       .unique();
@@ -447,6 +594,7 @@ export const reconcileTwilioCallStatus = internalMutation({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex action builder.
 export const checkAvailabilityForVoice = internalAction({
   args: {
     businessId: v.id("businesses"),
@@ -455,13 +603,16 @@ export const checkAvailabilityForVoice = internalAction({
     timezone: v.string(),
     preferredStaffId: v.optional(v.id("staff")),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: ActionCtx,
+    args: CheckAvailabilityForVoiceArgs,
+  ): Promise<CheckAvailabilityForVoiceResult> => {
     const service = await resolveServiceDocument(ctx, args.businessId, args.serviceName);
     if (!service || service.businessId !== args.businessId || !service.active) {
       throw new Error("Service not found for this business.");
     }
 
-    const setup = await ctx.runQuery(
+    const setup: { activeStaffCount: number; assignmentCount: number } = await ctx.runQuery(
       internal.voice.runtime.getActiveStaffAssignmentsForService,
       {
         businessId: args.businessId,
@@ -502,6 +653,7 @@ export const checkAvailabilityForVoice = internalAction({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex action builder.
 export const findAvailabilityForVoice = internalAction({
   args: {
     businessId: v.id("businesses"),
@@ -513,13 +665,16 @@ export const findAvailabilityForVoice = internalAction({
     preferredMinute: v.optional(v.number()),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: ActionCtx,
+    args: FindAvailabilityForVoiceArgs,
+  ): Promise<FindAvailabilityForVoiceResult> => {
     const service = await resolveServiceDocument(ctx, args.businessId, args.serviceName);
     if (!service || service.businessId !== args.businessId || !service.active) {
       throw new Error("Service not found for this business.");
     }
 
-    const setup = await ctx.runQuery(
+    const setup: { activeStaffCount: number; assignmentCount: number } = await ctx.runQuery(
       internal.voice.runtime.getActiveStaffAssignmentsForService,
       {
         businessId: args.businessId,
@@ -581,6 +736,7 @@ export const findAvailabilityForVoice = internalAction({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex action builder.
 export const bookAppointmentForVoice = internalAction({
   args: {
     businessId: v.id("businesses"),
@@ -591,7 +747,10 @@ export const bookAppointmentForVoice = internalAction({
     contactName: v.optional(v.string()),
     contactPhone: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx: ActionCtx,
+    args: BookAppointmentForVoiceArgs,
+  ): Promise<BookAppointmentForVoiceResult> => {
     const service = await resolveServiceDocument(ctx, args.businessId, args.serviceName);
     if (!service || service.businessId !== args.businessId || !service.active) {
       throw new Error("Service not found for this business.");
@@ -621,14 +780,15 @@ export const bookAppointmentForVoice = internalAction({
   },
 });
 
+// @ts-ignore Deep type instantiation from Convex query builder.
 export const listRecentCalls = query({
   args: {
     businessId: v.id("businesses"),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: ListRecentCallsArgs) => {
     await requireMembership(ctx, args.businessId);
-    const calls = await ctx.db
+    const calls: Array<Doc<"calls">> = await ctx.db
       .query("calls")
       .withIndex("by_business_id_and_started_at", (q) => q.eq("businessId", args.businessId))
       .order("desc")
@@ -658,9 +818,9 @@ export const getCallTranscript = query({
     businessId: v.id("businesses"),
     callId: v.id("calls"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx: QueryCtx, args: GetCallTranscriptArgs) => {
     await requireMembership(ctx, args.businessId);
-    const call = await ctx.db.get(args.callId);
+    const call: Doc<"calls"> | null = await ctx.db.get(args.callId);
     if (!call || call.businessId !== args.businessId) {
       throw new Error("Call not found.");
     }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "seed:demo": "tsx scripts/seed-demo.ts"
   },
   "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
     "@types/luxon": "^3.7.1",
     "@types/node": "^24.0.0",
     "concurrently": "^9.1.2",
+    "convex-test": "^0.0.41",
     "tsx": "^4.20.3",
     "typescript": "^5.8.2",
     "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "node": ">=20.0.0",
     "pnpm": ">=10.0.0"
   },
+  "pnpm": {
+    "overrides": {
+      "hono": "4.12.7"
+    }
+  },
   "dependencies": {
     "@ai-sdk/google": "^3.0.43",
     "@convex-dev/action-retrier": "latest",

--- a/packages/testing/src/convexCompliance.test.ts
+++ b/packages/testing/src/convexCompliance.test.ts
@@ -1,0 +1,256 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+import schema from "../../../convex/schema";
+
+import {
+  getOpenConversationForContact,
+  reassignPreviewSessions,
+  replaceBusinessStaffServiceAssignments,
+} from "../../../convex/lib/indexedQueries";
+
+declare global {
+  interface ImportMeta {
+    glob(pattern: string): Record<string, () => Promise<unknown>>;
+  }
+}
+
+const convexModules = import.meta.glob("../../../convex/**/*.ts");
+
+describe("Convex indexed query helpers", () => {
+  it("reuses an open SMS conversation via the compound conversation index", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.run(async (ctx) => {
+      const businessId = await ctx.db.insert("businesses", {
+        slug: "sms-business",
+        name: "SMS Business",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        deploymentMode: "manual",
+        status: "active",
+      });
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550001",
+      });
+      const openConversationId = await ctx.db.insert("conversations", {
+        businessId,
+        contactId,
+        channel: "sms",
+        status: "open",
+      });
+      await ctx.db.insert("conversations", {
+        businessId,
+        contactId,
+        channel: "voice",
+        status: "open",
+      });
+      await ctx.db.insert("conversations", {
+        businessId,
+        contactId,
+        channel: "sms",
+        status: "closed",
+      });
+
+      const result = await getOpenConversationForContact(ctx, {
+        businessId,
+        contactId,
+        channel: "sms",
+      });
+
+      expect(result?._id).toBe(openConversationId);
+    });
+  });
+
+  it("reuses an open voice conversation via the compound conversation index", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.run(async (ctx) => {
+      const businessId = await ctx.db.insert("businesses", {
+        slug: "voice-business",
+        name: "Voice Business",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        deploymentMode: "manual",
+        status: "active",
+      });
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550002",
+      });
+      const openConversationId = await ctx.db.insert("conversations", {
+        businessId,
+        contactId,
+        channel: "voice",
+        status: "open",
+      });
+      await ctx.db.insert("conversations", {
+        businessId,
+        contactId,
+        channel: "sms",
+        status: "open",
+      });
+
+      const result = await getOpenConversationForContact(ctx, {
+        businessId,
+        contactId,
+        channel: "voice",
+      });
+
+      expect(result?._id).toBe(openConversationId);
+    });
+  });
+
+  it("replaces only the scoped staff-service assignments", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.run(async (ctx) => {
+      const businessId = await ctx.db.insert("businesses", {
+        slug: "assignment-business",
+        name: "Assignment Business",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        deploymentMode: "manual",
+        status: "active",
+      });
+      const otherBusinessId = await ctx.db.insert("businesses", {
+        slug: "other-assignment-business",
+        name: "Other Assignment Business",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        deploymentMode: "manual",
+        status: "active",
+      });
+      const [staffA, staffB, staffOther] = await Promise.all([
+        ctx.db.insert("staff", {
+          businessId,
+          name: "Alice",
+          timezone: "America/Toronto",
+          active: true,
+        }),
+        ctx.db.insert("staff", {
+          businessId,
+          name: "Bob",
+          timezone: "America/Toronto",
+          active: true,
+        }),
+        ctx.db.insert("staff", {
+          businessId: otherBusinessId,
+          name: "Other",
+          timezone: "America/Toronto",
+          active: true,
+        }),
+      ]);
+      const [serviceA, serviceB, serviceOther] = await Promise.all([
+        ctx.db.insert("services", {
+          businessId,
+          name: "Cut",
+          slug: "cut",
+          durationMinutes: 30,
+          active: true,
+        }),
+        ctx.db.insert("services", {
+          businessId,
+          name: "Color",
+          slug: "color",
+          durationMinutes: 45,
+          active: true,
+        }),
+        ctx.db.insert("services", {
+          businessId: otherBusinessId,
+          name: "Repair",
+          slug: "repair",
+          durationMinutes: 60,
+          active: true,
+        }),
+      ]);
+
+      await ctx.db.insert("staff_service_assignments", {
+        businessId,
+        staffId: staffA,
+        serviceId: serviceA,
+      });
+      await ctx.db.insert("staff_service_assignments", {
+        businessId,
+        staffId: staffB,
+        serviceId: serviceB,
+      });
+      const otherAssignmentId = await ctx.db.insert("staff_service_assignments", {
+        businessId: otherBusinessId,
+        staffId: staffOther,
+        serviceId: serviceOther,
+      });
+
+      await replaceBusinessStaffServiceAssignments(ctx, {
+        businessId,
+        assignments: [{ staffId: staffB, serviceId: serviceA }],
+      });
+
+      const scopedAssignments = await ctx.db
+        .query("staff_service_assignments")
+        .withIndex("by_business_id", (q) => q.eq("businessId", businessId))
+        .collect();
+      const otherAssignments = await ctx.db
+        .query("staff_service_assignments")
+        .withIndex("by_business_id", (q) => q.eq("businessId", otherBusinessId))
+        .collect();
+
+      expect(scopedAssignments).toHaveLength(1);
+      expect(scopedAssignments[0]).toMatchObject({
+        businessId,
+        staffId: staffB,
+        serviceId: serviceA,
+      });
+      expect(otherAssignments).toHaveLength(1);
+      expect(otherAssignments[0]?._id).toBe(otherAssignmentId);
+    });
+  });
+
+  it("reassigns only preview sessions owned by the legacy user", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.run(async (ctx) => {
+      const businessId = await ctx.db.insert("businesses", {
+        slug: "preview-business",
+        name: "Preview Business",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        deploymentMode: "manual",
+        status: "active",
+      });
+      const legacyUserId = await ctx.db.insert("users", {
+        authSubject: "legacy-user",
+      });
+      const currentUserId = await ctx.db.insert("users", {
+        authSubject: "current-user",
+      });
+      const otherUserId = await ctx.db.insert("users", {
+        authSubject: "other-user",
+      });
+      const legacyPreviewSessionId = await ctx.db.insert("preview_sessions", {
+        businessId,
+        userId: legacyUserId,
+        prompt: "legacy prompt",
+        streamId: "stream-legacy",
+      });
+      const otherPreviewSessionId = await ctx.db.insert("preview_sessions", {
+        businessId,
+        userId: otherUserId,
+        prompt: "other prompt",
+        streamId: "stream-other",
+      });
+
+      await reassignPreviewSessions(ctx, {
+        fromUserId: legacyUserId,
+        toUserId: currentUserId,
+      });
+
+      const legacyPreviewSession = await ctx.db.get(legacyPreviewSessionId);
+      const otherPreviewSession = await ctx.db.get(otherPreviewSessionId);
+
+      expect(legacyPreviewSession?.userId).toBe(currentUserId);
+      expect(otherPreviewSession?.userId).toBe(otherUserId);
+    });
+  });
+});

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "edge-runtime",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: 4.12.7
+
 importers:
 
   .:
@@ -16,7 +19,7 @@ importers:
         version: 0.3.0(convex@1.32.0(react@19.2.4))
       '@convex-dev/agent':
         specifier: latest
-        version: 0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(react@19.2.4)
+        version: 0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(react@19.2.4)
       '@convex-dev/auth':
         specifier: latest
         version: 0.0.91(@auth/core@0.37.4)(convex@1.32.0(react@19.2.4))(react@19.2.4)
@@ -28,13 +31,13 @@ importers:
         version: 0.3.0(convex@1.32.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@convex-dev/rag':
         specifier: latest
-        version: 0.7.1(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(zod@3.25.76)
+        version: 0.7.1(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(zod@3.25.76)
       '@convex-dev/workflow':
         specifier: latest
-        version: 0.3.5(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
+        version: 0.3.5(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
       '@convex-dev/workpool':
         specifier: latest
-        version: 0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
+        version: 0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
       ai:
         specifier: latest
         version: 6.0.116(zod@3.25.76)
@@ -945,7 +948,7 @@ packages:
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.7
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -1819,7 +1822,7 @@ packages:
     peerDependencies:
       '@standard-schema/spec': ^1.0.0
       convex: ^1.32.0
-      hono: ^4.0.5
+      hono: 4.12.7
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       typescript: ^5.5
       zod: ^3.25.0 || ^4.0.0
@@ -2289,8 +2292,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.5:
-    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+  hono@4.12.7:
+    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -3807,12 +3810,12 @@ snapshots:
     dependencies:
       convex: 1.32.0(react@19.2.4)
 
-  '@convex-dev/agent@0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(react@19.2.4)':
+  '@convex-dev/agent@0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
       ai: 6.0.116(zod@3.25.76)
       convex: 1.32.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       '@ungap/structured-clone': 1.3.0
       react: 19.2.4
@@ -3845,26 +3848,26 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@convex-dev/rag@0.7.1(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(zod@3.25.76)':
+  '@convex-dev/rag@0.7.1(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(zod@3.25.76)':
     dependencies:
-      '@convex-dev/workpool': 0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
+      '@convex-dev/workpool': 0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
       ai: 6.0.116(zod@3.25.76)
       convex: 1.32.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 
-  '@convex-dev/workflow@0.3.5(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
+  '@convex-dev/workflow@0.3.5(@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
     dependencies:
-      '@convex-dev/workpool': 0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
+      '@convex-dev/workpool': 0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
       async-channel: 0.2.0
       convex: 1.32.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
 
-  '@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
+  '@convex-dev/workpool@0.4.1(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
     dependencies:
       convex: 1.32.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -4132,9 +4135,9 @@ snapshots:
 
   '@fontsource-variable/public-sans@5.2.7': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.5)':
+  '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
-      hono: 4.12.5
+      hono: 4.12.7
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -4185,7 +4188,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.5)
+      '@hono/node-server': 1.19.11(hono@4.12.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4195,7 +4198,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.5
+      hono: 4.12.7
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4892,12 +4895,12 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.5)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76):
+  convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       convex: 1.32.0(react@19.2.4)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
-      hono: 4.12.5
+      hono: 4.12.7
       react: 19.2.4
       typescript: 5.9.3
       zod: 3.25.76
@@ -5398,7 +5401,7 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.5: {}
+  hono@4.12.7: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@types/luxon':
         specifier: ^3.7.1
         version: 3.7.1
@@ -57,6 +60,9 @@ importers:
       concurrently:
         specifier: ^9.1.2
         version: 9.2.1
+      convex-test:
+        specifier: ^0.0.41
+        version: 0.0.41(convex@1.32.0(react@19.2.4))
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -65,7 +71,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)
 
   apps/voice-gateway:
     dependencies:
@@ -572,6 +578,14 @@ packages:
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@edge-runtime/primitives@6.0.0':
+    resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
+    engines: {node: '>=18'}
+
+  '@edge-runtime/vm@5.0.0':
+    resolution: {integrity: sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.27.0':
     resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
@@ -1820,6 +1834,11 @@ packages:
         optional: true
       zod:
         optional: true
+
+  convex-test@0.0.41:
+    resolution: {integrity: sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ==}
+    peerDependencies:
+      convex: ^1.16.4
 
   convex@1.32.0:
     resolution: {integrity: sha512-5FlajdLpW75pdLS+/CgGH5H6yeRuA+ru50AKJEYbJpmyILUS+7fdTvsdTaQ7ZFXMv0gE8mX4S+S3AtJ94k0mfw==}
@@ -3895,6 +3914,12 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@edge-runtime/primitives@6.0.0': {}
+
+  '@edge-runtime/vm@5.0.0':
+    dependencies:
+      '@edge-runtime/primitives': 6.0.0
+
   '@esbuild/aix-ppc64@0.27.0':
     optional: true
 
@@ -4876,6 +4901,10 @@ snapshots:
       react: 19.2.4
       typescript: 5.9.3
       zod: 3.25.76
+
+  convex-test@0.0.41(convex@1.32.0(react@19.2.4)):
+    dependencies:
+      convex: 1.32.0(react@19.2.4)
 
   convex@1.32.0(react@19.2.4):
     dependencies:
@@ -6426,7 +6455,7 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -6452,6 +6481,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
       '@types/node': 24.12.0
     transitivePeerDependencies:
       - jiti

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,0 +1,60 @@
+# Security Best Practices Report
+
+## Executive Summary
+
+I reviewed `feature/ope-43-convex-compliance-phase-1` against `main` (merge base `95e924bed02073b9e82215a745f8ce81f9fc0ada`) with a branch-focused security lens. I did not find any branch-introduced vulnerabilities that would merit remediation before merge. The most security-relevant code changes improve request validation on Convex HTTP endpoints and preserve existing authentication or webhook-verification gates.
+
+After the initial review, I remediated the pre-existing moderate `hono` advisory by pinning the transitive dependency to `4.12.7` via a root pnpm override in [package.json:10](/Users/raphael/Coding/ai-receptionist/package.json#L10). The resolved dependency graph now points the Convex helper chain at `hono@4.12.7`, visible in [pnpm-lock.yaml:8](/Users/raphael/Coding/ai-receptionist/pnpm-lock.yaml#L8) and [pnpm-lock.yaml:2295](/Users/raphael/Coding/ai-receptionist/pnpm-lock.yaml#L2295), and `pnpm audit --prod --dev` now reports no known vulnerabilities.
+
+## Scope
+
+- Diff review against `main` for:
+  - [convex/http.ts](/Users/raphael/Coding/ai-receptionist/convex/http.ts)
+  - [convex/conversations/webhooks.ts](/Users/raphael/Coding/ai-receptionist/convex/conversations/webhooks.ts)
+  - [convex/voice/runtime.ts](/Users/raphael/Coding/ai-receptionist/convex/voice/runtime.ts)
+  - [convex/lib/auth.ts](/Users/raphael/Coding/ai-receptionist/convex/lib/auth.ts)
+  - [convex/ai/context/knowledge.ts](/Users/raphael/Coding/ai-receptionist/convex/ai/context/knowledge.ts)
+  - schema/index changes that affect authorization or data routing
+- Validation:
+  - `pnpm typecheck`
+  - `pnpm test`
+  - `pnpm audit --prod --dev`
+
+## Critical Findings
+
+None.
+
+## High Findings
+
+None.
+
+## Medium Findings
+
+None.
+
+## Low Findings
+
+None.
+
+## Informational Notes
+
+### INFO-1: Branch improves validation on exposed Convex HTTP routes
+
+The branch adds explicit Zod validation and early `400` handling for the exposed HTTP entrypoints in [convex/http.ts:18](/Users/raphael/Coding/ai-receptionist/convex/http.ts#L18), [convex/http.ts:133](/Users/raphael/Coding/ai-receptionist/convex/http.ts#L133), and [convex/http.ts:201](/Users/raphael/Coding/ai-receptionist/convex/http.ts#L201). This is aligned with the backend guidance to validate untrusted request data before it reaches business logic.
+
+### INFO-2: Existing authn/authz checks remain in place for the newly refactored knowledge actions
+
+The knowledge preview and search paths still require an authenticated identity plus business membership before performing business-scoped work, as shown in [convex/ai/context/knowledge.ts:78](/Users/raphael/Coding/ai-receptionist/convex/ai/context/knowledge.ts#L78). I did not find an authorization regression in the refactor from internal action chaining to shared helper functions.
+
+### INFO-3: Pre-existing `hono` advisory has been remediated
+
+The earlier `pnpm audit --prod --dev` result for `GHSA-v8w9-8mx6-g223` was caused by the existing Convex dependency chain `@convex-dev/agent -> convex-helpers -> hono`. I fixed that by forcing `hono@4.12.7` with a root pnpm override in [package.json:10](/Users/raphael/Coding/ai-receptionist/package.json#L10). The lockfile now resolves the whole Convex helper chain to the patched version, including [pnpm-lock.yaml:22](/Users/raphael/Coding/ai-receptionist/pnpm-lock.yaml#L22), [pnpm-lock.yaml:1825](/Users/raphael/Coding/ai-receptionist/pnpm-lock.yaml#L1825), and [pnpm-lock.yaml:5404](/Users/raphael/Coding/ai-receptionist/pnpm-lock.yaml#L5404), and a fresh `pnpm audit --prod --dev` returns clean.
+
+## Residual Risks To Verify Outside App Code
+
+- Internal voice endpoints rely on `x-internal-service-token` rather than user-facing auth, which is appropriate for service-to-service traffic but should still be protected by secret rotation and network boundary controls. The branch does not weaken this pattern.
+- Twilio webhook authenticity still depends on correct `TWILIO_AUTH_TOKEN` configuration and deployment URL consistency. The branch preserves signature verification for SMS ingress at [convex/http.ts:171](/Users/raphael/Coding/ai-receptionist/convex/http.ts#L171).
+
+## Conclusion
+
+No branch-specific security blockers were found, and the one pre-existing dependency advisory identified during the review has now been remediated and verified.


### PR DESCRIPTION
## Summary

Implements the OPE-43 Convex compliance phase 1 sweep and a follow-up security remediation.

This PR:
- adds missing indexes for current Convex query hotspots
- replaces collect/filter patterns with direct indexed reads
- removes file-wide `@ts-nocheck` from key public/auth-sensitive Convex modules
- normalizes touched `internal.*` references
- hardens `convex/http.ts` with explicit request validation and `400` handling for malformed payloads
- adds Convex compliance coverage in `packages/testing`
- patches the pre-existing transitive `hono` advisory by pinning `hono@4.12.7` via pnpm override

## Verification

- `pnpm audit --prod --dev`
- `pnpm typecheck`
- `pnpm test`

## Notes

- Security review report written to `security_best_practices_report.md`
- Linear: `OPE-43`