### PR TITLE
OPE-45 remove final Convex ts-nochecks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,7 +16,7 @@ import {
   IconHeadphones,
 } from "@tabler/icons-react";
 
-import type { BusinessContextSnapshot } from "@ai-receptionist/shared";
+import type { BusinessContextSnapshot, BusinessType } from "@ai-receptionist/shared";
 import { demoSnapshot } from "@ai-receptionist/testing";
 
 import { api } from "../../../convex/_generated/api";
@@ -48,6 +48,37 @@ import { PhoneNumbersCard } from "@/features/settings/PhoneNumbersCard";
 import { BusinessProfileForm } from "@/features/settings/BusinessProfileForm";
 import { BusinessSnapshotCard } from "@/features/settings/BusinessSnapshotCard";
 import { ServicesCard } from "@/features/settings/ServicesCard";
+
+const BUSINESS_TYPES: ReadonlyArray<BusinessType> = [
+  "clinic",
+  "repair_shop",
+  "salon",
+  "service_company",
+  "other",
+];
+const TRANSFER_MODES: ReadonlyArray<BusinessContextSnapshot["transferPolicy"]["mode"]> = [
+  "never",
+  "always",
+  "on_request",
+  "on_urgent",
+  "during_business_hours",
+];
+
+function normalizeBusinessType(value: string): BusinessType {
+  return BUSINESS_TYPES.includes(value as BusinessType)
+    ? (value as BusinessType)
+    : "other";
+}
+
+function normalizeTransferMode(
+  value: string,
+): BusinessContextSnapshot["transferPolicy"]["mode"] {
+  return TRANSFER_MODES.includes(
+    value as BusinessContextSnapshot["transferPolicy"]["mode"],
+  )
+    ? (value as BusinessContextSnapshot["transferPolicy"]["mode"])
+    : "on_request";
+}
 
 function LoadingScreen() {
   return (
@@ -532,7 +563,19 @@ function WorkspaceShell() {
     api.ai.context.snapshots.getForDashboard,
     businessId ? { businessId } : "skip",
   );
-  const resolvedSnapshot = snapshot ?? demoSnapshot;
+  const resolvedSnapshot: BusinessContextSnapshot = snapshot
+    ? {
+        ...snapshot,
+        businessType: normalizeBusinessType(snapshot.businessType),
+        transferPolicy: {
+          ...snapshot.transferPolicy,
+          mode: normalizeTransferMode(snapshot.transferPolicy.mode),
+        },
+      }
+    : demoSnapshot;
+  const routeBusinessProps = businessId ? { businessId } : {};
+  const sidebarBusinessSlug =
+    activeBusiness?.slug !== undefined ? { businessSlug: activeBusiness.slug } : {};
 
   const headerCopy = useMemo(() => {
     const path = location.pathname;
@@ -575,8 +618,8 @@ function WorkspaceShell() {
     >
       <AppSidebar
         businessName={activeBusiness?.name ?? "AI Receptionist"}
-        businessSlug={activeBusiness?.slug}
         onSignOut={() => void signOut()}
+        {...sidebarBusinessSlug}
       />
       <SidebarInset>
         <SiteHeader description={headerCopy.description} title={headerCopy.title} />
@@ -585,20 +628,20 @@ function WorkspaceShell() {
             <Route
               element={
                 <DashboardHome
-                  businessId={businessId}
                   businessName={activeBusiness?.name ?? resolvedSnapshot.displayName}
                   snapshot={resolvedSnapshot}
+                  {...routeBusinessProps}
                 />
               }
               path="/"
             />
-            <Route element={<InboxPage businessId={businessId} />} path="/inbox" />
+            <Route element={<InboxPage {...routeBusinessProps} />} path="/inbox" />
             <Route
-              element={<KnowledgePage businessId={businessId} snapshot={resolvedSnapshot} />}
+              element={<KnowledgePage snapshot={resolvedSnapshot} {...routeBusinessProps} />}
               path="/knowledge"
             />
             <Route
-              element={<SettingsPage businessId={businessId} snapshot={resolvedSnapshot} />}
+              element={<SettingsPage snapshot={resolvedSnapshot} {...routeBusinessProps} />}
               path="/settings"
             />
             <Route element={<Navigate replace to="/" />} path="*" />

--- a/apps/web/src/features/settings/BookableTeamCard.tsx
+++ b/apps/web/src/features/settings/BookableTeamCard.tsx
@@ -128,13 +128,14 @@ export function BookableTeamCard(props: BookableTeamCardProps) {
     setErrorMessage(null);
 
     try {
+      const trimmedTransferNumber = transferNumber.trim();
       const result = await upsertStaff({
         businessId: props.businessId,
-        staffId: selectedStaff?._id,
         name: name.trim(),
         timezone: timezone.trim() || businessTimezone,
         active,
-        transferNumber: transferNumber.trim() || undefined,
+        ...(selectedStaff?._id !== undefined ? { staffId: selectedStaff._id } : {}),
+        ...(trimmedTransferNumber ? { transferNumber: trimmedTransferNumber } : {}),
       });
       setSelectedStaffKey(String(result.staffId));
       setStaffSaveMessage(selectedStaff ? "Saved team member." : "Added team member.");

--- a/apps/web/src/features/settings/BusinessProfileForm.tsx
+++ b/apps/web/src/features/settings/BusinessProfileForm.tsx
@@ -50,16 +50,21 @@ export function BusinessProfileForm(props: BusinessProfileFormProps) {
     setIsSaving(true);
     setStatus(null);
     try {
+      const trimmedVoiceInstructions = voiceInstructions.trim();
+      const trimmedSmsInstructions = smsInstructions.trim();
+      const trimmedTransferNumber = transferNumber.trim();
       await saveProfile({
         businessId: props.businessId,
         greeting,
         tone,
         summary,
         bookingPolicy,
-        voiceInstructions: voiceInstructions.trim() || undefined,
-        smsInstructions: smsInstructions.trim() || undefined,
         transferMode,
-        transferNumber: transferNumber.trim() || undefined,
+        ...(trimmedVoiceInstructions
+          ? { voiceInstructions: trimmedVoiceInstructions }
+          : {}),
+        ...(trimmedSmsInstructions ? { smsInstructions: trimmedSmsInstructions } : {}),
+        ...(trimmedTransferNumber ? { transferNumber: trimmedTransferNumber } : {}),
       });
       setStatus("Saved receptionist profile.");
     } finally {

--- a/apps/web/src/features/settings/PhoneNumbersCard.tsx
+++ b/apps/web/src/features/settings/PhoneNumbersCard.tsx
@@ -88,14 +88,17 @@ export function PhoneNumbersCard(props: PhoneNumbersCardProps) {
     setErrorMessage(null);
 
     try {
+      const trimmedTwilioPhoneSid = twilioPhoneSid.trim();
       const result = await upsertPhoneNumber({
         businessId: props.businessId,
-        phoneNumberId: selectedPhoneNumber?._id,
         e164: e164.replace(/\s+/g, ""),
-        twilioPhoneSid: twilioPhoneSid.trim() || undefined,
         voiceEnabled,
         smsEnabled,
         status,
+        ...(selectedPhoneNumber?._id !== undefined
+          ? { phoneNumberId: selectedPhoneNumber._id }
+          : {}),
+        ...(trimmedTwilioPhoneSid ? { twilioPhoneSid: trimmedTwilioPhoneSid } : {}),
       });
 
       setSelectedPhoneNumberKey(String(result.phoneNumberId));

--- a/apps/web/src/features/settings/ServicesCard.tsx
+++ b/apps/web/src/features/settings/ServicesCard.tsx
@@ -43,13 +43,14 @@ export function ServicesCard(props: ServicesCardProps) {
     setIsSaving(true);
     setStatus(null);
     try {
+      const trimmedDescription = description.trim();
       await upsertService({
         businessId: props.businessId,
         name,
         slug,
-        description: description.trim() || undefined,
         durationMinutes: Number(durationMinutes),
         active: true,
+        ...(trimmedDescription ? { description: trimmedDescription } : {}),
       });
       setStatus("Saved service.");
       setName("");

--- a/convex/ai/context/knowledge.ts
+++ b/convex/ai/context/knowledge.ts
@@ -121,7 +121,9 @@ async function indexKnowledgeDocumentById(
     title: document.title,
     text: document.textContent,
     key: `document:${String(documentId)}`,
-    contentHash: document.contentHash,
+    ...(document.contentHash !== undefined
+      ? { contentHash: document.contentHash }
+      : {}),
     filterValues: [
       { name: "businessId", value: String(document.businessId) },
       { name: "sourceType", value: document.sourceType },

--- a/convex/ai/workflows/runtime.ts
+++ b/convex/ai/workflows/runtime.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import { internalMutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";

--- a/convex/appointments/booking.ts
+++ b/convex/appointments/booking.ts
@@ -195,7 +195,9 @@ async function bookAppointmentWithSource(
       serviceId: args.serviceId,
       startsAt: args.startsAt,
       timezone: args.timezone,
-      preferredStaffId: args.preferredStaffId,
+      ...(args.preferredStaffId !== undefined
+        ? { preferredStaffId: args.preferredStaffId }
+        : {}),
     },
   );
 
@@ -224,6 +226,9 @@ async function bookAppointmentWithSource(
   }
 
   const selected = availability[0];
+  if (!selected) {
+    throw new Error("No availability for the requested time.");
+  }
   const appointmentId = await ctx.db.insert("appointments", {
     businessId: args.businessId,
     contactId: contact._id,

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -322,7 +322,9 @@ export const handleTwilioSmsInbound = internalAction({
         contactId,
         channel: "sms",
         body: args.body,
-        providerMessageSid: args.messageSid,
+        ...(args.messageSid !== undefined
+          ? { providerMessageSid: args.messageSid }
+          : {}),
       },
     );
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -220,7 +220,9 @@ http.route({
       from: parsedPayload.data.From,
       to: parsedPayload.data.To,
       body: parsedPayload.data.Body,
-      messageSid: parsedPayload.data.MessageSid,
+      ...(parsedPayload.data.MessageSid !== undefined
+        ? { messageSid: parsedPayload.data.MessageSid }
+        : {}),
     });
 
     const twiml = [

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -1,12 +1,13 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import {
+  type ActionCtx,
   internalAction,
   internalMutation,
   internalQuery,
   mutation,
 } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { Doc } from "../_generated/dataModel";
 import { retrier } from "../lib/components";
 import { requireMembership } from "../lib/auth";
 
@@ -149,8 +150,8 @@ export const deliverNotification = internalAction({
 
 export const dispatchDueNotifications = internalAction({
   args: {},
-  handler: async (ctx) => {
-    const due = await ctx.runQuery(
+  handler: async (ctx: ActionCtx): Promise<{ count: number }> => {
+    const due: Array<Doc<"notifications">> = await ctx.runQuery(
       internal.notifications.reminders.listDueScheduledNotifications,
       {
         nowIso: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Completes the final Convex docs-compliance typing cleanup by removing the last file-level `@ts-nocheck` directives and fixing the surfaced exact-optional-property issues needed to keep the workspace green.

This PR:
- removes the final file-level `@ts-nocheck` directives from `convex/notifications/reminders.ts` and `convex/ai/workflows/runtime.ts`
- normalizes the dashboard snapshot shape in `apps/web/src/App.tsx` so it matches the shared `BusinessContextSnapshot` contract
- updates web settings mutation callsites to omit optional fields instead of explicitly passing `undefined`
- updates Convex knowledge, booking, and SMS webhook callsites to follow the same exact-optional-property pattern
- adds a small defensive narrowing in appointment booking after availability lookup

## Verification

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Notes

- Linear: `OPE-45`
- This is the final narrow follow-up after `OPE-43` and `OPE-44` to finish the Convex cleanup thread