### PR TITLE
Feature/ope 15 calendar reconciliation

### DIFF
--- a/convex/ai/workflows/runtime.ts
+++ b/convex/ai/workflows/runtime.ts
@@ -2,6 +2,7 @@
 import { v } from "convex/values";
 import { internalMutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";
+import { CALENDAR_RECONCILIATION_INTERVAL_MS } from "../../integrations/calendar";
 import { workflowManager, runtimeCrons } from "../../lib/components";
 
 export const refreshBusinessContextSnapshotWorkflow = workflowManager.define({
@@ -63,7 +64,7 @@ export const registerCalendarReconciliationCron = internalMutation({
 
     await runtimeCrons.register(
       ctx,
-      { kind: "interval", ms: 60 * 60 * 1000 },
+      { kind: "interval", ms: CALENDAR_RECONCILIATION_INTERVAL_MS },
       internal.integrations.calendar.runBusinessCalendarReconciliation,
       { businessId: args.businessId },
       name,

--- a/convex/appointments/booking.ts
+++ b/convex/appointments/booking.ts
@@ -223,6 +223,17 @@ async function bookAppointmentWithSource(
     throw new Error("Failed to create contact.");
   }
 
+  const calendarState: {
+    hasConnectedCalendar: boolean;
+    connectionCount: number;
+    selectedConnectionId?: Id<"calendar_connections">;
+    selectedCalendarId?: string;
+  } = await ctx.runQuery(
+    internal.integrations.calendar.getBusinessCalendarConnectionState,
+    {
+      businessId: args.businessId,
+    },
+  );
   const selected = availability[0];
   const appointmentId = await ctx.db.insert("appointments", {
     businessId: args.businessId,
@@ -234,7 +245,7 @@ async function bookAppointmentWithSource(
     timezone: args.timezone,
     status: "confirmed",
     sourceChannel: args.sourceChannel,
-    calendarSyncState: "pending",
+    calendarSyncState: calendarState.hasConnectedCalendar ? "pending" : "not_required",
   });
 
   await workflowManager.start(

--- a/convex/integrations/calendar.ts
+++ b/convex/integrations/calendar.ts
@@ -14,7 +14,8 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
 import { workflowManager } from "../lib/components";
 
-const CALENDAR_SYNC_RETRY_DELAY_MS = 5 * 60 * 1000;
+export const CALENDAR_RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
+const CALENDAR_SYNC_RETRY_DELAY_MS = CALENDAR_RECONCILIATION_INTERVAL_MS;
 const CALENDAR_SYNC_PENDING_TIMEOUT_MS = 15 * 60 * 1000;
 const CALENDAR_SYNC_SYNCING_TIMEOUT_MS = 15 * 60 * 1000;
 
@@ -101,6 +102,10 @@ function isPastDue(targetIso: string | undefined, nowMs: number): boolean {
   }
 
   return Date.parse(targetIso) <= nowMs;
+}
+
+function shouldRetrySync(targetIso: string | undefined, nowMs: number): boolean {
+  return targetIso === undefined || isPastDue(targetIso, nowMs);
 }
 
 function isStale(
@@ -684,9 +689,10 @@ export const runBusinessCalendarReconciliation = internalAction({
             calendarSyncState: "drifted",
             calendarLastSyncError:
               "Connected calendar exists but the appointment was never queued for sync.",
+            calendarReconcileAfter: getRetryTime(nowIso),
           },
         );
-        await ctx.runMutation(
+        const result = await ctx.runMutation(
           internal.integrations.calendar.upsertCalendarSyncIssue,
           {
             appointmentId: appointment._id,
@@ -704,7 +710,9 @@ export const runBusinessCalendarReconciliation = internalAction({
           },
         );
         drifted += 1;
-        issuesOpened += 1;
+        if (result.created) {
+          issuesOpened += 1;
+        }
         continue;
       }
 
@@ -720,9 +728,10 @@ export const runBusinessCalendarReconciliation = internalAction({
             calendarSyncState: "drifted",
             calendarLastSyncError:
               "Appointment is marked synced but has no external calendar event ID.",
+            calendarReconcileAfter: getRetryTime(nowIso),
           },
         );
-        await ctx.runMutation(
+        const result = await ctx.runMutation(
           internal.integrations.calendar.upsertCalendarSyncIssue,
           {
             appointmentId: appointment._id,
@@ -738,7 +747,9 @@ export const runBusinessCalendarReconciliation = internalAction({
           },
         );
         drifted += 1;
-        issuesOpened += 1;
+        if (result.created) {
+          issuesOpened += 1;
+        }
         continue;
       }
 
@@ -814,14 +825,22 @@ export const runBusinessCalendarReconciliation = internalAction({
         if (result.created) {
           issuesOpened += 1;
         }
+        if (shouldRetrySync(appointment.calendarReconcileAfter, nowMs)) {
+          retried += 1;
+          const retryResult = await ctx.runAction(
+            internal.integrations.calendar.syncAppointmentToExternalCalendars,
+            {
+              appointmentId: appointment._id,
+            },
+          );
+          if (retryResult.ok) {
+            recovered += 1;
+          }
+        }
         continue;
       }
 
-      if (
-        state === "failed" &&
-        !appointment.calendarSyncIssueId &&
-        isPastDue(appointment.calendarReconcileAfter, nowMs)
-      ) {
+      if (state === "failed" && shouldRetrySync(appointment.calendarReconcileAfter, nowMs)) {
         retried += 1;
         const result = await ctx.runAction(
           internal.integrations.calendar.syncAppointmentToExternalCalendars,

--- a/convex/integrations/calendar.ts
+++ b/convex/integrations/calendar.ts
@@ -3,12 +3,159 @@ import {
   action,
   internalAction,
   internalMutation,
+  internalQuery,
   mutation,
   query,
+  type MutationCtx,
+  type QueryCtx,
 } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
 import { workflowManager } from "../lib/components";
+
+const CALENDAR_SYNC_RETRY_DELAY_MS = 5 * 60 * 1000;
+const CALENDAR_SYNC_PENDING_TIMEOUT_MS = 15 * 60 * 1000;
+const CALENDAR_SYNC_SYNCING_TIMEOUT_MS = 15 * 60 * 1000;
+
+const calendarSyncStateValidator = v.union(
+  v.literal("not_required"),
+  v.literal("pending"),
+  v.literal("syncing"),
+  v.literal("synced"),
+  v.literal("failed"),
+  v.literal("drifted"),
+  v.literal("synced_mock"),
+);
+
+type CalendarSyncState =
+  | "not_required"
+  | "pending"
+  | "syncing"
+  | "synced"
+  | "failed"
+  | "drifted"
+  | "synced_mock";
+
+type NormalizedCalendarSyncState =
+  | "not_required"
+  | "pending"
+  | "syncing"
+  | "synced"
+  | "failed"
+  | "drifted";
+
+type AppointmentSyncContext = {
+  appointment: Doc<"appointments">;
+  serviceName: string;
+  contactName?: string;
+  contactPhone: string;
+  hasConnectedCalendar: boolean;
+  selectedConnectionId?: Id<"calendar_connections">;
+  selectedCalendarId?: string;
+};
+
+type CalendarConnectionState = {
+  hasConnectedCalendar: boolean;
+  connectionCount: number;
+  selectedConnectionId?: Id<"calendar_connections">;
+  selectedCalendarId?: string;
+};
+
+type CalendarReconciliationResult = {
+  businessId: Id<"businesses">;
+  processed: number;
+  retried: number;
+  failed: number;
+  drifted: number;
+  recovered: number;
+  issuesOpened: number;
+};
+
+type CalendarReconciliationSummary = {
+  businessId: Id<"businesses">;
+  counts: Record<NormalizedCalendarSyncState, number>;
+  openIssueCount: number;
+};
+
+function normalizeCalendarSyncState(
+  state: CalendarSyncState,
+): NormalizedCalendarSyncState {
+  return state === "synced_mock" ? "synced" : state;
+}
+
+function buildMockExternalEventId(
+  connectionId: Id<"calendar_connections">,
+  appointmentId: Id<"appointments">,
+): string {
+  return `mock:${String(connectionId)}:${String(appointmentId)}`;
+}
+
+function getRetryTime(nowIso: string): string {
+  return new Date(Date.parse(nowIso) + CALENDAR_SYNC_RETRY_DELAY_MS).toISOString();
+}
+
+function isPastDue(targetIso: string | undefined, nowMs: number): boolean {
+  if (!targetIso) {
+    return false;
+  }
+
+  return Date.parse(targetIso) <= nowMs;
+}
+
+function isStale(
+  referenceIso: string | undefined,
+  nowMs: number,
+  thresholdMs: number,
+): boolean {
+  if (!referenceIso) {
+    return false;
+  }
+
+  return nowMs - Date.parse(referenceIso) >= thresholdMs;
+}
+
+function buildCalendarSyncIssueBody(input: {
+  appointment: Doc<"appointments">;
+  serviceName: string;
+  contactName?: string;
+  contactPhone: string;
+}): string {
+  const lines = [
+    `Appointment: ${input.appointment.startsAt}`,
+    `Service: ${input.serviceName}`,
+    `Contact: ${input.contactName ?? "Unknown"} (${input.contactPhone})`,
+    `Sync state: ${normalizeCalendarSyncState(input.appointment.calendarSyncState)}`,
+  ];
+
+  if (input.appointment.calendarLastSyncError) {
+    lines.push(`Last error: ${input.appointment.calendarLastSyncError}`);
+  }
+
+  return lines.join("\n");
+}
+
+async function loadConnectedCalendarConnections(
+  ctx: Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">,
+  businessId: Id<"businesses">,
+): Promise<Array<Doc<"calendar_connections">>> {
+  return await ctx.db
+    .query("calendar_connections")
+    .withIndex("by_business_id_and_status", (q) =>
+      q.eq("businessId", businessId).eq("status", "connected"),
+    )
+    .collect();
+}
+
+function selectPreferredCalendarConnection(
+  connections: Array<Doc<"calendar_connections">>,
+): Doc<"calendar_connections"> | null {
+  return (
+    connections.find((connection) => connection.selectedCalendarId !== undefined) ??
+    connections[0] ??
+    null
+  );
+}
 
 export const listCalendarConnections = query({
   args: {
@@ -22,6 +169,24 @@ export const listCalendarConnections = query({
         q.eq("businessId", args.businessId),
       )
       .collect();
+  },
+});
+
+export const getBusinessCalendarConnectionState = internalQuery({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  handler: async (ctx, args): Promise<CalendarConnectionState> => {
+    const connections = await loadConnectedCalendarConnections(ctx, args.businessId);
+    const selected = selectPreferredCalendarConnection(connections);
+    return {
+      hasConnectedCalendar: connections.length > 0,
+      connectionCount: connections.length,
+      ...(selected?._id !== undefined ? { selectedConnectionId: selected._id } : {}),
+      ...(selected?.selectedCalendarId !== undefined
+        ? { selectedCalendarId: selected.selectedCalendarId }
+        : {}),
+    };
   },
 });
 
@@ -56,6 +221,12 @@ export const upsertCalendarConnection = mutation({
           : {}),
         status: "connected",
       });
+      await ctx.runMutation(
+        internal.ai.workflows.runtime.registerCalendarReconciliationCron,
+        {
+          businessId: args.businessId,
+        },
+      );
       return { connectionId: existing._id };
     }
 
@@ -76,6 +247,12 @@ export const upsertCalendarConnection = mutation({
       status: "connected",
     });
 
+    await ctx.runMutation(
+      internal.ai.workflows.runtime.registerCalendarReconciliationCron,
+      {
+        businessId: args.businessId,
+      },
+    );
     await workflowManager.start(
       ctx,
       internal.ai.workflows.runtime.refreshBusinessContextSnapshotWorkflow,
@@ -85,16 +262,245 @@ export const upsertCalendarConnection = mutation({
   },
 });
 
-export const markAppointmentSyncState = internalMutation({
+export const getAppointmentCalendarSyncContext = internalQuery({
   args: {
     appointmentId: v.id("appointments"),
-    calendarSyncState: v.string(),
+  },
+  handler: async (ctx, args): Promise<AppointmentSyncContext | null> => {
+    const appointment = await ctx.db.get(args.appointmentId);
+    if (!appointment) {
+      return null;
+    }
+
+    const [service, contact, connections] = await Promise.all([
+      ctx.db.get(appointment.serviceId),
+      ctx.db.get(appointment.contactId),
+      loadConnectedCalendarConnections(ctx, appointment.businessId),
+    ]);
+
+    if (!service) {
+      throw new Error("Service not found for appointment.");
+    }
+    if (!contact) {
+      throw new Error("Contact not found for appointment.");
+    }
+
+    const selected = selectPreferredCalendarConnection(connections);
+
+    return {
+      appointment,
+      serviceName: service.name,
+      ...(contact.name !== undefined ? { contactName: contact.name } : {}),
+      contactPhone: contact.phone,
+      hasConnectedCalendar: connections.length > 0,
+      ...(selected?._id !== undefined ? { selectedConnectionId: selected._id } : {}),
+      ...(selected?.selectedCalendarId !== undefined
+        ? { selectedCalendarId: selected.selectedCalendarId }
+        : {}),
+    };
+  },
+});
+
+export const listAppointmentsForCalendarReconciliation = internalQuery({
+  args: {
+    businessId: v.id("businesses"),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.appointmentId, {
+    const states: Array<CalendarSyncState> = [
+      "pending",
+      "syncing",
+      "failed",
+      "drifted",
+      "not_required",
+      "synced",
+      "synced_mock",
+    ];
+    const appointmentsById = new Map<Id<"appointments">, Doc<"appointments">>();
+
+    for (const state of states) {
+      const appointments = await ctx.db
+        .query("appointments")
+        .withIndex("by_business_id_and_calendar_sync_state_and_starts_at", (q) =>
+          q.eq("businessId", args.businessId).eq("calendarSyncState", state),
+        )
+        .collect();
+      for (const appointment of appointments) {
+        appointmentsById.set(appointment._id, appointment);
+      }
+    }
+
+    return [...appointmentsById.values()].sort((left, right) =>
+      left.startsAt.localeCompare(right.startsAt),
+    );
+  },
+});
+
+export const setAppointmentCalendarSyncState = internalMutation({
+  args: {
+    appointmentId: v.id("appointments"),
+    calendarSyncState: calendarSyncStateValidator,
+    calendarLastSyncAttemptAt: v.optional(v.string()),
+    calendarLastSyncedAt: v.optional(v.string()),
+    calendarLastSyncError: v.optional(v.string()),
+    calendarReconcileAfter: v.optional(v.string()),
+    calendarSyncIssueId: v.optional(v.id("inbox_items")),
+    calendarExternalEventId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const patch: Partial<Doc<"appointments">> = {
       calendarSyncState: args.calendarSyncState,
+    };
+
+    if (args.calendarLastSyncAttemptAt !== undefined) {
+      patch.calendarLastSyncAttemptAt = args.calendarLastSyncAttemptAt;
+    }
+    if (args.calendarLastSyncedAt !== undefined) {
+      patch.calendarLastSyncedAt = args.calendarLastSyncedAt;
+    }
+    if (args.calendarLastSyncError !== undefined) {
+      patch.calendarLastSyncError = args.calendarLastSyncError;
+    }
+    if (args.calendarReconcileAfter !== undefined) {
+      patch.calendarReconcileAfter = args.calendarReconcileAfter;
+    }
+    if (args.calendarSyncIssueId !== undefined) {
+      patch.calendarSyncIssueId = args.calendarSyncIssueId;
+    }
+    if (args.calendarExternalEventId !== undefined) {
+      patch.calendarExternalEventId = args.calendarExternalEventId;
+    }
+
+    await ctx.db.patch(args.appointmentId, patch);
+    return null;
+  },
+});
+
+export const recordCalendarAuditLog = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+    eventType: v.string(),
+    entityId: v.optional(v.string()),
+    payload: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("audit_logs", {
+      businessId: args.businessId,
+      eventType: args.eventType,
+      entityType: "appointment",
+      ...(args.entityId !== undefined ? { entityId: args.entityId } : {}),
+      ...(args.payload !== undefined ? { payload: args.payload } : {}),
     });
     return null;
+  },
+});
+
+export const upsertCalendarSyncIssue = internalMutation({
+  args: {
+    appointmentId: v.id("appointments"),
+  },
+  handler: async (ctx, args) => {
+    const appointment = await ctx.db.get(args.appointmentId);
+    if (!appointment) {
+      throw new Error("Appointment not found.");
+    }
+
+    const [service, contact, existingOpenIssue] = await Promise.all([
+      ctx.db.get(appointment.serviceId),
+      ctx.db.get(appointment.contactId),
+      ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(args.appointmentId)),
+        )
+        .collect(),
+    ]);
+
+    if (!service) {
+      throw new Error("Service not found for appointment.");
+    }
+    if (!contact) {
+      throw new Error("Contact not found for appointment.");
+    }
+
+    const title = `Calendar sync issue for ${service.name}`;
+    const body = buildCalendarSyncIssueBody({
+      appointment,
+      serviceName: service.name,
+      ...(contact.name !== undefined ? { contactName: contact.name } : {}),
+      contactPhone: contact.phone,
+    });
+
+    const openIssue = existingOpenIssue.find((item) => item.status === "open") ?? null;
+    if (openIssue) {
+      await ctx.db.patch(openIssue._id, {
+        title,
+        body,
+      });
+      if (appointment.calendarSyncIssueId !== openIssue._id) {
+        await ctx.db.patch(appointment._id, {
+          calendarSyncIssueId: openIssue._id,
+        });
+      }
+      return { issueId: openIssue._id, created: false };
+    }
+
+    const issueId = await ctx.db.insert("inbox_items", {
+      businessId: appointment.businessId,
+      kind: "calendar_sync_issue",
+      title,
+      body,
+      relatedId: String(args.appointmentId),
+      status: "open",
+    });
+
+    await ctx.db.patch(appointment._id, {
+      calendarSyncIssueId: issueId,
+    });
+    await ctx.db.insert("audit_logs", {
+      businessId: appointment.businessId,
+      eventType: "calendar_sync_issue_opened",
+      entityType: "appointment",
+      entityId: String(appointment._id),
+      payload: JSON.stringify({ issueId: String(issueId) }),
+    });
+
+    return { issueId, created: true };
+  },
+});
+
+export const resolveCalendarSyncIssue = internalMutation({
+  args: {
+    appointmentId: v.id("appointments"),
+  },
+  handler: async (ctx, args) => {
+    const appointment = await ctx.db.get(args.appointmentId);
+    if (!appointment) {
+      throw new Error("Appointment not found.");
+    }
+
+    const existingIssues = await ctx.db
+      .query("inbox_items")
+      .withIndex("by_kind_and_related_id", (q) =>
+        q.eq("kind", "calendar_sync_issue").eq("relatedId", String(args.appointmentId)),
+      )
+      .collect();
+    const openIssue = existingIssues.find((item) => item.status === "open") ?? null;
+    if (!openIssue) {
+      return { resolved: false };
+    }
+
+    await ctx.db.patch(openIssue._id, {
+      status: "resolved",
+    });
+    await ctx.db.insert("audit_logs", {
+      businessId: appointment.businessId,
+      eventType: "calendar_sync_issue_resolved",
+      entityType: "appointment",
+      entityId: String(appointment._id),
+      payload: JSON.stringify({ issueId: String(openIssue._id) }),
+    });
+
+    return { resolved: true, issueId: openIssue._id };
   },
 });
 
@@ -103,11 +509,138 @@ export const syncAppointmentToExternalCalendars = internalAction({
     appointmentId: v.id("appointments"),
   },
   handler: async (ctx, args) => {
-    await ctx.runMutation(internal.integrations.calendar.markAppointmentSyncState, {
-      appointmentId: args.appointmentId,
-      calendarSyncState: "synced_mock",
-    });
-    return { ok: true };
+    const context = await ctx.runQuery(
+      internal.integrations.calendar.getAppointmentCalendarSyncContext,
+      {
+        appointmentId: args.appointmentId,
+      },
+    );
+    if (!context) {
+      throw new Error("Appointment not found.");
+    }
+
+    const nowIso = new Date().toISOString();
+    const previousState = normalizeCalendarSyncState(
+      context.appointment.calendarSyncState,
+    );
+
+    if (context.appointment.status !== "confirmed") {
+      await ctx.runMutation(
+        internal.integrations.calendar.setAppointmentCalendarSyncState,
+        {
+          appointmentId: args.appointmentId,
+          calendarSyncState: "not_required",
+        },
+      );
+      return { ok: true, status: "not_required" as const };
+    }
+
+    if (!context.hasConnectedCalendar) {
+      await ctx.runMutation(
+        internal.integrations.calendar.setAppointmentCalendarSyncState,
+        {
+          appointmentId: args.appointmentId,
+          calendarSyncState: "not_required",
+        },
+      );
+      await ctx.runMutation(
+        internal.integrations.calendar.resolveCalendarSyncIssue,
+        {
+          appointmentId: args.appointmentId,
+        },
+      );
+      return { ok: true, status: "not_required" as const };
+    }
+
+    await ctx.runMutation(
+      internal.integrations.calendar.setAppointmentCalendarSyncState,
+      {
+        appointmentId: args.appointmentId,
+        calendarSyncState: "syncing",
+        calendarLastSyncAttemptAt: nowIso,
+      },
+    );
+
+    try {
+      if (!context.selectedConnectionId || !context.selectedCalendarId) {
+        throw new Error("Connected calendar is missing a selected calendar.");
+      }
+
+      const externalEventId = buildMockExternalEventId(
+        context.selectedConnectionId,
+        context.appointment._id,
+      );
+      await ctx.runMutation(
+        internal.integrations.calendar.setAppointmentCalendarSyncState,
+        {
+          appointmentId: args.appointmentId,
+          calendarSyncState: "synced",
+          calendarLastSyncAttemptAt: nowIso,
+          calendarLastSyncedAt: nowIso,
+          calendarExternalEventId: externalEventId,
+        },
+      );
+      await ctx.runMutation(
+        internal.integrations.calendar.resolveCalendarSyncIssue,
+        {
+          appointmentId: args.appointmentId,
+        },
+      );
+      await ctx.runMutation(
+        internal.integrations.calendar.recordCalendarAuditLog,
+        {
+          businessId: context.appointment.businessId,
+          eventType:
+            previousState === "failed" || previousState === "drifted"
+              ? "appointment_calendar_sync_recovered"
+              : "appointment_calendar_synced",
+          entityId: String(context.appointment._id),
+          payload: JSON.stringify({ externalEventId }),
+        },
+      );
+
+      return {
+        ok: true,
+        status: "synced" as const,
+        externalEventId,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Calendar sync failed.";
+      await ctx.runMutation(
+        internal.integrations.calendar.setAppointmentCalendarSyncState,
+        {
+          appointmentId: args.appointmentId,
+          calendarSyncState: "failed",
+          calendarLastSyncAttemptAt: nowIso,
+          calendarLastSyncError: message,
+          calendarReconcileAfter: getRetryTime(nowIso),
+        },
+      );
+      await ctx.runMutation(
+        internal.integrations.calendar.recordCalendarAuditLog,
+        {
+          businessId: context.appointment.businessId,
+          eventType: "appointment_calendar_sync_failed",
+          entityId: String(context.appointment._id),
+          payload: JSON.stringify({ error: message }),
+        },
+      );
+
+      if (previousState === "failed" || previousState === "drifted") {
+        await ctx.runMutation(
+          internal.integrations.calendar.upsertCalendarSyncIssue,
+          {
+            appointmentId: args.appointmentId,
+          },
+        );
+      }
+
+      return {
+        ok: false,
+        status: "failed" as const,
+        error: message,
+      };
+    }
   },
 });
 
@@ -115,8 +648,351 @@ export const runBusinessCalendarReconciliation = internalAction({
   args: {
     businessId: v.id("businesses"),
   },
-  handler: async (_ctx, args) => {
-    return { businessId: args.businessId, status: "queued_mock" };
+  handler: async (ctx, args): Promise<CalendarReconciliationResult> => {
+    const nowIso = new Date().toISOString();
+    const nowMs = Date.parse(nowIso);
+    const [calendarState, appointments]: [
+      CalendarConnectionState,
+      Array<Doc<"appointments">>,
+    ] = await Promise.all([
+      ctx.runQuery(internal.integrations.calendar.getBusinessCalendarConnectionState, {
+        businessId: args.businessId,
+      }),
+      ctx.runQuery(internal.integrations.calendar.listAppointmentsForCalendarReconciliation, {
+        businessId: args.businessId,
+      }),
+    ]);
+
+    let retried = 0;
+    let failed = 0;
+    let drifted = 0;
+    let recovered = 0;
+    let issuesOpened = 0;
+
+    for (const appointment of appointments) {
+      const state = normalizeCalendarSyncState(appointment.calendarSyncState);
+
+      if (
+        state === "not_required" &&
+        appointment.status === "confirmed" &&
+        calendarState.hasConnectedCalendar
+      ) {
+        await ctx.runMutation(
+          internal.integrations.calendar.setAppointmentCalendarSyncState,
+          {
+            appointmentId: appointment._id,
+            calendarSyncState: "drifted",
+            calendarLastSyncError:
+              "Connected calendar exists but the appointment was never queued for sync.",
+          },
+        );
+        await ctx.runMutation(
+          internal.integrations.calendar.upsertCalendarSyncIssue,
+          {
+            appointmentId: appointment._id,
+          },
+        );
+        await ctx.runMutation(
+          internal.integrations.calendar.recordCalendarAuditLog,
+          {
+            businessId: appointment.businessId,
+            eventType: "appointment_calendar_drift_detected",
+            entityId: String(appointment._id),
+            payload: JSON.stringify({
+              reason: "connected_calendar_with_not_required_state",
+            }),
+          },
+        );
+        drifted += 1;
+        issuesOpened += 1;
+        continue;
+      }
+
+      if (
+        state === "synced" &&
+        appointment.calendarSyncState !== "synced_mock" &&
+        !appointment.calendarExternalEventId
+      ) {
+        await ctx.runMutation(
+          internal.integrations.calendar.setAppointmentCalendarSyncState,
+          {
+            appointmentId: appointment._id,
+            calendarSyncState: "drifted",
+            calendarLastSyncError:
+              "Appointment is marked synced but has no external calendar event ID.",
+          },
+        );
+        await ctx.runMutation(
+          internal.integrations.calendar.upsertCalendarSyncIssue,
+          {
+            appointmentId: appointment._id,
+          },
+        );
+        await ctx.runMutation(
+          internal.integrations.calendar.recordCalendarAuditLog,
+          {
+            businessId: appointment.businessId,
+            eventType: "appointment_calendar_drift_detected",
+            entityId: String(appointment._id),
+            payload: JSON.stringify({ reason: "missing_external_event_id" }),
+          },
+        );
+        drifted += 1;
+        issuesOpened += 1;
+        continue;
+      }
+
+      if (
+        state === "pending" &&
+        isStale(
+          appointment.calendarLastSyncAttemptAt ?? new Date(appointment._creationTime).toISOString(),
+          nowMs,
+          CALENDAR_SYNC_PENDING_TIMEOUT_MS,
+        )
+      ) {
+        const error = "Calendar sync remained pending past the timeout window.";
+        await ctx.runMutation(
+          internal.integrations.calendar.setAppointmentCalendarSyncState,
+          {
+            appointmentId: appointment._id,
+            calendarSyncState: "failed",
+            calendarLastSyncError: error,
+            calendarReconcileAfter: getRetryTime(nowIso),
+          },
+        );
+        await ctx.runMutation(
+          internal.integrations.calendar.recordCalendarAuditLog,
+          {
+            businessId: appointment.businessId,
+            eventType: "appointment_calendar_sync_failed",
+            entityId: String(appointment._id),
+            payload: JSON.stringify({ error }),
+          },
+        );
+        failed += 1;
+        continue;
+      }
+
+      if (
+        state === "syncing" &&
+        isStale(
+          appointment.calendarLastSyncAttemptAt ?? new Date(appointment._creationTime).toISOString(),
+          nowMs,
+          CALENDAR_SYNC_SYNCING_TIMEOUT_MS,
+        )
+      ) {
+        const error = "Calendar sync was stuck in progress past the timeout window.";
+        await ctx.runMutation(
+          internal.integrations.calendar.setAppointmentCalendarSyncState,
+          {
+            appointmentId: appointment._id,
+            calendarSyncState: "failed",
+            calendarLastSyncError: error,
+            calendarReconcileAfter: getRetryTime(nowIso),
+          },
+        );
+        await ctx.runMutation(
+          internal.integrations.calendar.recordCalendarAuditLog,
+          {
+            businessId: appointment.businessId,
+            eventType: "appointment_calendar_sync_failed",
+            entityId: String(appointment._id),
+            payload: JSON.stringify({ error }),
+          },
+        );
+        failed += 1;
+        continue;
+      }
+
+      if (state === "drifted") {
+        const result = await ctx.runMutation(
+          internal.integrations.calendar.upsertCalendarSyncIssue,
+          {
+            appointmentId: appointment._id,
+          },
+        );
+        if (result.created) {
+          issuesOpened += 1;
+        }
+        continue;
+      }
+
+      if (
+        state === "failed" &&
+        !appointment.calendarSyncIssueId &&
+        isPastDue(appointment.calendarReconcileAfter, nowMs)
+      ) {
+        retried += 1;
+        const result = await ctx.runAction(
+          internal.integrations.calendar.syncAppointmentToExternalCalendars,
+          {
+            appointmentId: appointment._id,
+          },
+        );
+        if (result.ok) {
+          recovered += 1;
+        }
+      }
+    }
+
+    return {
+      businessId: args.businessId,
+      processed: appointments.length,
+      retried,
+      failed,
+      drifted,
+      recovered,
+      issuesOpened,
+    };
+  },
+});
+
+export const getCalendarReconciliationSummary = query({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  handler: async (ctx, args): Promise<CalendarReconciliationSummary> => {
+    await requireMembership(ctx, args.businessId);
+    const [appointments, openIssues]: [Array<Doc<"appointments">>, Array<Doc<"inbox_items">>] =
+      await Promise.all([
+      ctx.runQuery(internal.integrations.calendar.listAppointmentsForCalendarReconciliation, {
+        businessId: args.businessId,
+      }),
+      ctx.db
+        .query("inbox_items")
+        .withIndex("by_business_id_and_kind_and_status", (q) =>
+          q.eq("businessId", args.businessId)
+            .eq("kind", "calendar_sync_issue")
+            .eq("status", "open"),
+        )
+        .collect(),
+      ]);
+
+    const counts: Record<NormalizedCalendarSyncState, number> = {
+      not_required: 0,
+      pending: 0,
+      syncing: 0,
+      synced: 0,
+      failed: 0,
+      drifted: 0,
+    };
+
+    for (const appointment of appointments) {
+      counts[normalizeCalendarSyncState(appointment.calendarSyncState)] += 1;
+    }
+
+    return {
+      businessId: args.businessId,
+      counts,
+      openIssueCount: openIssues.length,
+    };
+  },
+});
+
+export const listCalendarReconciliationIssues = query({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  handler: async (ctx, args) => {
+    await requireMembership(ctx, args.businessId);
+    const issues = await ctx.db
+      .query("inbox_items")
+      .withIndex("by_business_id_and_kind_and_status", (q) =>
+        q.eq("businessId", args.businessId)
+          .eq("kind", "calendar_sync_issue")
+          .eq("status", "open"),
+      )
+      .collect();
+
+    const hydrated = await Promise.all(
+      issues.map(async (issue) => {
+        const appointmentId = issue.relatedId as Id<"appointments"> | undefined;
+        const appointment = appointmentId
+          ? await ctx.db.get(appointmentId)
+          : null;
+        const [service, contact] = appointment
+          ? await Promise.all([
+              ctx.db.get(appointment.serviceId),
+              ctx.db.get(appointment.contactId),
+            ])
+          : [null, null];
+
+        return {
+          issueId: issue._id,
+          title: issue.title,
+          body: issue.body,
+          status: issue.status,
+          appointmentId: appointment?._id,
+          startsAt: appointment?.startsAt,
+          serviceName: service?.name,
+          contactName: contact?.name,
+          contactPhone: contact?.phone,
+          syncState: appointment
+            ? normalizeCalendarSyncState(appointment.calendarSyncState)
+            : null,
+          lastSyncError:
+            appointment &&
+            normalizeCalendarSyncState(appointment.calendarSyncState) !== "synced"
+              ? appointment.calendarLastSyncError ?? null
+              : null,
+        };
+      }),
+    );
+
+    return hydrated;
+  },
+});
+
+export const listAppointmentsNeedingCalendarAttention = query({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  handler: async (ctx, args) => {
+    await requireMembership(ctx, args.businessId);
+    const unhealthyStates: Array<NormalizedCalendarSyncState> = [
+      "pending",
+      "syncing",
+      "failed",
+      "drifted",
+    ];
+    const appointmentsById = new Map<Id<"appointments">, Doc<"appointments">>();
+
+    for (const state of unhealthyStates) {
+      const appointments = await ctx.db
+        .query("appointments")
+        .withIndex("by_business_id_and_calendar_sync_state_and_starts_at", (q) =>
+          q.eq("businessId", args.businessId).eq("calendarSyncState", state),
+        )
+        .collect();
+      for (const appointment of appointments) {
+        appointmentsById.set(appointment._id, appointment);
+      }
+    }
+
+    const hydrated = await Promise.all(
+      [...appointmentsById.values()].map(async (appointment) => {
+        const [service, contact] = await Promise.all([
+          ctx.db.get(appointment.serviceId),
+          ctx.db.get(appointment.contactId),
+        ]);
+
+        return {
+          appointmentId: appointment._id,
+          startsAt: appointment.startsAt,
+          status: appointment.status,
+          syncState: normalizeCalendarSyncState(appointment.calendarSyncState),
+          lastSyncAttemptAt: appointment.calendarLastSyncAttemptAt ?? null,
+          lastSyncedAt: appointment.calendarLastSyncedAt ?? null,
+          lastSyncError: appointment.calendarLastSyncError ?? null,
+          reconcileAfter: appointment.calendarReconcileAfter ?? null,
+          serviceName: service?.name ?? null,
+          contactName: contact?.name ?? null,
+          contactPhone: contact?.phone ?? null,
+        };
+      }),
+    );
+
+    return hydrated.sort((left, right) => left.startsAt.localeCompare(right.startsAt));
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -321,9 +321,28 @@ export default defineSchema({
     timezone: v.string(),
     status: v.string(),
     sourceChannel: v.string(),
-    calendarSyncState: v.string(),
+    calendarSyncState: v.union(
+      v.literal("not_required"),
+      v.literal("pending"),
+      v.literal("syncing"),
+      v.literal("synced"),
+      v.literal("failed"),
+      v.literal("drifted"),
+      v.literal("synced_mock"),
+    ),
+    calendarLastSyncAttemptAt: v.optional(v.string()),
+    calendarLastSyncedAt: v.optional(v.string()),
+    calendarLastSyncError: v.optional(v.string()),
+    calendarReconcileAfter: v.optional(v.string()),
+    calendarSyncIssueId: v.optional(v.id("inbox_items")),
+    calendarExternalEventId: v.optional(v.string()),
   })
     .index("by_business_id_and_starts_at", ["businessId", "startsAt"])
+    .index("by_business_id_and_calendar_sync_state_and_starts_at", [
+      "businessId",
+      "calendarSyncState",
+      "startsAt",
+    ])
     .index("by_staff_id_and_starts_at", ["staffId", "startsAt"])
     .index("by_contact_id_and_starts_at", ["contactId", "startsAt"]),
 
@@ -339,6 +358,7 @@ export default defineSchema({
     syncCursor: v.optional(v.string()),
   })
     .index("by_business_id_and_provider", ["businessId", "provider"])
+    .index("by_business_id_and_status", ["businessId", "status"])
     .index("by_owner_user_id_and_provider", ["ownerUserId", "provider"])
     .index("by_provider_and_external_account_id", ["provider", "externalAccountId"]),
 
@@ -380,6 +400,8 @@ export default defineSchema({
     status: v.string(),
   })
     .index("by_business_id_and_status", ["businessId", "status"])
+    .index("by_business_id_and_kind_and_status", ["businessId", "kind", "status"])
+    .index("by_kind_and_related_id", ["kind", "relatedId"])
     .index("by_related_id", ["relatedId"]),
 
   audit_logs: defineTable({

--- a/packages/testing/src/calendarReconciliation.test.ts
+++ b/packages/testing/src/calendarReconciliation.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, internal } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
+import { CALENDAR_RECONCILIATION_INTERVAL_MS } from "../../../convex/integrations/calendar";
 import schema from "../../../convex/schema";
 
 declare global {
@@ -11,8 +12,10 @@ declare global {
   }
 }
 
-const { workflowStartMock } = vi.hoisted(() => ({
+const { workflowStartMock, runtimeCronsGetMock, runtimeCronsRegisterMock } = vi.hoisted(() => ({
   workflowStartMock: vi.fn(),
+  runtimeCronsGetMock: vi.fn(),
+  runtimeCronsRegisterMock: vi.fn(),
 }));
 
 vi.mock("../../../convex/lib/components", async () => {
@@ -25,6 +28,10 @@ vi.mock("../../../convex/lib/components", async () => {
     workflowManager: {
       define: actual.workflowManager.define.bind(actual.workflowManager),
       start: workflowStartMock,
+    },
+    runtimeCrons: {
+      get: runtimeCronsGetMock,
+      register: runtimeCronsRegisterMock,
     },
   };
 });
@@ -138,6 +145,8 @@ async function bookAppointment(
 beforeEach(() => {
   vi.clearAllMocks();
   workflowStartMock.mockResolvedValue(null);
+  runtimeCronsGetMock.mockResolvedValue(null);
+  runtimeCronsRegisterMock.mockResolvedValue(null);
 });
 
 describe("calendar reconciliation backend", () => {
@@ -393,6 +402,7 @@ describe("calendar reconciliation backend", () => {
         sourceChannel: "dashboard",
         calendarSyncState: "drifted",
         calendarLastSyncError: "Drifted record",
+        calendarReconcileAfter: "2099-03-18T09:00:00.000Z",
       });
     });
 
@@ -420,7 +430,7 @@ describe("calendar reconciliation backend", () => {
     });
   });
 
-  it("resolves the calendar sync issue once a failed appointment recovers", async () => {
+  it("automatically retries failed appointments after an issue exists and resolves the issue on recovery", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId, serviceId } = await t.run(async (ctx) => {
       const seeded = await seedBookableBusiness(ctx, {
@@ -447,6 +457,18 @@ describe("calendar reconciliation backend", () => {
       },
     );
 
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("failed");
+      const issues = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(appointmentId)),
+        )
+        .collect();
+      expect(issues.filter((issue) => issue.status === "open")).toHaveLength(1);
+    });
+
     const connectionId = await t.run(async (ctx) => {
       const connection = await ctx.db
         .query("calendar_connections")
@@ -460,19 +482,22 @@ describe("calendar reconciliation backend", () => {
       await ctx.db.patch(connection._id, {
         selectedCalendarId: "primary-calendar",
       });
+      await ctx.db.patch(appointmentId, {
+        calendarReconcileAfter: "2026-03-11T00:00:00.000Z",
+      });
       return connection._id;
     });
     expect(connectionId).toBeDefined();
 
     const result = await t.action(
-      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
       {
-        appointmentId,
+        businessId,
       },
     );
     expect(result).toMatchObject({
-      ok: true,
-      status: "synced",
+      retried: 1,
+      recovered: 1,
     });
 
     await t.run(async (ctx) => {
@@ -486,6 +511,163 @@ describe("calendar reconciliation backend", () => {
         .collect();
       expect(issues.some((issue) => issue.status === "resolved")).toBe(true);
     });
+  });
+
+  it("keeps retrying failed appointments with open issues without duplicating the issue", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "retry-open-issue-business",
+        name: "Retry Open Issue Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+      });
+      return seeded;
+    });
+
+    const appointmentId = await bookAppointment(t, { businessId, serviceId });
+    await t.action(internal.integrations.calendar.syncAppointmentToExternalCalendars, {
+      appointmentId,
+    });
+    await t.action(internal.integrations.calendar.syncAppointmentToExternalCalendars, {
+      appointmentId,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(appointmentId, {
+        calendarReconcileAfter: "2026-03-01T00:00:00.000Z",
+      });
+    });
+
+    const result = await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+
+    expect(result).toMatchObject({
+      retried: 1,
+      recovered: 0,
+    });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("failed");
+      expect(appointment?.calendarReconcileAfter).toBeTruthy();
+      expect(appointment?.calendarReconcileAfter).not.toBe("2026-03-01T00:00:00.000Z");
+
+      const issues = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(appointmentId)),
+        )
+        .collect();
+      expect(issues.filter((issue) => issue.status === "open")).toHaveLength(1);
+    });
+  });
+
+  it("retries drifted appointments automatically once they are due and resolves the issue on recovery", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId, staffId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "drift-recovery-business",
+        name: "Drift Recovery Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+        selectedCalendarId: "calendar-a",
+      });
+      return seeded;
+    });
+
+    const appointmentId = await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550299",
+      });
+      return await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-03-18T11:00:00.000-04:00",
+        endsAt: "2026-03-18T11:30:00.000-04:00",
+        timezone: "America/Toronto",
+        status: "confirmed",
+        sourceChannel: "dashboard",
+        calendarSyncState: "synced",
+      });
+    });
+
+    await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("drifted");
+      expect(appointment?.calendarReconcileAfter).toBeTruthy();
+      await ctx.db.patch(appointmentId, {
+        calendarReconcileAfter: "2026-03-01T00:00:00.000Z",
+      });
+    });
+
+    const result = await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+
+    expect(result).toMatchObject({
+      retried: 1,
+      recovered: 1,
+    });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("synced");
+      expect(appointment?.calendarExternalEventId).toContain(String(appointmentId));
+      const issues = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(appointmentId)),
+        )
+        .collect();
+      expect(issues.some((issue) => issue.status === "resolved")).toBe(true);
+    });
+  });
+
+  it("registers the business reconciliation cron every five minutes", async () => {
+    const t = convexTest(schema, convexModules);
+    const businessId = await t.run(async (ctx) => {
+      return await insertBusiness(ctx, {
+        slug: "cron-registration-business",
+        name: "Cron Registration Business",
+      });
+    });
+
+    const cronName = await t.mutation(
+      internal.ai.workflows.runtime.registerCalendarReconciliationCron,
+      {
+        businessId,
+      },
+    );
+
+    expect(cronName).toBe(`calendar-reconcile-${String(businessId)}`);
+    expect(runtimeCronsGetMock).toHaveBeenCalled();
+    expect(runtimeCronsRegisterMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { kind: "interval", ms: CALENDAR_RECONCILIATION_INTERVAL_MS },
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      { businessId },
+      `calendar-reconcile-${String(businessId)}`,
+    );
   });
 
   it("scopes reconciliation queries to the requesting member's business", async () => {

--- a/packages/testing/src/calendarReconciliation.test.ts
+++ b/packages/testing/src/calendarReconciliation.test.ts
@@ -1,0 +1,641 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api, internal } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import schema from "../../../convex/schema";
+
+declare global {
+  interface ImportMeta {
+    glob(pattern: string): Record<string, () => Promise<unknown>>;
+  }
+}
+
+const { workflowStartMock } = vi.hoisted(() => ({
+  workflowStartMock: vi.fn(),
+}));
+
+vi.mock("../../../convex/lib/components", async () => {
+  const actual = await vi.importActual<typeof import("../../../convex/lib/components")>(
+    "../../../convex/lib/components",
+  );
+
+  return {
+    ...actual,
+    workflowManager: {
+      define: actual.workflowManager.define.bind(actual.workflowManager),
+      start: workflowStartMock,
+    },
+  };
+});
+
+type TestRunFunction = Parameters<TestConvex<typeof schema>["run"]>[0];
+type TestContext = Parameters<TestRunFunction>[0];
+
+const convexModules = import.meta.glob("../../../convex/**/*.ts");
+
+async function insertBusiness(
+  ctx: TestContext,
+  input: { slug: string; name: string },
+): Promise<Id<"businesses">> {
+  return await ctx.db.insert("businesses", {
+    slug: input.slug,
+    name: input.name,
+    timezone: "America/Toronto",
+    businessType: "clinic",
+    deploymentMode: "manual",
+    status: "active",
+  });
+}
+
+async function seedBookableBusiness(
+  ctx: TestContext,
+  input: { slug: string; name: string },
+): Promise<{
+  businessId: Id<"businesses">;
+  serviceId: Id<"services">;
+  staffId: Id<"staff">;
+}> {
+  const businessId = await insertBusiness(ctx, input);
+
+  for (let dayOfWeek = 1; dayOfWeek <= 5; dayOfWeek += 1) {
+    await ctx.db.insert("business_hours", {
+      businessId,
+      dayOfWeek,
+      openMinutes: 9 * 60,
+      closeMinutes: 17 * 60,
+    });
+  }
+
+  const staffId = await ctx.db.insert("staff", {
+    businessId,
+    name: `${input.name} Staff`,
+    timezone: "America/Toronto",
+    active: true,
+  });
+  const serviceId = await ctx.db.insert("services", {
+    businessId,
+    name: "Initial Consultation",
+    slug: "initial-consultation",
+    durationMinutes: 30,
+    active: true,
+  });
+  await ctx.db.insert("staff_service_assignments", {
+    businessId,
+    staffId,
+    serviceId,
+  });
+
+  return { businessId, serviceId, staffId };
+}
+
+async function insertConnectedCalendar(
+  ctx: TestContext,
+  input: {
+    businessId: Id<"businesses">;
+    selectedCalendarId?: string;
+  },
+): Promise<Id<"calendar_connections">> {
+  const userId = await ctx.db.insert("users", {
+    authSubject: `calendar-owner:${String(input.businessId)}`,
+  });
+  return await ctx.db.insert("calendar_connections", {
+    businessId: input.businessId,
+    provider: "google",
+    ownerUserId: userId,
+    externalAccountId: `acct-${String(input.businessId)}`,
+    ...(input.selectedCalendarId !== undefined
+      ? { selectedCalendarId: input.selectedCalendarId }
+      : {}),
+    status: "connected",
+  });
+}
+
+async function bookAppointment(
+  t: TestConvex<typeof schema>,
+  input: {
+    businessId: Id<"businesses">;
+    serviceId: Id<"services">;
+    startsAt?: string;
+    contactPhone?: string;
+  },
+): Promise<Id<"appointments">> {
+  const result = await t.mutation(
+    internal.appointments.booking.bookAppointmentForBusiness,
+    {
+      businessId: input.businessId,
+      serviceId: input.serviceId,
+      startsAt: input.startsAt ?? "2026-03-17T14:00:00.000-04:00",
+      timezone: "America/Toronto",
+      contactPhone: input.contactPhone ?? "+14165550199",
+      sourceChannel: "sms",
+    },
+  );
+
+  return result.appointmentId;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  workflowStartMock.mockResolvedValue(null);
+});
+
+describe("calendar reconciliation backend", () => {
+  it("marks bookings without a connected calendar as not_required", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId } = await t.run(async (ctx) => {
+      return await seedBookableBusiness(ctx, {
+        slug: "no-calendar-business",
+        name: "No Calendar Business",
+      });
+    });
+
+    const appointmentId = await bookAppointment(t, { businessId, serviceId });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("not_required");
+    });
+  });
+
+  it("starts connected-calendar bookings in pending and syncs them to synced", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "connected-calendar-business",
+        name: "Connected Calendar Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+        selectedCalendarId: "primary-calendar",
+      });
+      return seeded;
+    });
+
+    const appointmentId = await bookAppointment(t, { businessId, serviceId });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("pending");
+    });
+
+    const result = await t.action(
+      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      {
+        appointmentId,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "synced",
+    });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment).toMatchObject({
+        calendarSyncState: "synced",
+      });
+      expect(appointment?.calendarExternalEventId).toContain(String(appointmentId));
+      expect(appointment?.calendarLastSyncedAt).toBeTruthy();
+    });
+  });
+
+  it("records sync failures and schedules reconciliation", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "failing-calendar-business",
+        name: "Failing Calendar Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+      });
+      return seeded;
+    });
+
+    const appointmentId = await bookAppointment(t, { businessId, serviceId });
+    const result = await t.action(
+      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      {
+        appointmentId,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "failed",
+    });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("failed");
+      expect(appointment?.calendarLastSyncError).toContain("selected calendar");
+      expect(appointment?.calendarReconcileAfter).toBeTruthy();
+    });
+  });
+
+  it("converts stale pending and syncing appointments into failure states", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId, staffId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "stale-calendar-business",
+        name: "Stale Calendar Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+        selectedCalendarId: "calendar-a",
+      });
+      return seeded;
+    });
+
+    const stalePendingId = await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550201",
+      });
+      return await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-03-17T14:00:00.000-04:00",
+        endsAt: "2026-03-17T14:30:00.000-04:00",
+        timezone: "America/Toronto",
+        status: "confirmed",
+        sourceChannel: "dashboard",
+        calendarSyncState: "pending",
+        calendarLastSyncAttemptAt: "2026-03-11T10:00:00.000Z",
+      });
+    });
+    const staleSyncingId = await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550202",
+      });
+      return await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-03-17T15:00:00.000-04:00",
+        endsAt: "2026-03-17T15:30:00.000-04:00",
+        timezone: "America/Toronto",
+        status: "confirmed",
+        sourceChannel: "dashboard",
+        calendarSyncState: "syncing",
+        calendarLastSyncAttemptAt: "2026-03-11T10:00:00.000Z",
+      });
+    });
+
+    await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+
+    await t.run(async (ctx) => {
+      const pendingAppointment = await ctx.db.get(stalePendingId);
+      const syncingAppointment = await ctx.db.get(staleSyncingId);
+
+      expect(pendingAppointment?.calendarSyncState).toBe("failed");
+      expect(pendingAppointment?.calendarLastSyncError).toContain("pending");
+      expect(pendingAppointment?.calendarReconcileAfter).toBeTruthy();
+
+      expect(syncingAppointment?.calendarSyncState).toBe("failed");
+      expect(syncingAppointment?.calendarLastSyncError).toContain("stuck");
+      expect(syncingAppointment?.calendarReconcileAfter).toBeTruthy();
+    });
+  });
+
+  it("marks synced appointments without external event IDs as drifted", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId, staffId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "drift-calendar-business",
+        name: "Drift Calendar Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+        selectedCalendarId: "calendar-a",
+      });
+      return seeded;
+    });
+
+    const appointmentId = await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550203",
+      });
+      return await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-03-17T16:00:00.000-04:00",
+        endsAt: "2026-03-17T16:30:00.000-04:00",
+        timezone: "America/Toronto",
+        status: "confirmed",
+        sourceChannel: "dashboard",
+        calendarSyncState: "synced",
+      });
+    });
+
+    await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("drifted");
+      const issues = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(appointmentId)),
+        )
+        .collect();
+      expect(issues.filter((issue) => issue.status === "open")).toHaveLength(1);
+    });
+  });
+
+  it("dedupes calendar sync issues across repeated reconciliation runs", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId, staffId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "issue-dedupe-business",
+        name: "Issue Dedupe Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+        selectedCalendarId: "calendar-a",
+      });
+      return seeded;
+    });
+
+    const appointmentId = await t.run(async (ctx) => {
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        phone: "+14165550204",
+      });
+      return await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-03-18T09:00:00.000-04:00",
+        endsAt: "2026-03-18T09:30:00.000-04:00",
+        timezone: "America/Toronto",
+        status: "confirmed",
+        sourceChannel: "dashboard",
+        calendarSyncState: "drifted",
+        calendarLastSyncError: "Drifted record",
+      });
+    });
+
+    await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+    await t.action(
+      internal.integrations.calendar.runBusinessCalendarReconciliation,
+      {
+        businessId,
+      },
+    );
+
+    await t.run(async (ctx) => {
+      const issues = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(appointmentId)),
+        )
+        .collect();
+      expect(issues.filter((issue) => issue.status === "open")).toHaveLength(1);
+    });
+  });
+
+  it("resolves the calendar sync issue once a failed appointment recovers", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId } = await t.run(async (ctx) => {
+      const seeded = await seedBookableBusiness(ctx, {
+        slug: "recover-calendar-business",
+        name: "Recover Calendar Business",
+      });
+      await insertConnectedCalendar(ctx, {
+        businessId: seeded.businessId,
+      });
+      return seeded;
+    });
+
+    const appointmentId = await bookAppointment(t, { businessId, serviceId });
+    await t.action(
+      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      {
+        appointmentId,
+      },
+    );
+    await t.action(
+      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      {
+        appointmentId,
+      },
+    );
+
+    const connectionId = await t.run(async (ctx) => {
+      const connection = await ctx.db
+        .query("calendar_connections")
+        .withIndex("by_business_id_and_status", (q) =>
+          q.eq("businessId", businessId).eq("status", "connected"),
+        )
+        .unique();
+      if (!connection) {
+        throw new Error("Expected a connected calendar connection.");
+      }
+      await ctx.db.patch(connection._id, {
+        selectedCalendarId: "primary-calendar",
+      });
+      return connection._id;
+    });
+    expect(connectionId).toBeDefined();
+
+    const result = await t.action(
+      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      {
+        appointmentId,
+      },
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      status: "synced",
+    });
+
+    await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      expect(appointment?.calendarSyncState).toBe("synced");
+      const issues = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_kind_and_related_id", (q) =>
+          q.eq("kind", "calendar_sync_issue").eq("relatedId", String(appointmentId)),
+        )
+        .collect();
+      expect(issues.some((issue) => issue.status === "resolved")).toBe(true);
+    });
+  });
+
+  it("scopes reconciliation queries to the requesting member's business", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessAId, businessBId } = await t.run(async (ctx) => {
+      const businessAId = await insertBusiness(ctx, {
+        slug: "member-business-a",
+        name: "Member Business A",
+      });
+      const businessBId = await insertBusiness(ctx, {
+        slug: "member-business-b",
+        name: "Member Business B",
+      });
+      const userId = await ctx.db.insert("users", {
+        authSubject: "member-a",
+      });
+      await ctx.db.insert("business_memberships", {
+        businessId: businessAId,
+        userId,
+        role: "owner",
+        status: "active",
+      });
+
+      const [staffA, staffB] = await Promise.all([
+        ctx.db.insert("staff", {
+          businessId: businessAId,
+          name: "A Staff",
+          timezone: "America/Toronto",
+          active: true,
+        }),
+        ctx.db.insert("staff", {
+          businessId: businessBId,
+          name: "B Staff",
+          timezone: "America/Toronto",
+          active: true,
+        }),
+      ]);
+      const [serviceA, serviceB] = await Promise.all([
+        ctx.db.insert("services", {
+          businessId: businessAId,
+          name: "A Service",
+          slug: "a-service",
+          durationMinutes: 30,
+          active: true,
+        }),
+        ctx.db.insert("services", {
+          businessId: businessBId,
+          name: "B Service",
+          slug: "b-service",
+          durationMinutes: 30,
+          active: true,
+        }),
+      ]);
+      const [contactA, contactB] = await Promise.all([
+        ctx.db.insert("contacts", {
+          businessId: businessAId,
+          phone: "+14165550301",
+          name: "Alice",
+        }),
+        ctx.db.insert("contacts", {
+          businessId: businessBId,
+          phone: "+14165550302",
+          name: "Bob",
+        }),
+      ]);
+      const [appointmentAId, appointmentBId] = await Promise.all([
+        ctx.db.insert("appointments", {
+          businessId: businessAId,
+          contactId: contactA,
+          staffId: staffA,
+          serviceId: serviceA,
+          startsAt: "2026-03-20T09:00:00.000-04:00",
+          endsAt: "2026-03-20T09:30:00.000-04:00",
+          timezone: "America/Toronto",
+          status: "confirmed",
+          sourceChannel: "dashboard",
+          calendarSyncState: "failed",
+          calendarLastSyncError: "A failed sync",
+          calendarReconcileAfter: "2026-03-20T08:00:00.000Z",
+        }),
+        ctx.db.insert("appointments", {
+          businessId: businessBId,
+          contactId: contactB,
+          staffId: staffB,
+          serviceId: serviceB,
+          startsAt: "2026-03-21T09:00:00.000-04:00",
+          endsAt: "2026-03-21T09:30:00.000-04:00",
+          timezone: "America/Toronto",
+          status: "confirmed",
+          sourceChannel: "dashboard",
+          calendarSyncState: "drifted",
+          calendarLastSyncError: "B drifted sync",
+        }),
+      ]);
+
+      await ctx.db.insert("inbox_items", {
+        businessId: businessAId,
+        kind: "calendar_sync_issue",
+        title: "Business A issue",
+        body: "A",
+        relatedId: String(appointmentAId),
+        status: "open",
+      });
+      await ctx.db.insert("inbox_items", {
+        businessId: businessBId,
+        kind: "calendar_sync_issue",
+        title: "Business B issue",
+        body: "B",
+        relatedId: String(appointmentBId),
+        status: "open",
+      });
+
+      return { businessAId, businessBId };
+    });
+
+    const authed = t.withIdentity({ subject: "member-a" });
+    const summary = await authed.query(
+      api.integrations.calendar.getCalendarReconciliationSummary,
+      {
+        businessId: businessAId,
+      },
+    );
+    const issues = await authed.query(
+      api.integrations.calendar.listCalendarReconciliationIssues,
+      {
+        businessId: businessAId,
+      },
+    );
+    const appointments = await authed.query(
+      api.integrations.calendar.listAppointmentsNeedingCalendarAttention,
+      {
+        businessId: businessAId,
+      },
+    );
+
+    expect(summary.businessId).toBe(businessAId);
+    expect(summary.counts.failed).toBe(1);
+    expect(summary.counts.drifted).toBe(0);
+    expect(summary.openIssueCount).toBe(1);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.title).toBe("Business A issue");
+
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0]?.lastSyncError).toBe("A failed sync");
+
+    await expect(
+      authed.query(api.integrations.calendar.getCalendarReconciliationSummary, {
+        businessId: businessBId,
+      }),
+    ).rejects.toThrow("You do not have access to this business.");
+  });
+});

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,103 +1,76 @@
-# Security Review: `feature/ope-16-twilio-sms-status` vs `main`
+# OPE-15 Security Audit
 
 ## Executive Summary
 
-I reviewed the SMS/Twilio/agent changes on this branch against `main`, with special attention to webhook trust boundaries, prompt injection, tool abuse, tenant isolation, and confirmation fallback behavior.
+Reviewed `feature/ope-15-calendar-reconciliation` against `main`, focusing on the new calendar reconciliation backend in [convex/integrations/calendar.ts](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts), the booking-state change in [convex/appointments/booking.ts](/Users/raphael/Coding/ai-receptionist/convex/appointments/booking.ts), and the schema additions in [convex/schema.ts](/Users/raphael/Coding/ai-receptionist/convex/schema.ts).
 
-No new critical, high, medium, or low-severity security vulnerabilities remain in this diff after the prompt-hardening follow-up. The branch improves several security-relevant areas: Twilio SMS ingress and status callbacks now require signed webhooks, prompt context explicitly labels customer and knowledge inputs as untrusted, the booking tools ignore model-supplied freeform arguments and instead operate on the actual SMS text plus stored conversation state, and the SMS runtime no longer injects raw tenant `smsInstructions` into the hidden system prompt.
+I did **not** identify any new critical, high, or medium security vulnerabilities in this branch. The new public read APIs are membership-scoped, the reconciliation logic remains internal-only, and the diff does not introduce new prompt/tool surfaces that would create prompt-injection risk.
 
-I also ran `pnpm audit --prod --dev`, which reported no known dependency vulnerabilities at the time of review.
+I also ran `pnpm audit --prod --dev`, which reported **no known vulnerabilities**.
 
-## Critical
+## Scope Reviewed
 
-No critical findings in the branch diff reviewed.
+- [convex/integrations/calendar.ts](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts)
+- [convex/appointments/booking.ts](/Users/raphael/Coding/ai-receptionist/convex/appointments/booking.ts)
+- [convex/schema.ts](/Users/raphael/Coding/ai-receptionist/convex/schema.ts)
+- [packages/testing/src/calendarReconciliation.test.ts](/Users/raphael/Coding/ai-receptionist/packages/testing/src/calendarReconciliation.test.ts)
 
-## High
+Audit focus:
 
-No high-severity findings in the branch diff reviewed.
+- authorization boundaries on the new member-scoped read APIs
+- integrity of the new reconciliation and retry state machine
+- operator-visible recovery record creation and dedupe
+- exposure of sensitive data in the new query/issue surfaces
+- prompt-injection risk introduced by the branch
 
-## Medium
+## Critical Findings
 
-No medium-severity findings in the branch diff reviewed.
+None.
 
-## Low
+## High Findings
 
-No low-severity findings remain in the reviewed diff after the prompt-hardening follow-up.
+None.
+
+## Medium Findings
+
+None.
+
+## Low Findings
+
+None.
+
+## Informational Notes
+
+### INF-1: New reconciliation APIs expose raw sync error strings to members
+
+The branch now persists `calendarLastSyncError` and returns it through the member-scoped reconciliation surfaces in [convex/integrations/calendar.ts:425](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts#L425), [convex/integrations/calendar.ts:933](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts#L933), and [convex/integrations/calendar.ts:986](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts#L986).
+
+This is acceptable in the current mocked-provider implementation because the stored errors are controlled internal strings. When real Google/Microsoft provider adapters are added, these error strings should be normalized to user-safe categories before being exposed to members or copied into `inbox_items`, to avoid leaking provider/internal detail. I am **not** counting this as a branch vulnerability today.
 
 ## Prompt Injection Review
 
-### What I checked
+I did not find any branch-introduced prompt-injection risk.
 
-- Separation of untrusted inputs from system instructions
-- Whether tool calls can be induced from retrieved knowledge instead of the actual customer SMS
-- Whether model output alone can cause booking, cancellation, or resend side effects
-- Whether stale thread or booking state could enable cross-turn unsafe actions
+Why:
 
-### What looks good
+- This diff does not modify prompt construction, RAG context assembly, or agent tool registration.
+- The new reconciliation logic is implemented entirely in backend queries, mutations, and internal actions, not in model-driven tool flows.
+- No new attacker-controlled text is inserted into hidden prompts or used to select privileged actions.
 
-- Customer SMS and retrieved knowledge are explicitly marked untrusted in the prompt construction:
-  - `convex/ai/agents/runtime.ts:39-45`
-  - `convex/ai/agents/runtime.ts:69-75`
-- The tool layer does not accept model-supplied freeform arguments for privileged actions; each tool ignores model parameters and uses the real `conversationPrompt` plus stored server-side state instead:
-  - `convex/ai/agents/runtime.ts:1001-1078`
-- Knowledge lookup stays business-scoped by namespace:
-  - `convex/ai/context/knowledge.ts:211-219`
-- Blank or malformed model output no longer creates an empty outbound SMS body; the runtime falls back to a safe reply:
-  - `convex/ai/agents/runtime.ts:1900-1905`
-  - `convex/conversations/webhooks.ts:615-620`
-- The runtime explicitly instructs the model not to claim bookings, cancellations, or reschedules unless a tool-backed reply already confirmed that state:
-  - `convex/ai/agents/runtime.ts:34-47`
+The only new text surfaces are:
 
-### Residual prompt-injection risk
+- operator-facing `inbox_items.body` strings built from appointment/contact metadata in [convex/integrations/calendar.ts:118](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts#L118)
+- member-scoped query responses returning reconciliation metadata in [convex/integrations/calendar.ts:892](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts#L892) and [convex/integrations/calendar.ts:946](/Users/raphael/Coding/ai-receptionist/convex/integrations/calendar.ts#L946)
 
-- Retrieved knowledge and customer content are labeled untrusted, and the tool handlers materially reduce the risk of model-driven unauthorized booking actions.
-- The branch now removes raw tenant `smsInstructions` from the hidden SMS system prompt and short-circuits direct prompt-extraction attempts with a refusal response.
-- Hidden prompt leakage is still a general LLM risk category, but I did not identify a remaining branch-specific prompt-injection issue in the current diff.
-
-## Webhook Authenticity and Trust Boundaries
-
-### What looks good
-
-- Both inbound SMS and SMS status callbacks require a valid `X-Twilio-Signature` before side effects:
-  - `convex/http.ts:203-231`
-  - `convex/http.ts:246-320`
-- Signature validation is delegated to the official Twilio SDK:
-  - `convex/integrations/twilioSms.ts:23-36`
-- Status callbacks only mutate records matched by `providerMessageSid`, and transition guards prevent regressions from terminal states:
-  - `convex/integrations/twilioMessageStatus.ts:24-73`
-  - `packages/shared/src/twilioMessageStatus.ts`
-
-### Operational note
-
-- Twilio signature validation depends on the runtime seeing the same URL Twilio signed. I did not find a branch-introduced bug here, but this should still be verified in production behind any proxy or custom-domain setup.
-
-## Delivery Failure Confirmation Fallback
-
-### What looks good
-
-- The branch correctly adds a fallback confirmation path if the conversational booking confirmation SMS fails synchronously or later reconciles to `failed` / `undelivered`:
-  - `convex/conversations/webhooks.ts:444-507`
-  - `convex/integrations/twilioMessageStatus.ts:55-65`
-  - `convex/notifications/reminders.ts:210-252`
-- The notification dedupe path on `kind + relatedId` prevents duplicate fallback confirmations for the same appointment:
-  - `convex/notifications/reminders.ts:220-252`
-  - `convex/schema.ts:361-371`
+Those are application-data surfaces, not prompt surfaces.
 
 ## Validation Performed
 
-- Reviewed `git diff --stat main...HEAD`
-- Inspected security-relevant diffs in:
-  - `convex/http.ts`
-  - `convex/conversations/webhooks.ts`
-  - `convex/integrations/twilioSms.ts`
-  - `convex/integrations/twilioMessageStatus.ts`
-  - `convex/ai/agents/runtime.ts`
-  - `convex/ai/context/knowledge.ts`
-  - `convex/notifications/reminders.ts`
-  - `convex/schema.ts`
-- Ran:
-  - `pnpm audit --prod --dev`
+- `git diff main...HEAD`
+- `git diff --stat main...HEAD`
+- targeted manual review of the changed backend files listed above
+- `pnpm audit --prod --dev`
 
-## Conclusion
+## Branch Conclusion
 
-This branch does not appear to introduce new critical, high, medium, or low security vulnerabilities relative to `main` after the prompt-hardening follow-up. The prompt-injection posture is materially improved by separating untrusted content from the system prompt, removing raw tenant `smsInstructions` from the hidden SMS prompt, refusing direct prompt-extraction attempts, and constraining tool handlers to server-side conversation state instead of model-supplied arguments.
+This branch’s calendar reconciliation changes are in good shape from a security perspective. They add internal-only reconciliation behavior plus member-scoped read APIs without introducing new authorization bypasses, secret-handling regressions, or prompt-injection exposure.


### PR DESCRIPTION
## Summary

Implements the backend-first calendar reconciliation flow for appointment sync drift and failed calendar writes, then follows through on review fixes so reconciliation keeps healing automatically after issues are opened.

This PR:
- formalizes appointment calendar sync states as:
  - `not_required`
  - `pending`
  - `syncing`
  - `synced`
  - `failed`
  - `drifted`
- adds durable sync metadata to appointments, including last attempt/success timestamps, retry timing, issue linkage, and external event ids
- turns calendar sync into a real backend state machine for confirmed appointments with connected calendars
- adds business-level reconciliation that:
  - retries failed appointments
  - detects stale `pending` / `syncing` states
  - marks inconsistent rows as `drifted`
  - opens and resolves deduped `calendar_sync_issue` inbox items
- adds member-scoped reconciliation queries for future UI work:
  - summary counts
  - open issues
  - appointments needing attention
- records audit log events for sync failures, drift detection, issue lifecycle, and recovery
- fixes follow-up review findings by:
  - continuing to retry `failed` and `drifted` appointments even after an issue exists
  - scheduling drifted rows for self-healing
  - aligning the reconciliation cron cadence with the stored retry delay by running every 5 minutes
- includes a refreshed branch security audit report in `security_best_practices_report.md`

## Verification

- `pnpm exec convex codegen`
- `pnpm --filter @ai-receptionist/testing test -- calendarReconciliation`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Notes

- Linear: `OPE-15`
- This is the backend-first slice only; no current web UI changes are included
- Provider sync is still scaffolded/mock-backed, but the reconciliation state model and recovery path now match the intended production shape