### PR TITLE
OPE-48 fix dashboard review findings

### DIFF
--- a/convex/dashboard/contacts.ts
+++ b/convex/dashboard/contacts.ts
@@ -20,6 +20,7 @@ export const listContacts = query({
   },
   handler: async (ctx, args) => {
     await requireMembership(ctx, args.businessId);
+    const now = Date.now();
 
     const contacts = await ctx.db
       .query("contacts")
@@ -55,9 +56,12 @@ export const listContacts = query({
 
         const allCalls = callsByConversation.flat();
         const allMessages = messagesByConversation.flat();
+        const pastAppointmentTimestamps = appointments
+          .map((appointment) => Date.parse(appointment.startsAt))
+          .filter((timestamp) => timestamp <= now);
         const lastInteractionAt = Math.max(
           contact._creationTime,
-          ...appointments.map((appointment) => Date.parse(appointment.startsAt)),
+          ...pastAppointmentTimestamps,
           ...allCalls.map((call) => Date.parse(call.startedAt)),
           ...allMessages.map((message) => message._creationTime),
         );

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -39,6 +39,10 @@ export const listConversationSummaries = query({
 
         const latestMessage = messages[messages.length - 1] ?? null;
 
+        if (messages.length === 0) {
+          return null;
+        }
+
         return {
           id: conversation._id,
           channel: conversation.channel,
@@ -54,7 +58,9 @@ export const listConversationSummaries = query({
       }),
     );
 
-    return summaries.sort((left, right) => right.lastMessageAt - left.lastMessageAt);
+    return summaries
+      .filter((summary): summary is NonNullable<typeof summary> => summary !== null)
+      .sort((left, right) => right.lastMessageAt - left.lastMessageAt);
   },
 });
 

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -420,6 +420,9 @@ export const getAnalyticsSummary = query({
       const timestamp = Date.parse(call.startedAt);
       return timestamp >= currentWeekStart && timestamp < nextWeekStart;
     });
+    const currentWeekMessages = allMessages.filter(
+      (message) => message._creationTime >= currentWeekStart && message._creationTime < nextWeekStart,
+    );
 
     const outcomes = {
       completed: 0,
@@ -431,17 +434,22 @@ export const getAnalyticsSummary = query({
       outcomes[categorizeCallOutcome(call)] += 1;
     }
 
-    const currentWeekConversations = conversations.filter(
-      (conversation) =>
-        conversation._creationTime >= currentWeekStart && conversation._creationTime < nextWeekStart,
+    const conversationChannels = new Map(
+      conversations.map((conversation) => [conversation._id, conversation.channel] as const),
     );
     const channels = {
       voice: 0,
       sms: 0,
       other: 0,
     };
-    for (const conversation of currentWeekConversations) {
-      channels[categorizeConversationChannel(conversation.channel)] += 1;
+    for (const call of currentWeekCalls) {
+      const channel = call.conversationId
+        ? conversationChannels.get(call.conversationId) ?? "voice"
+        : "voice";
+      channels[categorizeConversationChannel(channel)] += 1;
+    }
+    for (const message of currentWeekMessages) {
+      channels[categorizeConversationChannel(message.channel)] += 1;
     }
 
     const channelTotal = Object.values(channels).reduce((sum, value) => sum + value, 0);


### PR DESCRIPTION
## Summary
- exclude voice-only conversations from the Messages inbox by omitting conversations that have no messages
- stop treating future appointments as the last interaction timestamp for contacts
- base Analytics weekly channel percentages on this week’s actual call and message activity instead of conversation creation time

## Why
These changes address review findings from the dashboard port:
- the Messages inbox should not show call-only voice threads
- the Contacts page should not show future appointments as past interaction activity
- the Analytics channel mix should reflect this week’s real traffic, including ongoing conversations that started earlier

## Verification
- pnpm typecheck