### PR TITLE
OPE-45 remove final Convex ts-nochecks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,7 @@ import { useConvexAuth, useQuery } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useTranslation } from "react-i18next";
 
-import { demoSnapshot } from "@ai-receptionist/shared";
+import { demoSnapshot, type BusinessContextSnapshot } from "@ai-receptionist/shared";
 
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
@@ -216,7 +216,41 @@ function WorkspaceShell() {
     api.ai.context.snapshots.getForDashboard,
     businessId ? { businessId } : "skip",
   );
-  const resolvedSnapshot = snapshot ?? demoSnapshot;
+  const resolvedSnapshot: BusinessContextSnapshot =
+    snapshot == null
+      ? demoSnapshot
+      : {
+          ...demoSnapshot,
+          ...snapshot,
+          defaultLocale:
+            snapshot.defaultLocale === "en" || snapshot.defaultLocale === "fr"
+              ? snapshot.defaultLocale
+              : demoSnapshot.defaultLocale,
+          businessType:
+            snapshot.businessType === "clinic" ||
+            snapshot.businessType === "repair_shop" ||
+            snapshot.businessType === "salon" ||
+            snapshot.businessType === "service_company" ||
+            snapshot.businessType === "other"
+              ? snapshot.businessType
+              : demoSnapshot.businessType,
+          transferPolicy: {
+            ...demoSnapshot.transferPolicy,
+            ...(snapshot.transferPolicy ?? {}),
+            mode:
+              snapshot.transferPolicy?.mode === "never" ||
+              snapshot.transferPolicy?.mode === "always" ||
+              snapshot.transferPolicy?.mode === "on_request" ||
+              snapshot.transferPolicy?.mode === "on_urgent" ||
+              snapshot.transferPolicy?.mode === "during_business_hours"
+                ? snapshot.transferPolicy.mode
+                : demoSnapshot.transferPolicy.mode,
+          },
+          contactChannels: {
+            ...demoSnapshot.contactChannels,
+            ...(snapshot.contactChannels ?? {}),
+          },
+        };
 
   if (businesses === undefined) {
     return <LoadingScreen />;
@@ -225,30 +259,51 @@ function WorkspaceShell() {
   return (
     <AuthenticatedLayout
       businessName={activeBusiness?.name ?? "AI Receptionist"}
-      businessSlug={activeBusiness?.slug}
+      {...(activeBusiness?.slug ? { businessSlug: activeBusiness.slug } : {})}
       onSignOut={() => void signOut()}
     >
       <Main className="flex flex-1 flex-col" fixed>
         <Routes>
-          <Route element={<HomePage businessId={businessId} snapshot={resolvedSnapshot} />} path="/" />
-          <Route element={<CallsPage businessId={businessId} />} path="/calls" />
-          <Route element={<MessagesPage businessId={businessId} />} path="/messages" />
-          <Route element={<AutomationsPage businessId={businessId} />} path="/automations" />
           <Route
-            element={<AgentPage businessId={businessId} snapshot={resolvedSnapshot} />}
+            element={<HomePage {...(businessId ? { businessId } : {})} snapshot={resolvedSnapshot} />}
+            path="/"
+          />
+          <Route element={<CallsPage {...(businessId ? { businessId } : {})} />} path="/calls" />
+          <Route
+            element={<MessagesPage {...(businessId ? { businessId } : {})} />}
+            path="/messages"
+          />
+          <Route
+            element={<AutomationsPage {...(businessId ? { businessId } : {})} />}
+            path="/automations"
+          />
+          <Route
+            element={<AgentPage {...(businessId ? { businessId } : {})} snapshot={resolvedSnapshot} />}
             path="/agent"
           />
-          <Route element={<ContactsPage businessId={businessId} />} path="/contacts" />
+          <Route element={<ContactsPage {...(businessId ? { businessId } : {})} />} path="/contacts" />
           <Route
-            element={<SettingsLayout businessId={businessId} />}
+            element={<SettingsLayout {...(businessId ? { businessId } : {})} />}
             path="/settings/*"
           >
             <Route
-              element={<SettingsBusinessPage businessId={businessId as Id<"businesses">} snapshot={resolvedSnapshot} />}
+              element={
+                businessId ? (
+                  <SettingsBusinessPage businessId={businessId} snapshot={resolvedSnapshot} />
+                ) : (
+                  <Navigate replace to="/settings" />
+                )
+              }
               index
             />
             <Route
-              element={<IntegrationsPage businessId={businessId as Id<"businesses">} />}
+              element={
+                businessId ? (
+                  <IntegrationsPage businessId={businessId} />
+                ) : (
+                  <Navigate replace to="/settings" />
+                )
+              }
               path="integrations"
             />
           </Route>

--- a/apps/web/src/components/locale-provider.tsx
+++ b/apps/web/src/components/locale-provider.tsx
@@ -74,10 +74,12 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
       setPendingLocale(null);
     }
 
+    const storedLocale = readStoredLocale();
+    const browserLocale = i18n.resolvedLanguage ?? i18n.language;
     const normalizedLocale = resolveAuthenticatedLocale({
-      preferredLocale: preferredLocale ?? undefined,
-      storedLocale: readStoredLocale(),
-      browserLocale: i18n.resolvedLanguage ?? i18n.language,
+      ...(preferredLocale ? { preferredLocale } : {}),
+      ...(storedLocale ? { storedLocale } : {}),
+      ...(browserLocale ? { browserLocale } : {}),
     });
     if (normalizedLocale !== locale) {
       void i18n.changeLanguage(normalizedLocale);

--- a/apps/web/src/features/settings/BookableTeamCard.tsx
+++ b/apps/web/src/features/settings/BookableTeamCard.tsx
@@ -132,11 +132,11 @@ export function BookableTeamCard(props: BookableTeamCardProps) {
     try {
       const result = await upsertStaff({
         businessId: props.businessId,
-        staffId: selectedStaff?._id,
+        ...(selectedStaff?._id ? { staffId: selectedStaff._id } : {}),
         name: name.trim(),
         timezone: timezone.trim() || businessTimezone,
         active,
-        transferNumber: transferNumber.trim() || undefined,
+        ...(transferNumber.trim() ? { transferNumber: transferNumber.trim() } : {}),
       });
       setSelectedStaffKey(String(result.staffId));
       setStaffSaveMessage(selectedStaff ? t("settings:team.saved") : t("settings:team.added"));

--- a/apps/web/src/features/settings/BusinessProfileForm.tsx
+++ b/apps/web/src/features/settings/BusinessProfileForm.tsx
@@ -62,10 +62,10 @@ export function BusinessProfileForm(props: BusinessProfileFormProps) {
         tone,
         summary,
         bookingPolicy,
-        voiceInstructions: voiceInstructions.trim() || undefined,
-        smsInstructions: smsInstructions.trim() || undefined,
+        ...(voiceInstructions.trim() ? { voiceInstructions: voiceInstructions.trim() } : {}),
+        ...(smsInstructions.trim() ? { smsInstructions: smsInstructions.trim() } : {}),
         transferMode,
-        transferNumber: transferNumber.trim() || undefined,
+        ...(transferNumber.trim() ? { transferNumber: transferNumber.trim() } : {}),
       });
       setStatus(t("profile.saved"));
     } finally {

--- a/apps/web/src/features/settings/IntegrationsPage.tsx
+++ b/apps/web/src/features/settings/IntegrationsPage.tsx
@@ -408,13 +408,17 @@ export function IntegrationsPage({ businessId }: IntegrationsPageProps) {
                     <Button
                       disabled={isLoadingCalendars || !selectedConnection.staffId}
                       onClick={() => {
+                        const connectionStaffId = selectedConnection.staffId;
+                        if (!connectionStaffId) {
+                          return;
+                        }
                         setSelectedCalendarId(selectedConnection.selectedCalendarId ?? "");
                         setStatusMessage(null);
                         setErrorMessage(null);
                         setIsLoadingCalendars(true);
                         void listGoogleCalendars({
                           businessId,
-                          staffId: selectedConnection.staffId,
+                          staffId: connectionStaffId,
                         })
                           .then((calendars) => {
                             const nextCalendars = calendars as Array<GoogleCalendarOption>;

--- a/apps/web/src/features/settings/PhoneNumbersCard.tsx
+++ b/apps/web/src/features/settings/PhoneNumbersCard.tsx
@@ -108,9 +108,9 @@ export function PhoneNumbersCard(props: PhoneNumbersCardProps) {
     try {
       const result = await upsertPhoneNumber({
         businessId: props.businessId,
-        phoneNumberId: selectedPhoneNumber?._id,
+        ...(selectedPhoneNumber?._id ? { phoneNumberId: selectedPhoneNumber._id } : {}),
         e164: e164.replace(/\s+/g, ""),
-        twilioPhoneSid: twilioPhoneSid.trim() || undefined,
+        ...(twilioPhoneSid.trim() ? { twilioPhoneSid: twilioPhoneSid.trim() } : {}),
         voiceEnabled,
         smsEnabled,
         status,

--- a/apps/web/src/features/settings/ServicesCard.tsx
+++ b/apps/web/src/features/settings/ServicesCard.tsx
@@ -54,7 +54,7 @@ export function ServicesCard(props: ServicesCardProps) {
         businessId: props.businessId,
         name: trimmedName,
         slug: trimmedSlug,
-        description: description.trim() || undefined,
+        ...(description.trim() ? { description: description.trim() } : {}),
         durationMinutes: Number(durationMinutes),
         active: true,
       });

--- a/convex/ai/context/knowledge.ts
+++ b/convex/ai/context/knowledge.ts
@@ -121,7 +121,7 @@ async function indexKnowledgeDocumentById(
     title: document.title,
     text: document.textContent,
     key: `document:${String(documentId)}`,
-    contentHash: document.contentHash,
+    ...(document.contentHash !== undefined ? { contentHash: document.contentHash } : {}),
     filterValues: [
       { name: "businessId", value: String(document.businessId) },
       { name: "sourceType", value: document.sourceType },

--- a/convex/ai/workflows/runtime.ts
+++ b/convex/ai/workflows/runtime.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import { internalMutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";

--- a/convex/appointments/booking.ts
+++ b/convex/appointments/booking.ts
@@ -195,7 +195,9 @@ async function bookAppointmentWithSource(
       serviceId: args.serviceId,
       startsAt: args.startsAt,
       timezone: args.timezone,
-      preferredStaffId: args.preferredStaffId,
+      ...(args.preferredStaffId !== undefined
+        ? { preferredStaffId: args.preferredStaffId }
+        : {}),
     },
   );
 
@@ -224,6 +226,9 @@ async function bookAppointmentWithSource(
   }
 
   const selected = availability[0];
+  if (!selected) {
+    throw new Error("No availability for the requested time.");
+  }
   const calendarState: {
     hasConnectedCalendar: boolean;
     selectedConnectionId?: Id<"calendar_connections">;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -326,8 +326,10 @@ http.route({
       from: parsedPayload.data.From,
       to: parsedPayload.data.To,
       body: parsedPayload.data.Body,
-      messageSid: parsedPayload.data.MessageSid,
-      smsSid: parsedPayload.data.SmsSid,
+      ...(parsedPayload.data.MessageSid !== undefined
+        ? { messageSid: parsedPayload.data.MessageSid }
+        : {}),
+      ...(parsedPayload.data.SmsSid !== undefined ? { smsSid: parsedPayload.data.SmsSid } : {}),
       ...(media.length > 0 ? { media } : {}),
     });
 

--- a/convex/integrations/googleCalendar.ts
+++ b/convex/integrations/googleCalendar.ts
@@ -417,7 +417,9 @@ async function withGoogleAccessToken(
 
   const refreshed = await refreshGoogleAccessToken({
     connectionId,
-    encryptedRefreshToken: connection.encryptedRefreshToken,
+    ...(connection.encryptedRefreshToken !== undefined
+      ? { encryptedRefreshToken: connection.encryptedRefreshToken }
+      : {}),
   });
   await ctx.runMutation(internal.integrations.calendar.updateCalendarConnectionCredentials, {
     connectionId,
@@ -540,6 +542,10 @@ export const completeOAuthCallback = internalAction({
     if (!selectedCalendar) {
       throw new Error("Google account does not have a writable calendar.");
     }
+    const tokenExpiresAt =
+      tokenPayload.expires_in !== undefined
+        ? getTokenExpiryIso(tokenPayload.expires_in)
+        : undefined;
 
     const connectionId: Id<"calendar_connections"> = await ctx.runMutation(
       internal.integrations.calendar.upsertGoogleCalendarConnection,
@@ -555,9 +561,7 @@ export const completeOAuthCallback = internalAction({
         ...(tokenPayload.refresh_token !== undefined
           ? { encryptedRefreshToken: encryptSecret(tokenPayload.refresh_token) }
           : {}),
-        ...(tokenPayload.expires_in !== undefined
-          ? { tokenExpiresAt: getTokenExpiryIso(tokenPayload.expires_in) }
-          : {}),
+        ...(tokenExpiresAt !== undefined ? { tokenExpiresAt } : {}),
       },
     );
 

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -1,12 +1,13 @@
-// @ts-nocheck
 import { v } from "convex/values";
 import {
+  type ActionCtx,
   internalAction,
   internalMutation,
   internalQuery,
   mutation,
 } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
 import { retrier } from "../lib/components";
 import { requireMembership } from "../lib/auth";
 import {
@@ -14,6 +15,24 @@ import {
   normalizeRuntimeLocale,
 } from "../lib/runtimeLocale";
 import { selectSmsSenderPhoneNumber } from "../lib/smsPhoneNumbers";
+
+type AppointmentNotificationKind = "appointment_reminder" | "booking_confirmation";
+
+type NotificationDeliveryContext = {
+  notificationId: Id<"notifications">;
+  to: string;
+  from: string;
+  body: string;
+};
+
+type DeliverNotificationResult = {
+  delivered: true;
+  providerMessageId: string;
+};
+
+function isAppointmentNotificationKind(kind: string): kind is AppointmentNotificationKind {
+  return kind === "appointment_reminder" || kind === "booking_confirmation";
+}
 
 function buildTwilioSmsStatusCallbackUrl(): string {
   const siteUrl = process.env.CONVEX_SITE_URL;
@@ -37,7 +56,7 @@ export const getNotificationDeliveryContext = internalQuery({
   args: {
     notificationId: v.id("notifications"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<NotificationDeliveryContext | null> => {
     const notification = await ctx.db.get(args.notificationId);
     if (!notification) {
       return null;
@@ -51,7 +70,15 @@ export const getNotificationDeliveryContext = internalQuery({
       throw new Error("Notification is missing a related appointment.");
     }
 
-    const appointment = await ctx.db.get(notification.relatedId as any);
+    const appointmentId = await ctx.db.normalizeId(
+      "appointments",
+      notification.relatedId,
+    );
+    if (!appointmentId) {
+      throw new Error("Notification is missing a valid appointment reference.");
+    }
+
+    const appointment = await ctx.db.get(appointmentId);
     if (!appointment) {
       throw new Error("Appointment not found for notification.");
     }
@@ -76,6 +103,9 @@ export const getNotificationDeliveryContext = internalQuery({
 
     if (!business) {
       throw new Error("Business not found for notification.");
+    }
+    if (!isAppointmentNotificationKind(notification.kind)) {
+      throw new Error("Unsupported notification kind.");
     }
 
     const senderPhoneNumber = selectSmsSenderPhoneNumber(phoneNumbers);
@@ -277,8 +307,8 @@ export const deliverNotification = internalAction({
   args: {
     notificationId: v.id("notifications"),
   },
-  handler: async (ctx, args) => {
-    const deliveryContext = await ctx.runQuery(
+  handler: async (ctx, args): Promise<DeliverNotificationResult> => {
+    const deliveryContext: NotificationDeliveryContext | null = await ctx.runQuery(
       internal.notifications.reminders.getNotificationDeliveryContext,
       { notificationId: args.notificationId },
     );
@@ -287,12 +317,15 @@ export const deliverNotification = internalAction({
     }
 
     try {
-      const result = await ctx.runAction(internal.integrations.twilioSms.sendMessage, {
+      const result: { providerMessageSid: string; providerStatus: string } = await ctx.runAction(
+        internal.integrations.twilioSms.sendMessage,
+        {
         to: deliveryContext.to,
         from: deliveryContext.from,
         body: deliveryContext.body,
         statusCallbackUrl: buildTwilioSmsStatusCallbackUrl(),
-      });
+        },
+      );
 
       await ctx.runMutation(internal.notifications.reminders.markNotificationSent, {
         notificationId: args.notificationId,
@@ -318,8 +351,8 @@ export const deliverNotification = internalAction({
 
 export const dispatchDueNotifications = internalAction({
   args: {},
-  handler: async (ctx) => {
-    const due = await ctx.runQuery(
+  handler: async (ctx: ActionCtx): Promise<{ count: number }> => {
+    const due: Array<Doc<"notifications">> = await ctx.runQuery(
       internal.notifications.reminders.listDueScheduledNotifications,
       {
         nowIso: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Implements OPE-45 by removing the final Convex `@ts-nocheck` directives and fixing the surfaced exact-optional-property typing issues on current `main`.

### What changed
- removed the remaining file-level `@ts-nocheck` directives from:
  - `convex/notifications/reminders.ts`
  - `convex/ai/workflows/runtime.ts`
- tightened reminder delivery typing so appointment notification context and delivery results are explicit and ID normalization is type-safe
- fixed exact-optional-property mismatches across Convex call sites by omitting optional args instead of passing `undefined`
- fixed the booking availability selection path to guard the selected slot explicitly
- normalized dashboard snapshot handling in `apps/web/src/App.tsx` so the web app no longer relies on loose inferred snapshot types
- updated settings form submissions to conditionally include optional fields only when present
- tightened integrations page calendar refresh handling for staff-scoped requests

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

## Manual smoke test suggestions
- sign in and load dashboard routes: Home, Calls, Messages, Automations, Contacts, Settings
- save optional-field forms in Settings with some fields left blank
- open Integrations and refresh/list Google calendars for a mapped staff member

## Linear
- OPE-45