### PR TITLE
Add Resend-backed auth email delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NODE_ENV=development
 DEPLOYMENT_MODE=development
 APP_BASE_URL=http://localhost:5173
+SITE_URL=http://localhost:5173
 VOICE_GATEWAY_BASE_URL=http://localhost:3001
 PORT=3001
 CONVEX_URL=https://your-deployment.convex.cloud

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker/
 
 Mock providers are part of the default development path so contributors can exercise flows without live Twilio, OpenAI, calendar, or email credentials.
 Password reset email uses the official Convex Resend component. Setup and local verification steps live in [docs/providers/resend.md](/Users/raphael/Coding/ai-receptionist/docs/providers/resend.md).
+Password reset auth also requires `SITE_URL` on the Convex deployment so Convex Auth can complete its email reset flow.
 
 ## Product Principles
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ docker/
 5. Seed demo data with `pnpm seed:demo`.
 
 Mock providers are part of the default development path so contributors can exercise flows without live Twilio, OpenAI, calendar, or email credentials.
+Password reset email uses the official Convex Resend component. Setup and local verification steps live in [docs/providers/resend.md](/Users/raphael/Coding/ai-receptionist/docs/providers/resend.md).
 
 ## Product Principles
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ docker/
 5. Seed demo data with `pnpm seed:demo`.
 
 Mock providers are part of the default development path so contributors can exercise flows without live Twilio, OpenAI, calendar, or email credentials.
-Password reset email uses the official Convex Resend component. Setup and local verification steps live in [docs/providers/resend.md](/Users/raphael/Coding/ai-receptionist/docs/providers/resend.md).
-Password reset auth also requires `SITE_URL` on the Convex deployment so Convex Auth can complete its email reset flow.
+Password reset and email-change confirmation use the official Convex Resend component. Setup and local verification steps live in [docs/providers/resend.md](/Users/raphael/Coding/ai-receptionist/docs/providers/resend.md).
+These auth email flows also require `SITE_URL` on the Convex deployment so Convex Auth can build the correct reset and confirmation links.
 
 ## Product Principles
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,9 +48,12 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^5.0.2",
+    "jsdom": "^29.0.1",
     "vite": "^7.1.3"
   }
 }

--- a/apps/web/public/locales/en/auth.json
+++ b/apps/web/public/locales/en/auth.json
@@ -59,6 +59,7 @@
     "accountExists": "An account with that email already exists. Try signing in instead.",
     "invalidPassword": "Use a password with at least 12 characters and avoid common passwords.",
     "signupFailed": "We couldn't create your account. Please try again.",
+    "passwordResetMissingSiteUrl": "Password reset isn't configured yet. Set SITE_URL on the Convex deployment and try again.",
     "passwordResetRequestFailed": "We couldn't send a reset code right now. Please try again.",
     "invalidResetCode": "That reset code is invalid or expired. Try requesting a new one.",
     "passwordResetFailed": "We couldn't reset your password. Please try again."

--- a/apps/web/public/locales/en/auth.json
+++ b/apps/web/public/locales/en/auth.json
@@ -8,6 +8,7 @@
     "passwordPlaceholder": "••••••••",
     "submit": "Sign in",
     "submitting": "Signing in...",
+    "forgotPassword": "Forgot password?",
     "noAccount": "Don't have an account?",
     "createOne": "Create one"
   },
@@ -23,18 +24,43 @@
     "haveAccount": "Already have an account?",
     "signIn": "Sign in"
   },
+  "forgotPassword": {
+    "title": "Reset your password",
+    "subtitle": "Enter your account email and we'll send you a reset code.",
+    "verifyTitle": "Enter your reset code",
+    "verifySubtitle": "If an account exists for {{email}}, we sent an 8-digit code.",
+    "email": "Email",
+    "emailPlaceholder": "you@business.com",
+    "code": "Reset code",
+    "codePlaceholder": "12345678",
+    "newPassword": "New password",
+    "newPasswordPlaceholder": "Choose a new password",
+    "submit": "Send reset code",
+    "submitting": "Sending reset code...",
+    "verifySubmit": "Reset password",
+    "verifySubmitting": "Resetting password...",
+    "back": "Use a different email",
+    "backToLogin": "Back to sign in"
+  },
   "status": {
     "continuingSignIn": "Continuing sign-in in a new browser flow...",
     "signedInFinishing": "Signed in. Finishing your session...",
     "signInCompleted": "Sign-in completed. Finalizing your session...",
     "continuingSignUp": "Continuing sign-up in a new browser flow...",
     "accountCreatedFinishing": "Account created. Finishing your session...",
-    "accountCreatedFinalizing": "Account created. Finalizing your session..."
+    "accountCreatedFinalizing": "Account created. Finalizing your session...",
+    "resetCodeSent": "If an account exists for that email, we sent a reset code.",
+    "continuingPasswordReset": "Continuing password reset in a new browser flow...",
+    "passwordResetFinishing": "Password reset complete. Finishing your session...",
+    "passwordResetCompleted": "Password reset complete. Finalizing your session..."
   },
   "errors": {
     "incorrectCredentials": "Incorrect email or password. Please try again.",
     "accountExists": "An account with that email already exists. Try signing in instead.",
     "invalidPassword": "Use a password with at least 12 characters and avoid common passwords.",
-    "signupFailed": "We couldn't create your account. Please try again."
+    "signupFailed": "We couldn't create your account. Please try again.",
+    "passwordResetRequestFailed": "We couldn't send a reset code right now. Please try again.",
+    "invalidResetCode": "That reset code is invalid or expired. Try requesting a new one.",
+    "passwordResetFailed": "We couldn't reset your password. Please try again."
   }
 }

--- a/apps/web/public/locales/en/auth.json
+++ b/apps/web/public/locales/en/auth.json
@@ -42,6 +42,16 @@
     "back": "Use a different email",
     "backToLogin": "Back to sign in"
   },
+  "confirmEmailChange": {
+    "title": "Confirm your new email",
+    "subtitle": "Confirm {{email}} as the new sign-in email for this account.",
+    "submit": "Confirm email change",
+    "submitting": "Confirming email change...",
+    "success": "Your sign-in email has been updated to {{email}}.",
+    "invalidLink": "This email confirmation link is invalid or expired. Request a new one from Settings.",
+    "backToLogin": "Back to sign in",
+    "backToSettings": "Back to settings"
+  },
   "status": {
     "continuingSignIn": "Continuing sign-in in a new browser flow...",
     "signedInFinishing": "Signed in. Finishing your session...",

--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -142,19 +142,20 @@
   "account": {
     "changeEmail": {
       "label": "Change email",
-      "description": "Enter your new email and current password.",
+      "description": "Enter your new email and current password. We'll send a confirmation link before we update your sign-in email.",
       "newEmailPlaceholder": "New email",
       "currentPasswordPlaceholder": "Current password",
-      "save": "Save",
+      "save": "Send confirmation link",
       "currentEmail": "Current email: {{email}}",
-      "saved": "Email updated to {{email}}.",
+      "confirmationSent": "We sent a confirmation link to {{email}}.",
       "errors": {
         "invalidPassword": "Current password is incorrect.",
         "alreadyExists": "An account with that email already exists.",
         "unchanged": "Enter a different email address.",
         "noEmail": "No email is configured for this account yet.",
+        "missingSiteUrl": "Email confirmation isn't configured yet. Set SITE_URL on the Convex deployment and try again.",
         "required": "Enter a new email address.",
-        "failed": "We couldn't update your email. Please try again."
+        "failed": "We couldn't send a confirmation link. Please try again."
       }
     }
   },

--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -139,6 +139,25 @@
       "transferNumber": "+1 555 123 4567"
     }
   },
+  "account": {
+    "changeEmail": {
+      "label": "Change email",
+      "description": "Enter your new email and current password.",
+      "newEmailPlaceholder": "New email",
+      "currentPasswordPlaceholder": "Current password",
+      "save": "Save",
+      "currentEmail": "Current email: {{email}}",
+      "saved": "Email updated to {{email}}.",
+      "errors": {
+        "invalidPassword": "Current password is incorrect.",
+        "alreadyExists": "An account with that email already exists.",
+        "unchanged": "Enter a different email address.",
+        "noEmail": "No email is configured for this account yet.",
+        "required": "Enter a new email address.",
+        "failed": "We couldn't update your email. Please try again."
+      }
+    }
+  },
   "hours": {
     "title": "Opening Hours",
     "description": "Structured hours stay authoritative over documents and help the receptionist answer availability questions reliably.",

--- a/apps/web/public/locales/fr/auth.json
+++ b/apps/web/public/locales/fr/auth.json
@@ -8,6 +8,7 @@
     "passwordPlaceholder": "••••••••",
     "submit": "Se connecter",
     "submitting": "Connexion...",
+    "forgotPassword": "Mot de passe oublié?",
     "noAccount": "Vous n'avez pas de compte?",
     "createOne": "Créer un compte"
   },
@@ -23,18 +24,43 @@
     "haveAccount": "Vous avez déjà un compte?",
     "signIn": "Se connecter"
   },
+  "forgotPassword": {
+    "title": "Réinitialiser votre mot de passe",
+    "subtitle": "Entrez le courriel de votre compte et nous vous enverrons un code de réinitialisation.",
+    "verifyTitle": "Entrez votre code de réinitialisation",
+    "verifySubtitle": "Si un compte existe pour {{email}}, nous avons envoyé un code à 8 chiffres.",
+    "email": "Courriel",
+    "emailPlaceholder": "vous@entreprise.com",
+    "code": "Code de réinitialisation",
+    "codePlaceholder": "12345678",
+    "newPassword": "Nouveau mot de passe",
+    "newPasswordPlaceholder": "Choisissez un nouveau mot de passe",
+    "submit": "Envoyer le code",
+    "submitting": "Envoi du code...",
+    "verifySubmit": "Réinitialiser le mot de passe",
+    "verifySubmitting": "Réinitialisation...",
+    "back": "Utiliser un autre courriel",
+    "backToLogin": "Retour à la connexion"
+  },
   "status": {
     "continuingSignIn": "Poursuite de la connexion dans un nouveau flux du navigateur...",
     "signedInFinishing": "Connexion réussie. Finalisation de votre session...",
     "signInCompleted": "Connexion terminée. Finalisation de votre session...",
     "continuingSignUp": "Poursuite de l'inscription dans un nouveau flux du navigateur...",
     "accountCreatedFinishing": "Compte créé. Finalisation de votre session...",
-    "accountCreatedFinalizing": "Compte créé. Finalisation de votre session..."
+    "accountCreatedFinalizing": "Compte créé. Finalisation de votre session...",
+    "resetCodeSent": "Si un compte existe pour ce courriel, nous avons envoyé un code de réinitialisation.",
+    "continuingPasswordReset": "Poursuite de la réinitialisation dans un nouveau flux du navigateur...",
+    "passwordResetFinishing": "Mot de passe réinitialisé. Finalisation de votre session...",
+    "passwordResetCompleted": "Mot de passe réinitialisé. Finalisation de votre session..."
   },
   "errors": {
     "incorrectCredentials": "Courriel ou mot de passe incorrect. Veuillez réessayer.",
     "accountExists": "Un compte existe déjà avec ce courriel. Essayez plutôt de vous connecter.",
     "invalidPassword": "Utilisez un mot de passe d'au moins 12 caractères et évitez les mots de passe courants.",
-    "signupFailed": "Impossible de créer votre compte. Veuillez réessayer."
+    "signupFailed": "Impossible de créer votre compte. Veuillez réessayer.",
+    "passwordResetRequestFailed": "Impossible d'envoyer un code de réinitialisation pour le moment. Veuillez réessayer.",
+    "invalidResetCode": "Ce code de réinitialisation est invalide ou expiré. Demandez-en un nouveau.",
+    "passwordResetFailed": "Impossible de réinitialiser votre mot de passe. Veuillez réessayer."
   }
 }

--- a/apps/web/public/locales/fr/auth.json
+++ b/apps/web/public/locales/fr/auth.json
@@ -59,6 +59,7 @@
     "accountExists": "Un compte existe déjà avec ce courriel. Essayez plutôt de vous connecter.",
     "invalidPassword": "Utilisez un mot de passe d'au moins 12 caractères et évitez les mots de passe courants.",
     "signupFailed": "Impossible de créer votre compte. Veuillez réessayer.",
+    "passwordResetMissingSiteUrl": "La réinitialisation du mot de passe n'est pas encore configurée. Définissez SITE_URL sur le déploiement Convex puis réessayez.",
     "passwordResetRequestFailed": "Impossible d'envoyer un code de réinitialisation pour le moment. Veuillez réessayer.",
     "invalidResetCode": "Ce code de réinitialisation est invalide ou expiré. Demandez-en un nouveau.",
     "passwordResetFailed": "Impossible de réinitialiser votre mot de passe. Veuillez réessayer."

--- a/apps/web/public/locales/fr/auth.json
+++ b/apps/web/public/locales/fr/auth.json
@@ -42,6 +42,16 @@
     "back": "Utiliser un autre courriel",
     "backToLogin": "Retour à la connexion"
   },
+  "confirmEmailChange": {
+    "title": "Confirmez votre nouveau courriel",
+    "subtitle": "Confirmez {{email}} comme nouveau courriel de connexion pour ce compte.",
+    "submit": "Confirmer le changement de courriel",
+    "submitting": "Confirmation du changement de courriel...",
+    "success": "Votre courriel de connexion a ete mis a jour vers {{email}}.",
+    "invalidLink": "Ce lien de confirmation est invalide ou expire. Demandez-en un nouveau dans les reglages.",
+    "backToLogin": "Retour a la connexion",
+    "backToSettings": "Retour aux reglages"
+  },
   "status": {
     "continuingSignIn": "Poursuite de la connexion dans un nouveau flux du navigateur...",
     "signedInFinishing": "Connexion réussie. Finalisation de votre session...",

--- a/apps/web/public/locales/fr/settings.json
+++ b/apps/web/public/locales/fr/settings.json
@@ -142,19 +142,20 @@
   "account": {
     "changeEmail": {
       "label": "Changer le courriel",
-      "description": "Entrez votre nouveau courriel et votre mot de passe actuel.",
+      "description": "Entrez votre nouveau courriel et votre mot de passe actuel. Nous enverrons un lien de confirmation avant de modifier votre courriel de connexion.",
       "newEmailPlaceholder": "Nouveau courriel",
       "currentPasswordPlaceholder": "Mot de passe actuel",
-      "save": "Enregistrer",
+      "save": "Envoyer le lien de confirmation",
       "currentEmail": "Courriel actuel : {{email}}",
-      "saved": "Courriel mis a jour vers {{email}}.",
+      "confirmationSent": "Nous avons envoye un lien de confirmation a {{email}}.",
       "errors": {
         "invalidPassword": "Le mot de passe actuel est incorrect.",
         "alreadyExists": "Un compte existe deja avec ce courriel.",
         "unchanged": "Entrez une adresse courriel differente.",
         "noEmail": "Aucun courriel n'est configure pour ce compte.",
+        "missingSiteUrl": "La confirmation du courriel n'est pas encore configuree. Definissez SITE_URL sur le deploiement Convex puis reessayez.",
         "required": "Entrez une nouvelle adresse courriel.",
-        "failed": "Impossible de mettre a jour votre courriel. Veuillez reessayer."
+        "failed": "Impossible d'envoyer un lien de confirmation. Veuillez reessayer."
       }
     }
   },

--- a/apps/web/public/locales/fr/settings.json
+++ b/apps/web/public/locales/fr/settings.json
@@ -139,6 +139,25 @@
       "transferNumber": "+1 555 123 4567"
     }
   },
+  "account": {
+    "changeEmail": {
+      "label": "Changer le courriel",
+      "description": "Entrez votre nouveau courriel et votre mot de passe actuel.",
+      "newEmailPlaceholder": "Nouveau courriel",
+      "currentPasswordPlaceholder": "Mot de passe actuel",
+      "save": "Enregistrer",
+      "currentEmail": "Courriel actuel : {{email}}",
+      "saved": "Courriel mis a jour vers {{email}}.",
+      "errors": {
+        "invalidPassword": "Le mot de passe actuel est incorrect.",
+        "alreadyExists": "Un compte existe deja avec ce courriel.",
+        "unchanged": "Entrez une adresse courriel differente.",
+        "noEmail": "Aucun courriel n'est configure pour ce compte.",
+        "required": "Entrez une nouvelle adresse courriel.",
+        "failed": "Impossible de mettre a jour votre courriel. Veuillez reessayer."
+      }
+    }
+  },
   "hours": {
     "title": "Heures d'ouverture",
     "description": "Les heures structurées font autorité sur les documents et aident la réceptionniste à répondre correctement aux questions de disponibilité.",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Main } from "@/components/layout/main";
 import {
+  ConfirmEmailChangePage,
   ForgotPasswordPage,
   LoginPage,
   SignupPage,
@@ -218,6 +219,7 @@ export default function App() {
             }
             path="/forgot-password"
           />
+          <Route element={<ConfirmEmailChangePage />} path="/confirm-email-change" />
           <Route
             element={
               <RequireAuth>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,26 +1,21 @@
 import type { ReactNode } from "react";
-import { FormEvent, useState } from "react";
-import {
-  BrowserRouter,
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-} from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useConvexAuth, useQuery } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useTranslation } from "react-i18next";
 
 import { demoSnapshot, type BusinessContextSnapshot } from "@ai-receptionist/shared";
 
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
 import { LoadingScreen } from "@/components/loading-screen";
-import { LoginForm } from "@/components/login-form";
-import { SignupForm } from "@/components/signup-form";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Main } from "@/components/layout/main";
+import {
+  ForgotPasswordPage,
+  LoginPage,
+  SignupPage,
+} from "@/features/auth/AuthPages";
 import { AutomationsPage } from "@/features/automations/AutomationsPage";
 import { AnalyticsPage } from "@/features/analytics/AnalyticsPage";
 import { AgentPage } from "@/features/agent/AgentPage";
@@ -32,155 +27,6 @@ import { SettingsLayout } from "@/features/settings/SettingsLayout";
 import { SettingsAppearancePage } from "@/features/settings/SettingsAppearancePage";
 import { IntegrationsPage } from "@/features/settings/IntegrationsPage";
 import { SettingsBusinessPage } from "@/features/settings/SettingsBusinessPage";
-
-function AuthShell(props: { children: ReactNode }) {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top_left,rgba(15,23,42,0.08),transparent_32%),linear-gradient(180deg,rgba(255,255,255,0.98),rgba(248,250,252,0.95))] px-6 py-10">
-      <section className="flex w-full items-center justify-center">
-        <div className="w-full max-w-md rounded-[2rem] border border-border/70 bg-card/95 p-8 shadow-xl shadow-black/5">
-          {props.children}
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function getAuthErrorMessage(
-  error: unknown,
-  flow: "signIn" | "signUp",
-  t: (key: string) => string,
-): string {
-  const message = error instanceof Error ? error.message : "";
-
-  if (flow === "signIn") {
-    if (message.includes("InvalidSecret") || message.includes("Invalid credentials")) {
-      return t("errors.incorrectCredentials");
-    }
-    return t("errors.incorrectCredentials");
-  }
-
-  if (message.includes("already exists")) {
-    return t("errors.accountExists");
-  }
-
-  if (message.includes("Invalid password")) {
-    return t("errors.invalidPassword");
-  }
-
-  return t("errors.signupFailed");
-}
-
-function LoginPage() {
-  const { t } = useTranslation("auth");
-  const { signIn } = useAuthActions();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setIsSubmitting(true);
-    setStatusMessage(null);
-    setErrorMessage(null);
-
-    try {
-      const formData = new FormData();
-      formData.set("flow", "signIn");
-      formData.set("email", email);
-      formData.set("password", password);
-      const result = await signIn("password", formData);
-
-      if (result.redirect) {
-        setStatusMessage(t("status.continuingSignIn"));
-        return;
-      }
-
-      if (result.signingIn) {
-        setStatusMessage(t("status.signedInFinishing"));
-        return;
-      }
-
-      setStatusMessage(t("status.signInCompleted"));
-    } catch (error) {
-      setErrorMessage(getAuthErrorMessage(error, "signIn", t));
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  return (
-    <AuthShell>
-      <LoginForm
-        email={email}
-        errorMessage={errorMessage}
-        isSubmitting={isSubmitting}
-        onEmailChange={setEmail}
-        onPasswordChange={setPassword}
-        onSubmit={handleSubmit}
-        password={password}
-        statusMessage={statusMessage}
-      />
-    </AuthShell>
-  );
-}
-
-function SignupPage() {
-  const { t } = useTranslation("auth");
-  const { signIn } = useAuthActions();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setIsSubmitting(true);
-    setStatusMessage(null);
-    setErrorMessage(null);
-
-    try {
-      const formData = new FormData();
-      formData.set("flow", "signUp");
-      formData.set("email", email);
-      formData.set("password", password);
-      const result = await signIn("password", formData);
-
-      if (result.redirect) {
-        setStatusMessage(t("status.continuingSignUp"));
-        return;
-      }
-
-      if (result.signingIn) {
-        setStatusMessage(t("status.accountCreatedFinishing"));
-        return;
-      }
-
-      setStatusMessage(t("status.accountCreatedFinalizing"));
-    } catch (error) {
-      setErrorMessage(getAuthErrorMessage(error, "signUp", t));
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  return (
-    <AuthShell>
-      <SignupForm
-        email={email}
-        errorMessage={errorMessage}
-        isSubmitting={isSubmitting}
-        onEmailChange={setEmail}
-        onPasswordChange={setPassword}
-        onSubmit={handleSubmit}
-        password={password}
-        statusMessage={statusMessage}
-      />
-    </AuthShell>
-  );
-}
 
 function RequireAuth(props: { children: ReactNode }) {
   const auth = useConvexAuth();
@@ -355,6 +201,14 @@ export default function App() {
               </PublicOnly>
             }
             path="/signup"
+          />
+          <Route
+            element={
+              <PublicOnly>
+                <ForgotPasswordPage />
+              </PublicOnly>
+            }
+            path="/forgot-password"
           />
           <Route
             element={

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -59,6 +59,7 @@ function PublicOnly(props: { children: ReactNode }) {
 function WorkspaceShell() {
   const { signOut } = useAuthActions();
   const location = useLocation();
+  const currentUser = useQuery(api.users.current, {});
   const businesses = useQuery(api.businesses.admin.listForCurrentUser, {});
   const activeBusiness = businesses?.[0]?.business;
   const businessId = activeBusiness?._id;
@@ -114,6 +115,13 @@ function WorkspaceShell() {
       businessName={activeBusiness?.name ?? "AI Receptionist"}
       {...(activeBusiness?.slug ? { businessSlug: activeBusiness.slug } : {})}
       onSignOut={() => void signOut()}
+      {...(currentUser?.image ? { operatorAvatar: currentUser.image } : {})}
+      {...(currentUser?.email ? { operatorEmail: currentUser.email } : {})}
+      {...(
+        currentUser?.displayName ?? currentUser?.name
+          ? { operatorName: currentUser.displayName ?? currentUser.name! }
+          : {}
+      )}
     >
       <Main className="flex flex-1 flex-col" fixed={usesFixedMain}>
         <Routes>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -30,20 +30,26 @@ type AppSidebarProps = {
   businessName: string;
   businessSlug?: string | undefined;
   onSignOut: () => void;
+  operatorAvatar?: string;
+  operatorEmail?: string;
+  operatorName?: string;
 };
 
 export function AppSidebar({
   businessName,
   onSignOut,
+  operatorAvatar,
+  operatorEmail,
+  operatorName,
   ...props
 }: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
   const { t } = useTranslation(["common", "nav", "settings"]);
-  const operatorEmail = "operator@local";
   const sidebarData: SidebarData = React.useMemo(
     () => ({
       user: {
-        name: businessName,
-        email: operatorEmail,
+        name: operatorName ?? businessName,
+        email: operatorEmail ?? "",
+        ...(operatorAvatar ? { avatar: operatorAvatar } : {}),
       },
       teams: [
         {
@@ -92,7 +98,7 @@ export function AppSidebar({
         },
       ],
     }),
-    [businessName, operatorEmail, t],
+    [businessName, operatorAvatar, operatorEmail, operatorName, t],
   );
 
   return (

--- a/apps/web/src/components/forgot-password-form.tsx
+++ b/apps/web/src/components/forgot-password-form.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Rows3 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+type ForgotPasswordFormProps = {
+  className?: string;
+  step: "request" | "verify";
+  email: string;
+  code: string;
+  newPassword: string;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  statusMessage: string | null;
+  onEmailChange: (value: string) => void;
+  onCodeChange: (value: string) => void;
+  onNewPasswordChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onBackToRequest: () => void;
+};
+
+export function ForgotPasswordForm({
+  className,
+  step,
+  email,
+  code,
+  newPassword,
+  isSubmitting,
+  errorMessage,
+  statusMessage,
+  onEmailChange,
+  onCodeChange,
+  onNewPasswordChange,
+  onSubmit,
+  onBackToRequest,
+}: ForgotPasswordFormProps) {
+  const { t } = useTranslation("auth");
+  const isVerifyStep = step === "verify";
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)}>
+      <form onSubmit={onSubmit}>
+        <FieldGroup>
+          <div className="flex flex-col items-center gap-3 text-center">
+            <div className="flex size-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <Rows3 className="size-5" />
+            </div>
+            <div className="space-y-2">
+              <h1 className="text-xl font-semibold tracking-tight">
+                {isVerifyStep ? t("forgotPassword.verifyTitle") : t("forgotPassword.title")}
+              </h1>
+              <FieldDescription>
+                {isVerifyStep
+                  ? t("forgotPassword.verifySubtitle", { email })
+                  : t("forgotPassword.subtitle")}
+              </FieldDescription>
+            </div>
+          </div>
+
+          {isVerifyStep ? (
+            <>
+              <Field>
+                <FieldLabel htmlFor="reset-code">{t("forgotPassword.code")}</FieldLabel>
+                <Input
+                  id="reset-code"
+                  autoComplete="one-time-code"
+                  inputMode="numeric"
+                  onChange={(event) => onCodeChange(event.target.value)}
+                  placeholder={t("forgotPassword.codePlaceholder")}
+                  required
+                  type="text"
+                  value={code}
+                />
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="reset-new-password">
+                  {t("forgotPassword.newPassword")}
+                </FieldLabel>
+                <Input
+                  id="reset-new-password"
+                  autoComplete="new-password"
+                  onChange={(event) => onNewPasswordChange(event.target.value)}
+                  placeholder={t("forgotPassword.newPasswordPlaceholder")}
+                  required
+                  type="password"
+                  value={newPassword}
+                />
+              </Field>
+            </>
+          ) : (
+            <Field>
+              <FieldLabel htmlFor="reset-email">{t("forgotPassword.email")}</FieldLabel>
+              <Input
+                id="reset-email"
+                autoComplete="email"
+                onChange={(event) => onEmailChange(event.target.value)}
+                placeholder={t("forgotPassword.emailPlaceholder")}
+                required
+                type="email"
+                value={email}
+              />
+            </Field>
+          )}
+
+          <div>
+            {statusMessage || errorMessage ? (
+              <div className="mb-6 mt-2 space-y-2">
+                {statusMessage ? <FieldDescription>{statusMessage}</FieldDescription> : null}
+                {errorMessage ? <FieldError>{errorMessage}</FieldError> : null}
+              </div>
+            ) : (
+              <div aria-hidden="true" className="h-8" />
+            )}
+
+            <div className="flex flex-col gap-3">
+              <Button className="w-full" disabled={isSubmitting} size="lg" type="submit">
+                {isSubmitting
+                  ? isVerifyStep
+                    ? t("forgotPassword.verifySubmitting")
+                    : t("forgotPassword.submitting")
+                  : isVerifyStep
+                    ? t("forgotPassword.verifySubmit")
+                    : t("forgotPassword.submit")}
+              </Button>
+
+              {isVerifyStep ? (
+                <Button
+                  className="w-full"
+                  disabled={isSubmitting}
+                  onClick={onBackToRequest}
+                  type="button"
+                  variant="outline"
+                >
+                  {t("forgotPassword.back")}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </FieldGroup>
+      </form>
+
+      <FieldDescription className="text-center">
+        <Link className="font-medium text-foreground underline underline-offset-4" to="/login">
+          {t("forgotPassword.backToLogin")}
+        </Link>
+      </FieldDescription>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/authenticated-layout.tsx
+++ b/apps/web/src/components/layout/authenticated-layout.tsx
@@ -10,6 +10,9 @@ type AuthenticatedLayoutProps = {
   businessSlug?: string;
   children: ReactNode;
   onSignOut: () => void;
+  operatorAvatar?: string;
+  operatorEmail?: string;
+  operatorName?: string;
 };
 
 function getSidebarDefaultOpen(): boolean {
@@ -29,6 +32,9 @@ export function AuthenticatedLayout({
   businessSlug,
   children,
   onSignOut,
+  operatorAvatar,
+  operatorEmail,
+  operatorName,
 }: AuthenticatedLayoutProps) {
   const defaultOpen = getSidebarDefaultOpen();
 
@@ -45,6 +51,9 @@ export function AuthenticatedLayout({
         businessName={businessName}
         businessSlug={businessSlug}
         onSignOut={onSignOut}
+        {...(operatorAvatar ? { operatorAvatar } : {})}
+        {...(operatorEmail ? { operatorEmail } : {})}
+        {...(operatorName ? { operatorName } : {})}
       />
       <SidebarInset
         className={cn(

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -70,7 +70,15 @@ export function LoginForm({
 
           <div>
             <Field>
-              <FieldLabel htmlFor="login-password">{t("login.password")}</FieldLabel>
+              <div className="flex items-center justify-between gap-3">
+                <FieldLabel htmlFor="login-password">{t("login.password")}</FieldLabel>
+                <Link
+                  className="text-sm font-medium text-muted-foreground hover:text-foreground"
+                  to="/forgot-password"
+                >
+                  {t("login.forgotPassword")}
+                </Link>
+              </div>
               <Input
                 id="login-password"
                 autoComplete="current-password"
@@ -94,15 +102,6 @@ export function LoginForm({
             <Button className="w-full" disabled={isSubmitting} size="lg" type="submit">
               {isSubmitting ? t("login.submitting") : t("login.submit")}
             </Button>
-
-            <FieldDescription className="mt-3 text-center">
-              <Link
-                className="font-medium text-foreground underline underline-offset-4"
-                to="/forgot-password"
-              >
-                {t("login.forgotPassword")}
-              </Link>
-            </FieldDescription>
           </div>
         </FieldGroup>
       </form>

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -94,6 +94,15 @@ export function LoginForm({
             <Button className="w-full" disabled={isSubmitting} size="lg" type="submit">
               {isSubmitting ? t("login.submitting") : t("login.submit")}
             </Button>
+
+            <FieldDescription className="mt-3 text-center">
+              <Link
+                className="font-medium text-foreground underline underline-offset-4"
+                to="/forgot-password"
+              >
+                {t("login.forgotPassword")}
+              </Link>
+            </FieldDescription>
           </div>
         </FieldGroup>
       </form>

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -1,0 +1,99 @@
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ForgotPasswordPage } from "./AuthPages";
+
+const signInMock = vi.fn();
+
+vi.mock("@convex-dev/auth/react", () => ({
+  useAuthActions: () => ({
+    signIn: signInMock,
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      typeof options?.email === "string" ? `${key}:${options.email}` : key,
+  }),
+}));
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    signInMock.mockReset();
+  });
+
+  it("submits a reset request with the expected FormData", async () => {
+    signInMock.mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
+
+    expect(signInMock).toHaveBeenCalledTimes(1);
+    const [provider, formData] = signInMock.mock.calls[0] as [string, FormData];
+
+    expect(provider).toBe("password");
+    expect(formData.get("flow")).toBe("reset");
+    expect(formData.get("email")).toBe("owner@example.com");
+    expect(screen.getByText("forgotPassword.verifyTitle")).toBeTruthy();
+  });
+
+  it("submits reset verification with email, code, and new password", async () => {
+    signInMock
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ signingIn: true });
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
+    await user.type(screen.getByLabelText("forgotPassword.code"), "12345678");
+    await user.type(screen.getByLabelText("forgotPassword.newPassword"), "a-secure-password");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.verifySubmit" }));
+
+    expect(signInMock).toHaveBeenCalledTimes(2);
+    const [provider, formData] = signInMock.mock.calls[1] as [string, FormData];
+
+    expect(provider).toBe("password");
+    expect(formData.get("flow")).toBe("reset-verification");
+    expect(formData.get("email")).toBe("owner@example.com");
+    expect(formData.get("code")).toBe("12345678");
+    expect(formData.get("newPassword")).toBe("a-secure-password");
+    expect(screen.getByText("status.passwordResetFinishing")).toBeTruthy();
+  });
+
+  it("renders reset-specific errors from Convex Auth failures", async () => {
+    signInMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("Invalid code"));
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
+    await user.type(screen.getByLabelText("forgotPassword.code"), "12345678");
+    await user.type(screen.getByLabelText("forgotPassword.newPassword"), "a-secure-password");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.verifySubmit" }));
+
+    expect(screen.getByText("errors.invalidResetCode")).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -47,6 +47,22 @@ describe("ForgotPasswordPage", () => {
     expect(screen.getByText("forgotPassword.verifyTitle")).toBeTruthy();
   });
 
+  it("renders a specific error when SITE_URL is missing on the Convex deployment", async () => {
+    signInMock.mockRejectedValueOnce(new Error("Missing environment variable `SITE_URL`"));
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
+
+    expect(screen.getByText("errors.passwordResetMissingSiteUrl")).toBeTruthy();
+  });
+
   it("submits reset verification with email, code, and new password", async () => {
     signInMock
       .mockResolvedValueOnce({})

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -112,4 +112,25 @@ describe("ForgotPasswordPage", () => {
 
     expect(screen.getByText("errors.invalidResetCode")).toBeTruthy();
   });
+
+  it("masks missing accounts as invalid reset codes during verification", async () => {
+    signInMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("InvalidAccountId"));
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
+    await user.type(screen.getByLabelText("forgotPassword.code"), "12345678");
+    await user.type(screen.getByLabelText("forgotPassword.newPassword"), "a-secure-password");
+    await user.click(screen.getByRole("button", { name: "forgotPassword.verifySubmit" }));
+
+    expect(screen.getByText("errors.invalidResetCode")).toBeTruthy();
+  });
 });

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -56,7 +56,11 @@ function getAuthErrorMessage(
   }
 
   if (flow === "resetVerification") {
-    if (message.includes("Invalid code") || message.includes("Could not verify code")) {
+    if (
+      message.includes("Invalid code") ||
+      message.includes("Could not verify code") ||
+      message.includes("InvalidAccountId")
+    ) {
       return t("errors.invalidResetCode");
     }
 

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -1,0 +1,269 @@
+import type { FormEvent, ReactNode } from "react";
+import { useState } from "react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+
+import { ForgotPasswordForm } from "@/components/forgot-password-form";
+import { LoginForm } from "@/components/login-form";
+import { SignupForm } from "@/components/signup-form";
+
+type AuthErrorFlow = "signIn" | "signUp" | "resetRequest" | "resetVerification";
+
+function AuthShell(props: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top_left,rgba(15,23,42,0.08),transparent_32%),linear-gradient(180deg,rgba(255,255,255,0.98),rgba(248,250,252,0.95))] px-6 py-10">
+      <section className="flex w-full items-center justify-center">
+        <div className="w-full max-w-md rounded-[2rem] border border-border/70 bg-card/95 p-8 shadow-xl shadow-black/5">
+          {props.children}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function getAuthErrorMessage(
+  error: unknown,
+  flow: AuthErrorFlow,
+  t: TFunction<"auth">,
+): string {
+  const message = error instanceof Error ? error.message : "";
+
+  if (flow === "signIn") {
+    if (message.includes("InvalidSecret") || message.includes("Invalid credentials")) {
+      return t("errors.incorrectCredentials");
+    }
+    return t("errors.incorrectCredentials");
+  }
+
+  if (flow === "signUp") {
+    if (message.includes("already exists")) {
+      return t("errors.accountExists");
+    }
+
+    if (message.includes("Invalid password")) {
+      return t("errors.invalidPassword");
+    }
+
+    return t("errors.signupFailed");
+  }
+
+  if (flow === "resetVerification") {
+    if (message.includes("Invalid code") || message.includes("Could not verify code")) {
+      return t("errors.invalidResetCode");
+    }
+
+    if (message.includes("Invalid password")) {
+      return t("errors.invalidPassword");
+    }
+
+    return t("errors.passwordResetFailed");
+  }
+
+  return t("errors.passwordResetRequestFailed");
+}
+
+function isResetRequestLookupError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : "";
+  return message.includes("InvalidAccountId");
+}
+
+export function LoginPage() {
+  const { t } = useTranslation("auth");
+  const { signIn } = useAuthActions();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const formData = new FormData();
+      formData.set("flow", "signIn");
+      formData.set("email", email);
+      formData.set("password", password);
+      const result = await signIn("password", formData);
+
+      if (result.redirect) {
+        setStatusMessage(t("status.continuingSignIn"));
+        return;
+      }
+
+      if (result.signingIn) {
+        setStatusMessage(t("status.signedInFinishing"));
+        return;
+      }
+
+      setStatusMessage(t("status.signInCompleted"));
+    } catch (error) {
+      setErrorMessage(getAuthErrorMessage(error, "signIn", t));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell>
+      <LoginForm
+        email={email}
+        errorMessage={errorMessage}
+        isSubmitting={isSubmitting}
+        onEmailChange={setEmail}
+        onPasswordChange={setPassword}
+        onSubmit={handleSubmit}
+        password={password}
+        statusMessage={statusMessage}
+      />
+    </AuthShell>
+  );
+}
+
+export function SignupPage() {
+  const { t } = useTranslation("auth");
+  const { signIn } = useAuthActions();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const formData = new FormData();
+      formData.set("flow", "signUp");
+      formData.set("email", email);
+      formData.set("password", password);
+      const result = await signIn("password", formData);
+
+      if (result.redirect) {
+        setStatusMessage(t("status.continuingSignUp"));
+        return;
+      }
+
+      if (result.signingIn) {
+        setStatusMessage(t("status.accountCreatedFinishing"));
+        return;
+      }
+
+      setStatusMessage(t("status.accountCreatedFinalizing"));
+    } catch (error) {
+      setErrorMessage(getAuthErrorMessage(error, "signUp", t));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell>
+      <SignupForm
+        email={email}
+        errorMessage={errorMessage}
+        isSubmitting={isSubmitting}
+        onEmailChange={setEmail}
+        onPasswordChange={setPassword}
+        onSubmit={handleSubmit}
+        password={password}
+        statusMessage={statusMessage}
+      />
+    </AuthShell>
+  );
+}
+
+export function ForgotPasswordPage() {
+  const { t } = useTranslation("auth");
+  const { signIn } = useAuthActions();
+  const [step, setStep] = useState<"request" | "verify">("request");
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const formData = new FormData();
+      formData.set("email", email);
+
+      if (step === "request") {
+        formData.set("flow", "reset");
+        await signIn("password", formData);
+        setStep("verify");
+        setStatusMessage(t("status.resetCodeSent"));
+        return;
+      }
+
+      formData.set("flow", "reset-verification");
+      formData.set("code", code);
+      formData.set("newPassword", newPassword);
+      const result = await signIn("password", formData);
+
+      if (result.redirect) {
+        setStatusMessage(t("status.continuingPasswordReset"));
+        return;
+      }
+
+      if (result.signingIn) {
+        setStatusMessage(t("status.passwordResetFinishing"));
+        return;
+      }
+
+      setStatusMessage(t("status.passwordResetCompleted"));
+    } catch (error) {
+      if (step === "request" && isResetRequestLookupError(error)) {
+        setStep("verify");
+        setStatusMessage(t("status.resetCodeSent"));
+        return;
+      }
+
+      setErrorMessage(
+        getAuthErrorMessage(error, step === "request" ? "resetRequest" : "resetVerification", t),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleBackToRequest() {
+    setStep("request");
+    setCode("");
+    setNewPassword("");
+    setStatusMessage(null);
+    setErrorMessage(null);
+  }
+
+  return (
+    <AuthShell>
+      <ForgotPasswordForm
+        code={code}
+        email={email}
+        errorMessage={errorMessage}
+        isSubmitting={isSubmitting}
+        newPassword={newPassword}
+        onBackToRequest={handleBackToRequest}
+        onCodeChange={setCode}
+        onEmailChange={setEmail}
+        onNewPasswordChange={setNewPassword}
+        onSubmit={handleSubmit}
+        statusMessage={statusMessage}
+        step={step}
+      />
+    </AuthShell>
+  );
+}

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -60,6 +60,10 @@ function getAuthErrorMessage(
     return t("errors.passwordResetFailed");
   }
 
+  if (flow === "resetRequest" && message.includes("Missing environment variable `SITE_URL`")) {
+    return t("errors.passwordResetMissingSiteUrl");
+  }
+
   return t("errors.passwordResetRequestFailed");
 }
 

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -32,6 +32,10 @@ function getAuthErrorMessage(
 ): string {
   const message = error instanceof Error ? error.message : "";
 
+  if (message.includes("Missing environment variable `SITE_URL`")) {
+    return t("errors.passwordResetMissingSiteUrl");
+  }
+
   if (flow === "signIn") {
     if (message.includes("InvalidSecret") || message.includes("Invalid credentials")) {
       return t("errors.incorrectCredentials");

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -63,10 +63,6 @@ function getAuthErrorMessage(
     return t("errors.passwordResetFailed");
   }
 
-  if (flow === "resetRequest" && message.includes("Missing environment variable `SITE_URL`")) {
-    return t("errors.passwordResetMissingSiteUrl");
-  }
-
   return t("errors.passwordResetRequestFailed");
 }
 

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -1,9 +1,12 @@
 import type { FormEvent, ReactNode } from "react";
 import { useState } from "react";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useAction, useConvexAuth } from "convex/react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
+import { Link, useSearchParams } from "react-router-dom";
 
+import { api } from "../../../../../convex/_generated/api";
 import { ForgotPasswordForm } from "@/components/forgot-password-form";
 import { LoginForm } from "@/components/login-form";
 import { SignupForm } from "@/components/signup-form";
@@ -268,6 +271,85 @@ export function ForgotPasswordPage() {
         statusMessage={statusMessage}
         step={step}
       />
+    </AuthShell>
+  );
+}
+
+export function ConfirmEmailChangePage() {
+  const { t } = useTranslation("auth");
+  const auth = useConvexAuth();
+  const confirmEmailChange = useAction(api.businesses.catalog.confirmEmailChange);
+  const [searchParams] = useSearchParams();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const token = searchParams.get("token")?.trim() ?? "";
+  const email = searchParams.get("email")?.trim().toLowerCase() ?? "";
+  const hasConfirmationParams = token.length > 0 && email.length > 0;
+  const returnHref = auth.isAuthenticated ? "/settings" : "/login";
+  const returnLabel = auth.isAuthenticated
+    ? t("confirmEmailChange.backToSettings")
+    : t("confirmEmailChange.backToLogin");
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    if (!hasConfirmationParams) {
+      setErrorMessage(t("confirmEmailChange.invalidLink"));
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await confirmEmailChange({
+        code: token,
+        email,
+      });
+      setStatusMessage(t("confirmEmailChange.success", { email: result.email }));
+    } catch {
+      setErrorMessage(t("confirmEmailChange.invalidLink"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell>
+      <div className="space-y-6 text-center">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">
+            {t("confirmEmailChange.title")}
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {hasConfirmationParams
+              ? t("confirmEmailChange.subtitle", { email })
+              : t("confirmEmailChange.invalidLink")}
+          </p>
+        </div>
+
+        {statusMessage ? <p className="text-sm text-muted-foreground">{statusMessage}</p> : null}
+        {errorMessage ? <p className="text-sm text-destructive">{errorMessage}</p> : null}
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <button
+            className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+            disabled={!hasConfirmationParams || isSubmitting || statusMessage !== null}
+            type="submit"
+          >
+            {isSubmitting
+              ? t("confirmEmailChange.submitting")
+              : t("confirmEmailChange.submit")}
+          </button>
+        </form>
+
+        <Link className="text-sm text-muted-foreground hover:text-foreground" to={returnHref}>
+          {returnLabel}
+        </Link>
+      </div>
     </AuthShell>
   );
 }

--- a/apps/web/src/features/settings/SettingsBusinessPage.tsx
+++ b/apps/web/src/features/settings/SettingsBusinessPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { useAction, useMutation, useQuery } from "convex/react";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
 
 import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
@@ -11,10 +13,13 @@ type SettingsBusinessPageProps = {
 };
 
 export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
+  const { t } = useTranslation("settings");
   const configuration = useQuery(api.businesses.catalog.getBusinessConfiguration, {
     businessId: props.businessId,
   });
+  const currentUser = useQuery(api.users.current, {});
   const updateBusinessName = useMutation(api.businesses.catalog.updateBusinessName);
+  const changeEmail = useAction(api.businesses.catalog.changeEmail);
   const changePassword = useAction(api.businesses.catalog.changePassword);
   const [businessName, setBusinessName] = useState("");
   const [email, setEmail] = useState("");
@@ -22,6 +27,8 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
+  const [emailStatus, setEmailStatus] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   useEffect(() => {
     const nextName = configuration?.business?.name;
@@ -50,6 +57,24 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
     setCurrentPassword("");
     setNewPassword("");
     setConfirmNewPassword("");
+  }
+
+  async function handleEmailSave(): Promise<void> {
+    setEmailStatus(null);
+    setEmailError(null);
+
+    try {
+      const result = await changeEmail({
+        currentPassword: currentEmailPassword,
+        newEmail: email,
+      });
+
+      setEmail("");
+      setCurrentEmailPassword("");
+      setEmailStatus(t("account.changeEmail.saved", { email: result.email }));
+    } catch (error) {
+      setEmailError(getChangeEmailErrorMessage(error, t));
+    }
   }
 
   return (
@@ -81,28 +106,40 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
           <div className="space-y-3">
             <div className="space-y-1">
               <label className="text-sm font-medium" htmlFor="profile-email">
-                Change email
+                {t("account.changeEmail.label")}
               </label>
               <p className="text-sm leading-6 text-muted-foreground">
-                Enter you new email and current password.
+                {t("account.changeEmail.description")}
               </p>
+              {currentUser?.email ? (
+                <p className="text-sm leading-6 text-muted-foreground">
+                  {t("account.changeEmail.currentEmail", { email: currentUser.email })}
+                </p>
+              ) : null}
             </div>
             <div className="space-y-4">
               <Input
                 id="profile-email"
-                placeholder="New email"
+                type="email"
+                autoComplete="email"
+                placeholder={t("account.changeEmail.newEmailPlaceholder")}
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
               />
               <Input
                 id="profile-password"
                 type="password"
-                placeholder="Current password"
+                autoComplete="current-password"
+                placeholder={t("account.changeEmail.currentPasswordPlaceholder")}
                 value={currentEmailPassword}
                 onChange={(event) => setCurrentEmailPassword(event.target.value)}
               />
+              {emailStatus ? <p className="text-sm text-muted-foreground">{emailStatus}</p> : null}
+              {emailError ? <p className="text-sm text-destructive">{emailError}</p> : null}
               <div className="pt-4">
-                <Button type="button">Save</Button>
+                <Button type="button" onClick={() => void handleEmailSave()}>
+                  {t("account.changeEmail.save")}
+                </Button>
               </div>
             </div>
           </div>
@@ -149,4 +186,29 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
       </div>
     </div>
   );
+}
+
+function getChangeEmailErrorMessage(
+  error: unknown,
+  t: TFunction<"settings">,
+) {
+  const message = error instanceof Error ? error.message : "";
+
+  if (message.includes("InvalidSecret")) {
+    return t("account.changeEmail.errors.invalidPassword");
+  }
+  if (message.includes("already exists")) {
+    return t("account.changeEmail.errors.alreadyExists");
+  }
+  if (message.includes("already on your account")) {
+    return t("account.changeEmail.errors.unchanged");
+  }
+  if (message.includes("No email is configured")) {
+    return t("account.changeEmail.errors.noEmail");
+  }
+  if (message.includes("required")) {
+    return t("account.changeEmail.errors.required");
+  }
+
+  return t("account.changeEmail.errors.failed");
 }

--- a/apps/web/src/features/settings/SettingsBusinessPage.tsx
+++ b/apps/web/src/features/settings/SettingsBusinessPage.tsx
@@ -71,7 +71,7 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
 
       setEmail("");
       setCurrentEmailPassword("");
-      setEmailStatus(t("account.changeEmail.saved", { email: result.email }));
+      setEmailStatus(t("account.changeEmail.confirmationSent", { email: result.email }));
     } catch (error) {
       setEmailError(getChangeEmailErrorMessage(error, t));
     }
@@ -202,6 +202,9 @@ function getChangeEmailErrorMessage(
   }
   if (message.includes("already on your account")) {
     return t("account.changeEmail.errors.unchanged");
+  }
+  if (message.includes("SITE_URL is required")) {
+    return t("account.changeEmail.errors.missingSiteUrl");
   }
   if (message.includes("No email is configured")) {
     return t("account.changeEmail.errors.noEmail");

--- a/apps/web/src/features/settings/SettingsBusinessPage.tsx
+++ b/apps/web/src/features/settings/SettingsBusinessPage.tsx
@@ -209,7 +209,7 @@ function getChangeEmailErrorMessage(
   if (message.includes("No email is configured")) {
     return t("account.changeEmail.errors.noEmail");
   }
-  if (message.includes("required")) {
+  if (message.includes("New email is required")) {
     return t("account.changeEmail.errors.required");
   }
 

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,6 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,15 @@
 import path from "node:path";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   envDir: "../../",
   plugins: [react(), tailwindcss()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -39,6 +39,8 @@ import type * as lib_messageAttachmentUrls from "../lib/messageAttachmentUrls.js
 import type * as lib_messageAttachments from "../lib/messageAttachments.js";
 import type * as lib_node_imagePreviews from "../lib/node/imagePreviews.js";
 import type * as lib_passwordPolicy from "../lib/passwordPolicy.js";
+import type * as lib_passwordReset from "../lib/passwordReset.js";
+import type * as lib_providers_email from "../lib/providers/email.js";
 import type * as lib_providers_embeddings from "../lib/providers/embeddings.js";
 import type * as lib_providers_nonRealtimeText from "../lib/providers/nonRealtimeText.js";
 import type * as lib_runtimeLocale from "../lib/runtimeLocale.js";
@@ -94,6 +96,8 @@ declare const fullApi: ApiFromModules<{
   "lib/messageAttachments": typeof lib_messageAttachments;
   "lib/node/imagePreviews": typeof lib_node_imagePreviews;
   "lib/passwordPolicy": typeof lib_passwordPolicy;
+  "lib/passwordReset": typeof lib_passwordReset;
+  "lib/providers/email": typeof lib_providers_email;
   "lib/providers/embeddings": typeof lib_providers_embeddings;
   "lib/providers/nonRealtimeText": typeof lib_providers_nonRealtimeText;
   "lib/runtimeLocale": typeof lib_runtimeLocale;
@@ -3388,6 +3392,155 @@ export declare const components: {
             startOrder: number;
           }>;
         }
+      >;
+    };
+  };
+  resend: {
+    lib: {
+      cancelEmail: FunctionReference<
+        "mutation",
+        "internal",
+        { emailId: string },
+        null
+      >;
+      cleanupAbandonedEmails: FunctionReference<
+        "mutation",
+        "internal",
+        { olderThan?: number },
+        null
+      >;
+      cleanupOldEmails: FunctionReference<
+        "mutation",
+        "internal",
+        { olderThan?: number },
+        null
+      >;
+      createManualEmail: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          from: string;
+          headers?: Array<{ name: string; value: string }>;
+          replyTo?: Array<string>;
+          subject: string;
+          to: Array<string> | string;
+        },
+        string
+      >;
+      get: FunctionReference<
+        "query",
+        "internal",
+        { emailId: string },
+        {
+          bcc?: Array<string>;
+          bounced?: boolean;
+          cc?: Array<string>;
+          clicked?: boolean;
+          complained: boolean;
+          createdAt: number;
+          deliveryDelayed?: boolean;
+          errorMessage?: string;
+          failed?: boolean;
+          finalizedAt: number;
+          from: string;
+          headers?: Array<{ name: string; value: string }>;
+          html?: string;
+          opened: boolean;
+          replyTo: Array<string>;
+          resendId?: string;
+          segment: number;
+          status:
+            | "waiting"
+            | "queued"
+            | "cancelled"
+            | "sent"
+            | "delivered"
+            | "delivery_delayed"
+            | "bounced"
+            | "failed";
+          subject?: string;
+          template?: {
+            id: string;
+            variables?: Record<string, string | number>;
+          };
+          text?: string;
+          to: Array<string>;
+        } | null
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { emailId: string },
+        {
+          bounced: boolean;
+          clicked: boolean;
+          complained: boolean;
+          deliveryDelayed: boolean;
+          errorMessage: string | null;
+          failed: boolean;
+          opened: boolean;
+          status:
+            | "waiting"
+            | "queued"
+            | "cancelled"
+            | "sent"
+            | "delivered"
+            | "delivery_delayed"
+            | "bounced"
+            | "failed";
+        } | null
+      >;
+      handleEmailEvent: FunctionReference<
+        "mutation",
+        "internal",
+        { event: any },
+        null
+      >;
+      sendEmail: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          bcc?: Array<string>;
+          cc?: Array<string>;
+          from: string;
+          headers?: Array<{ name: string; value: string }>;
+          html?: string;
+          options: {
+            apiKey: string;
+            initialBackoffMs: number;
+            onEmailEvent?: { fnHandle: string };
+            retryAttempts: number;
+            testMode: boolean;
+          };
+          replyTo?: Array<string>;
+          subject?: string;
+          template?: {
+            id: string;
+            variables?: Record<string, string | number>;
+          };
+          text?: string;
+          to: Array<string>;
+        },
+        string
+      >;
+      updateManualEmail: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          emailId: string;
+          errorMessage?: string;
+          resendId?: string;
+          status:
+            | "waiting"
+            | "queued"
+            | "cancelled"
+            | "sent"
+            | "delivered"
+            | "delivery_delayed"
+            | "bounced"
+            | "failed";
+        },
+        null
       >;
     };
   };

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as integrations_twilioSmsDebug from "../integrations/twilioSmsDebu
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_availability from "../lib/availability.js";
 import type * as lib_components from "../lib/components.js";
+import type * as lib_emailChange from "../lib/emailChange.js";
 import type * as lib_indexedQueries from "../lib/indexedQueries.js";
 import type * as lib_messageAttachmentUrls from "../lib/messageAttachmentUrls.js";
 import type * as lib_messageAttachments from "../lib/messageAttachments.js";
@@ -91,6 +92,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/availability": typeof lib_availability;
   "lib/components": typeof lib_components;
+  "lib/emailChange": typeof lib_emailChange;
   "lib/indexedQueries": typeof lib_indexedQueries;
   "lib/messageAttachmentUrls": typeof lib_messageAttachmentUrls;
   "lib/messageAttachments": typeof lib_messageAttachments;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -31,6 +31,7 @@ import type * as integrations_messageMedia from "../integrations/messageMedia.js
 import type * as integrations_twilioMessageStatus from "../integrations/twilioMessageStatus.js";
 import type * as integrations_twilioSms from "../integrations/twilioSms.js";
 import type * as integrations_twilioSmsDebug from "../integrations/twilioSmsDebug.js";
+import type * as lib_accountCredentials from "../lib/accountCredentials.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_availability from "../lib/availability.js";
 import type * as lib_components from "../lib/components.js";
@@ -89,6 +90,7 @@ declare const fullApi: ApiFromModules<{
   "integrations/twilioMessageStatus": typeof integrations_twilioMessageStatus;
   "integrations/twilioSms": typeof integrations_twilioSms;
   "integrations/twilioSmsDebug": typeof integrations_twilioSmsDebug;
+  "lib/accountCredentials": typeof lib_accountCredentials;
   "lib/auth": typeof lib_auth;
   "lib/availability": typeof lib_availability;
   "lib/components": typeof lib_components;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,5 +1,6 @@
 import { Password } from "@convex-dev/auth/providers/Password";
 import { convexAuth } from "@convex-dev/auth/server";
+import { emailChangeProvider } from "./lib/emailChange";
 import { validatePasswordRequirements } from "./lib/passwordPolicy";
 import { passwordResetProvider } from "./lib/passwordReset";
 
@@ -13,5 +14,6 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
       reset: passwordResetProvider,
       validatePasswordRequirements,
     }),
+    emailChangeProvider,
   ],
 });

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,6 +1,5 @@
 import { Password } from "@convex-dev/auth/providers/Password";
 import { convexAuth } from "@convex-dev/auth/server";
-import { emailChangeProvider } from "./lib/emailChange";
 import { validatePasswordRequirements } from "./lib/passwordPolicy";
 import { passwordResetProvider } from "./lib/passwordReset";
 
@@ -14,6 +13,5 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
       reset: passwordResetProvider,
       validatePasswordRequirements,
     }),
-    emailChangeProvider,
   ],
 });

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,11 +1,17 @@
 import { Password } from "@convex-dev/auth/providers/Password";
 import { convexAuth } from "@convex-dev/auth/server";
 import { validatePasswordRequirements } from "./lib/passwordPolicy";
+import { passwordResetProvider } from "./lib/passwordReset";
 
 /**
  * The hosted and self-hosted products use the same auth implementation.
  * Deployment mode changes secret ownership and email delivery, not the auth API.
  */
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
-  providers: [Password({ validatePasswordRequirements })],
+  providers: [
+    Password({
+      reset: passwordResetProvider,
+      validatePasswordRequirements,
+    }),
+  ],
 });

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -19,6 +19,10 @@ import {
   type QueryCtx,
 } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
+import {
+  getPasswordAccountForUser,
+  resolveUserForPasswordCredentials,
+} from "../lib/accountCredentials";
 import { requireMembership } from "../lib/auth";
 import {
   EMAIL_CHANGE_MAX_AGE_SECONDS,
@@ -74,7 +78,6 @@ type PhoneNumberWebhookSyncInput = {
   status: string;
 };
 
-type CredentialsDbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
 type CredentialsWriterCtx = Pick<MutationCtx, "db">;
 
 function shouldSyncSmsWebhook(input: PhoneNumberWebhookSyncInput): boolean {
@@ -108,20 +111,8 @@ function buildPhoneNumberWithWebhookState(
   return next;
 }
 
-async function getPasswordAccountForUser(
-  ctx: CredentialsDbCtx,
-  userId: Id<"users">,
-): Promise<Doc<"authAccounts"> | null> {
-  return await ctx.db
-    .query("authAccounts")
-    .withIndex("userIdAndProvider", (q) =>
-      q.eq("userId", userId).eq("provider", "password"),
-    )
-    .unique();
-}
-
 async function assertPasswordEmailAvailable(
-  ctx: CredentialsDbCtx,
+  ctx: Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">,
   input: {
     newEmail: string;
     userId: Id<"users">;
@@ -296,23 +287,7 @@ export const getCurrentUserForPasswordChange = internalQuery({
     authUserId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const authUserId = args.authUserId
-      ? await ctx.db.normalizeId("users", args.authUserId)
-      : null;
-    const authUser = authUserId ? await ctx.db.get(authUserId) : null;
-    const legacyUser = await ctx.db
-      .query("users")
-      .withIndex("by_auth_subject", (q) => q.eq("authSubject", args.authSubject))
-      .unique();
-    const [authPasswordAccount, legacyPasswordAccount] = await Promise.all([
-      authUser ? getPasswordAccountForUser(ctx, authUser._id) : Promise.resolve(null),
-      legacyUser && legacyUser._id !== authUser?._id
-        ? getPasswordAccountForUser(ctx, legacyUser._id)
-        : Promise.resolve(null),
-    ]);
-    const user =
-      authPasswordAccount || !legacyPasswordAccount ? (authUser ?? legacyUser) : legacyUser;
-    const passwordAccount = authPasswordAccount ?? legacyPasswordAccount;
+    const { user, passwordAccount } = await resolveUserForPasswordCredentials(ctx, args);
 
     if (!user) {
       throw new Error("User profile not initialized.");

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -5,7 +5,6 @@ import {
   invalidateSessions,
   modifyAccountCredentials,
   retrieveAccount,
-  signInViaProvider,
 } from "@convex-dev/auth/server";
 import { internal } from "../_generated/api";
 import {
@@ -21,7 +20,12 @@ import {
 } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
-import { EMAIL_CHANGE_PROVIDER_ID, emailChangeProvider } from "../lib/emailChange";
+import {
+  EMAIL_CHANGE_MAX_AGE_SECONDS,
+  EMAIL_CHANGE_PROVIDER_ID,
+  generateEmailChangeToken,
+  sendEmailChangeConfirmation,
+} from "../lib/emailChange";
 import {
   listStaffServiceAssignmentsForBusiness,
   replaceBusinessStaffServiceAssignments,
@@ -482,14 +486,23 @@ export const changeEmail = action({
       newEmail: nextEmail,
       userId: user.userId,
     });
-    await signInViaProvider(
-      ctx as unknown as Parameters<typeof signInViaProvider>[0],
-      emailChangeProvider,
-      {
+    const confirmationToken = generateEmailChangeToken();
+    await ctx.runMutation("auth:store" as any, {
+      args: {
+        type: "createVerificationCode",
         accountId: user.passwordAccountId,
-        params: {
-          email: nextEmail,
-        },
+        provider: EMAIL_CHANGE_PROVIDER_ID,
+        email: nextEmail,
+        code: confirmationToken,
+        expirationTime: Date.now() + EMAIL_CHANGE_MAX_AGE_SECONDS * 1000,
+        allowExtraProviders: true,
+      },
+    });
+    await sendEmailChangeConfirmation(
+      ctx as unknown as Pick<ActionCtx, "runMutation">,
+      {
+        email: nextEmail,
+        token: confirmationToken,
       },
     );
 

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -362,6 +362,7 @@ export const confirmPendingEmailChange = internalMutation({
 
     await ctx.db.patch(account._id, {
       providerAccountId: nextEmail,
+      emailVerified: nextEmail,
     });
     await ctx.db.patch(user._id, {
       email: nextEmail,

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import {
   getAuthSessionId,
+  getAuthUserId,
   invalidateSessions,
   modifyAccountCredentials,
   retrieveAccount,
@@ -202,12 +203,18 @@ export const updateBusinessName = mutation({
 export const getCurrentUserForPasswordChange = internalQuery({
   args: {
     authSubject: v.string(),
+    authUserId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const user = await ctx.db
+    const authUserId = args.authUserId
+      ? await ctx.db.normalizeId("users", args.authUserId)
+      : null;
+    const authUser = authUserId ? await ctx.db.get(authUserId) : null;
+    const legacyUser = await ctx.db
       .query("users")
       .withIndex("by_auth_subject", (q) => q.eq("authSubject", args.authSubject))
       .unique();
+    const user = authUser ?? legacyUser;
 
     if (!user) {
       throw new Error("User profile not initialized.");
@@ -286,6 +293,7 @@ export const changePassword = action({
     if (!identity) {
       throw new Error("Authentication required.");
     }
+    const authUserId = await getAuthUserId(ctx);
 
     validatePasswordRequirements(args.newPassword);
 
@@ -295,6 +303,7 @@ export const changePassword = action({
       passwordAccountEmail: string | null;
     } = await ctx.runQuery(internal.businesses.catalog.getCurrentUserForPasswordChange, {
       authSubject: identity.subject,
+      ...(authUserId ? { authUserId: String(authUserId) } : {}),
     });
     const accountEmail = user.passwordAccountEmail ?? user.email;
 
@@ -340,6 +349,7 @@ export const changeEmail = action({
     if (!identity) {
       throw new Error("Authentication required.");
     }
+    const authUserId = await getAuthUserId(ctx);
 
     const nextEmail = args.newEmail.trim().toLowerCase();
     if (!nextEmail) {
@@ -352,6 +362,7 @@ export const changeEmail = action({
       passwordAccountEmail: string | null;
     } = await ctx.runQuery(internal.businesses.catalog.getCurrentUserForPasswordChange, {
       authSubject: identity.subject,
+      ...(authUserId ? { authUserId: String(authUserId) } : {}),
     });
     const accountEmail = user.passwordAccountEmail ?? user.email;
 

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -5,6 +5,7 @@ import {
   invalidateSessions,
   modifyAccountCredentials,
   retrieveAccount,
+  signInViaProvider,
 } from "@convex-dev/auth/server";
 import { internal } from "../_generated/api";
 import {
@@ -15,9 +16,12 @@ import {
   mutation,
   query,
   type ActionCtx,
+  type MutationCtx,
+  type QueryCtx,
 } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
+import { EMAIL_CHANGE_PROVIDER_ID, emailChangeProvider } from "../lib/emailChange";
 import {
   listStaffServiceAssignmentsForBusiness,
   replaceBusinessStaffServiceAssignments,
@@ -67,6 +71,8 @@ type PhoneNumberWebhookSyncInput = {
   status: string;
 };
 
+type CredentialsDbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+
 function shouldSyncSmsWebhook(input: PhoneNumberWebhookSyncInput): boolean {
   return Boolean(input.twilioPhoneSid && input.smsEnabled && input.status === "active");
 }
@@ -96,6 +102,58 @@ function buildPhoneNumberWithWebhookState(
   }
 
   return next;
+}
+
+async function getPasswordAccountForUser(
+  ctx: CredentialsDbCtx,
+  userId: Id<"users">,
+): Promise<Doc<"authAccounts"> | null> {
+  return await ctx.db
+    .query("authAccounts")
+    .withIndex("userIdAndProvider", (q) =>
+      q.eq("userId", userId).eq("provider", "password"),
+    )
+    .unique();
+}
+
+async function assertPasswordEmailAvailable(
+  ctx: CredentialsDbCtx,
+  input: {
+    newEmail: string;
+    userId: Id<"users">;
+    currentAccountId?: Id<"authAccounts">;
+  },
+): Promise<void> {
+  const duplicateAccount = await ctx.db
+    .query("authAccounts")
+    .withIndex("providerAndAccountId", (q) =>
+      q.eq("provider", "password").eq("providerAccountId", input.newEmail),
+    )
+    .unique();
+
+  if (
+    duplicateAccount &&
+    (!input.currentAccountId || duplicateAccount._id !== input.currentAccountId)
+  ) {
+    throw new Error("An account with that email already exists.");
+  }
+
+  const duplicateUser = await ctx.db
+    .query("users")
+    .withIndex("email", (q) => q.eq("email", input.newEmail))
+    .unique();
+
+  if (duplicateUser && duplicateUser._id !== input.userId) {
+    throw new Error("An account with that email already exists.");
+  }
+}
+
+async function hashVerificationCode(code: string): Promise<string> {
+  const encoded = new TextEncoder().encode(code);
+  const hash = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(hash), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
 }
 
 export const resolveBusinessByPhoneNumber = internalQuery({
@@ -230,56 +288,87 @@ export const getCurrentUserForPasswordChange = internalQuery({
     return {
       userId: user._id,
       email: user.email ?? null,
+      passwordAccountId: passwordAccount?._id ?? null,
       passwordAccountEmail: passwordAccount?.providerAccountId ?? null,
     };
   },
 });
 
-export const updatePasswordAccountEmail = internalMutation({
+export const assertPendingEmailChangeTarget = internalQuery({
   args: {
     newEmail: v.string(),
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const existingAccount = await ctx.db
-      .query("authAccounts")
-      .withIndex("userIdAndProvider", (q) =>
-        q.eq("userId", args.userId).eq("provider", "password"),
-      )
-      .unique();
-
-    if (!existingAccount) {
+    const passwordAccount = await getPasswordAccountForUser(ctx, args.userId);
+    if (!passwordAccount) {
       throw new Error("Password account not found.");
     }
 
-    const duplicateAccount = await ctx.db
-      .query("authAccounts")
-      .withIndex("providerAndAccountId", (q) =>
-        q.eq("provider", "password").eq("providerAccountId", args.newEmail),
-      )
-      .unique();
-
-    if (duplicateAccount && duplicateAccount._id !== existingAccount._id) {
-      throw new Error("An account with that email already exists.");
-    }
-
-    const duplicateUser = await ctx.db
-      .query("users")
-      .withIndex("email", (q) => q.eq("email", args.newEmail))
-      .unique();
-
-    if (duplicateUser && duplicateUser._id !== args.userId) {
-      throw new Error("An account with that email already exists.");
-    }
-
-    await ctx.db.patch(existingAccount._id, {
-      providerAccountId: args.newEmail,
-    });
-    await ctx.db.patch(args.userId, {
-      email: args.newEmail,
+    await assertPasswordEmailAvailable(ctx, {
+      newEmail: args.newEmail,
+      userId: args.userId,
+      currentAccountId: passwordAccount._id,
     });
 
     return null;
+  },
+});
+
+export const confirmPendingEmailChange = internalMutation({
+  args: {
+    codeHash: v.string(),
+    email: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const verificationCode = await ctx.db
+      .query("authVerificationCodes")
+      .withIndex("code", (q) => q.eq("code", args.codeHash))
+      .unique();
+
+    if (!verificationCode || verificationCode.provider !== EMAIL_CHANGE_PROVIDER_ID) {
+      throw new Error("Invalid or expired email confirmation link.");
+    }
+
+    if (verificationCode.expirationTime < Date.now()) {
+      await ctx.db.delete(verificationCode._id);
+      throw new Error("Invalid or expired email confirmation link.");
+    }
+
+    const nextEmail = verificationCode.emailVerified?.trim().toLowerCase();
+    if (!nextEmail || nextEmail !== args.email) {
+      throw new Error("Invalid or expired email confirmation link.");
+    }
+
+    const account = await ctx.db.get(verificationCode.accountId);
+    if (!account || account.provider !== "password") {
+      throw new Error("Password account not found.");
+    }
+
+    const user = await ctx.db.get(account.userId);
+    if (!user) {
+      throw new Error("User profile not initialized.");
+    }
+
+    await assertPasswordEmailAvailable(ctx, {
+      newEmail: nextEmail,
+      userId: user._id,
+      currentAccountId: account._id,
+    });
+
+    await ctx.db.patch(account._id, {
+      providerAccountId: nextEmail,
+    });
+    await ctx.db.patch(user._id, {
+      email: nextEmail,
+      emailVerificationTime: Date.now(),
+    });
+    await ctx.db.delete(verificationCode._id);
+
+    return {
+      email: nextEmail,
+      userId: user._id,
+    };
   },
 });
 
@@ -300,6 +389,7 @@ export const changePassword = action({
     const user: {
       userId: Id<"users">;
       email: string | null;
+      passwordAccountId: Id<"authAccounts"> | null;
       passwordAccountEmail: string | null;
     } = await ctx.runQuery(internal.businesses.catalog.getCurrentUserForPasswordChange, {
       authSubject: identity.subject,
@@ -359,6 +449,7 @@ export const changeEmail = action({
     const user: {
       userId: Id<"users">;
       email: string | null;
+      passwordAccountId: Id<"authAccounts"> | null;
       passwordAccountEmail: string | null;
     } = await ctx.runQuery(internal.businesses.catalog.getCurrentUserForPasswordChange, {
       authSubject: identity.subject,
@@ -373,6 +464,9 @@ export const changeEmail = action({
     if (accountEmail === nextEmail) {
       throw new Error("This email is already on your account.");
     }
+    if (!user.passwordAccountId) {
+      throw new Error("Password account not found.");
+    }
 
     const authCtx = ctx as unknown as Parameters<typeof retrieveAccount>[0];
 
@@ -384,19 +478,47 @@ export const changeEmail = action({
       },
     });
 
-    await ctx.runMutation(internal.businesses.catalog.updatePasswordAccountEmail, {
+    await ctx.runQuery(internal.businesses.catalog.assertPendingEmailChangeTarget, {
       newEmail: nextEmail,
       userId: user.userId,
     });
-
-    const sessionId = await getAuthSessionId(authCtx);
-    await invalidateSessions(authCtx, {
-      userId: user.userId,
-      ...(sessionId ? { except: [sessionId] } : {}),
-    });
+    await signInViaProvider(
+      ctx as unknown as Parameters<typeof signInViaProvider>[0],
+      emailChangeProvider,
+      {
+        accountId: user.passwordAccountId,
+        params: {
+          email: nextEmail,
+        },
+      },
+    );
 
     return {
       email: nextEmail,
+    };
+  },
+});
+
+export const confirmEmailChange = action({
+  args: {
+    code: v.string(),
+    email: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ email: string }> => {
+    const code = args.code.trim();
+    const email = args.email.trim().toLowerCase();
+
+    if (!code || !email) {
+      throw new Error("Invalid or expired email confirmation link.");
+    }
+
+    const result = await ctx.runMutation(internal.businesses.catalog.confirmPendingEmailChange, {
+      codeHash: await hashVerificationCode(code),
+      email,
+    });
+
+    return {
+      email: result.email,
     };
   },
 });

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -310,13 +310,20 @@ export const assertPendingEmailChangeTarget = internalQuery({
       throw new Error("Password account not found.");
     }
 
-    await assertPasswordEmailAvailable(ctx, {
-      newEmail: args.newEmail,
-      userId: args.userId,
-      currentAccountId: passwordAccount._id,
-    });
-
-    return null;
+    try {
+      await assertPasswordEmailAvailable(ctx, {
+        newEmail: args.newEmail,
+        userId: args.userId,
+        currentAccountId: passwordAccount._id,
+      });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (message.includes("already exists")) {
+        return false;
+      }
+      throw error;
+    }
   },
 });
 
@@ -512,10 +519,18 @@ export const changeEmail = action({
       },
     });
 
-    await ctx.runQuery(internal.businesses.catalog.assertPendingEmailChangeTarget, {
-      newEmail: nextEmail,
-      userId: user.userId,
-    });
+    const canSendConfirmation: boolean = await ctx.runQuery(
+      internal.businesses.catalog.assertPendingEmailChangeTarget,
+      {
+        newEmail: nextEmail,
+        userId: user.userId,
+      },
+    );
+    if (!canSendConfirmation) {
+      return {
+        email: nextEmail,
+      };
+    }
     const confirmationToken = generateEmailChangeToken();
     const createPendingEmailChangeResult: null = await ctx.runMutation(
       (internal as any).businesses.catalog.createPendingEmailChange,
@@ -557,6 +572,12 @@ export const confirmEmailChange = action({
     const result = await ctx.runMutation(internal.businesses.catalog.confirmPendingEmailChange, {
       codeHash: await hashVerificationCode(code),
       email,
+    });
+    const authCtx = ctx as unknown as Parameters<typeof invalidateSessions>[0];
+    const sessionId = await getAuthSessionId(authCtx);
+    await invalidateSessions(authCtx, {
+      userId: result.userId,
+      ...(sessionId ? { except: [sessionId] } : {}),
     });
 
     return {

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -22,7 +22,6 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
 import {
   EMAIL_CHANGE_MAX_AGE_SECONDS,
-  EMAIL_CHANGE_PROVIDER_ID,
   generateEmailChangeToken,
   sendEmailChangeConfirmation,
 } from "../lib/emailChange";
@@ -76,6 +75,7 @@ type PhoneNumberWebhookSyncInput = {
 };
 
 type CredentialsDbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type CredentialsWriterCtx = Pick<MutationCtx, "db">;
 
 function shouldSyncSmsWebhook(input: PhoneNumberWebhookSyncInput): boolean {
   return Boolean(input.twilioPhoneSid && input.smsEnabled && input.status === "active");
@@ -158,6 +158,34 @@ async function hashVerificationCode(code: string): Promise<string> {
   return Array.from(new Uint8Array(hash), (byte) =>
     byte.toString(16).padStart(2, "0"),
   ).join("");
+}
+
+async function clearPendingEmailChangesForAccount(
+  ctx: CredentialsWriterCtx,
+  accountId: Id<"authAccounts">,
+): Promise<void> {
+  const existingRequests = await ctx.db
+    .query("pending_email_changes")
+    .withIndex("by_account_id", (q) => q.eq("accountId", accountId))
+    .collect();
+
+  for (const existingRequest of existingRequests) {
+    await ctx.db.delete(existingRequest._id);
+  }
+}
+
+async function clearVerificationCodesForAccount(
+  ctx: CredentialsWriterCtx,
+  accountId: Id<"authAccounts">,
+): Promise<void> {
+  const verificationCodes = await ctx.db
+    .query("authVerificationCodes")
+    .withIndex("accountId", (q) => q.eq("accountId", accountId))
+    .collect();
+
+  for (const verificationCode of verificationCodes) {
+    await ctx.db.delete(verificationCode._id);
+  }
 }
 
 export const resolveBusinessByPhoneNumber = internalQuery({
@@ -335,14 +363,7 @@ export const createPendingEmailChange = internalMutation({
     expirationTime: v.number(),
   },
   handler: async (ctx, args) => {
-    const existingRequests = await ctx.db
-      .query("pending_email_changes")
-      .withIndex("by_account_id", (q) => q.eq("accountId", args.accountId))
-      .collect();
-
-    for (const existingRequest of existingRequests) {
-      await ctx.db.delete(existingRequest._id);
-    }
+    await clearPendingEmailChangesForAccount(ctx, args.accountId);
 
     await ctx.db.insert("pending_email_changes", {
       accountId: args.accountId,
@@ -396,6 +417,7 @@ export const confirmPendingEmailChange = internalMutation({
       currentAccountId: account._id,
     });
 
+    await clearVerificationCodesForAccount(ctx, account._id);
     await ctx.db.patch(account._id, {
       providerAccountId: nextEmail,
       emailVerified: nextEmail,
@@ -527,6 +549,13 @@ export const changeEmail = action({
       },
     );
     if (!canSendConfirmation) {
+      const clearPendingEmailChangesResult: null = await ctx.runMutation(
+        (internal as any).businesses.catalog.clearPendingEmailChanges,
+        {
+          accountId: user.passwordAccountId,
+        },
+      );
+      void clearPendingEmailChangesResult;
       return {
         email: nextEmail,
       };
@@ -553,6 +582,16 @@ export const changeEmail = action({
     return {
       email: nextEmail,
     };
+  },
+});
+
+export const clearPendingEmailChanges = internalMutation({
+  args: {
+    accountId: v.id("authAccounts"),
+  },
+  handler: async (ctx, args) => {
+    await clearPendingEmailChangesForAccount(ctx, args.accountId);
+    return null;
   },
 });
 

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -213,10 +213,66 @@ export const getCurrentUserForPasswordChange = internalQuery({
       throw new Error("User profile not initialized.");
     }
 
+    const passwordAccount = await ctx.db
+      .query("authAccounts")
+      .withIndex("userIdAndProvider", (q) =>
+        q.eq("userId", user._id).eq("provider", "password"),
+      )
+      .unique();
+
     return {
       userId: user._id,
       email: user.email ?? null,
+      passwordAccountEmail: passwordAccount?.providerAccountId ?? null,
     };
+  },
+});
+
+export const updatePasswordAccountEmail = internalMutation({
+  args: {
+    newEmail: v.string(),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const existingAccount = await ctx.db
+      .query("authAccounts")
+      .withIndex("userIdAndProvider", (q) =>
+        q.eq("userId", args.userId).eq("provider", "password"),
+      )
+      .unique();
+
+    if (!existingAccount) {
+      throw new Error("Password account not found.");
+    }
+
+    const duplicateAccount = await ctx.db
+      .query("authAccounts")
+      .withIndex("providerAndAccountId", (q) =>
+        q.eq("provider", "password").eq("providerAccountId", args.newEmail),
+      )
+      .unique();
+
+    if (duplicateAccount && duplicateAccount._id !== existingAccount._id) {
+      throw new Error("An account with that email already exists.");
+    }
+
+    const duplicateUser = await ctx.db
+      .query("users")
+      .withIndex("email", (q) => q.eq("email", args.newEmail))
+      .unique();
+
+    if (duplicateUser && duplicateUser._id !== args.userId) {
+      throw new Error("An account with that email already exists.");
+    }
+
+    await ctx.db.patch(existingAccount._id, {
+      providerAccountId: args.newEmail,
+    });
+    await ctx.db.patch(args.userId, {
+      email: args.newEmail,
+    });
+
+    return null;
   },
 });
 
@@ -233,12 +289,16 @@ export const changePassword = action({
 
     validatePasswordRequirements(args.newPassword);
 
-    const user = await ctx.runQuery(
-      internal.businesses.catalog.getCurrentUserForPasswordChange,
-      { authSubject: identity.subject },
-    );
+    const user: {
+      userId: Id<"users">;
+      email: string | null;
+      passwordAccountEmail: string | null;
+    } = await ctx.runQuery(internal.businesses.catalog.getCurrentUserForPasswordChange, {
+      authSubject: identity.subject,
+    });
+    const accountEmail = user.passwordAccountEmail ?? user.email;
 
-    if (!user.email) {
+    if (!accountEmail) {
       throw new Error("No email is configured for this account.");
     }
 
@@ -247,7 +307,7 @@ export const changePassword = action({
     await retrieveAccount(authCtx, {
       provider: "password",
       account: {
-        id: user.email,
+        id: accountEmail,
         secret: args.currentPassword,
       },
     });
@@ -255,7 +315,7 @@ export const changePassword = action({
     await modifyAccountCredentials(authCtx, {
       provider: "password",
       account: {
-        id: user.email,
+        id: accountEmail,
         secret: args.newPassword,
       },
     });
@@ -267,6 +327,66 @@ export const changePassword = action({
     });
 
     return null;
+  },
+});
+
+export const changeEmail = action({
+  args: {
+    currentPassword: v.string(),
+    newEmail: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ email: string }> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Authentication required.");
+    }
+
+    const nextEmail = args.newEmail.trim().toLowerCase();
+    if (!nextEmail) {
+      throw new Error("New email is required.");
+    }
+
+    const user: {
+      userId: Id<"users">;
+      email: string | null;
+      passwordAccountEmail: string | null;
+    } = await ctx.runQuery(internal.businesses.catalog.getCurrentUserForPasswordChange, {
+      authSubject: identity.subject,
+    });
+    const accountEmail = user.passwordAccountEmail ?? user.email;
+
+    if (!accountEmail) {
+      throw new Error("No email is configured for this account.");
+    }
+
+    if (accountEmail === nextEmail) {
+      throw new Error("This email is already on your account.");
+    }
+
+    const authCtx = ctx as unknown as Parameters<typeof retrieveAccount>[0];
+
+    await retrieveAccount(authCtx, {
+      provider: "password",
+      account: {
+        id: accountEmail,
+        secret: args.currentPassword,
+      },
+    });
+
+    await ctx.runMutation(internal.businesses.catalog.updatePasswordAccountEmail, {
+      newEmail: nextEmail,
+      userId: user.userId,
+    });
+
+    const sessionId = await getAuthSessionId(authCtx);
+    await invalidateSessions(authCtx, {
+      userId: user.userId,
+      ...(sessionId ? { except: [sessionId] } : {}),
+    });
+
+    return {
+      email: nextEmail,
+    };
   },
 });
 

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -276,18 +276,19 @@ export const getCurrentUserForPasswordChange = internalQuery({
       .query("users")
       .withIndex("by_auth_subject", (q) => q.eq("authSubject", args.authSubject))
       .unique();
-    const user = authUser ?? legacyUser;
+    const [authPasswordAccount, legacyPasswordAccount] = await Promise.all([
+      authUser ? getPasswordAccountForUser(ctx, authUser._id) : Promise.resolve(null),
+      legacyUser && legacyUser._id !== authUser?._id
+        ? getPasswordAccountForUser(ctx, legacyUser._id)
+        : Promise.resolve(null),
+    ]);
+    const user =
+      authPasswordAccount || !legacyPasswordAccount ? (authUser ?? legacyUser) : legacyUser;
+    const passwordAccount = authPasswordAccount ?? legacyPasswordAccount;
 
     if (!user) {
       throw new Error("User profile not initialized.");
     }
-
-    const passwordAccount = await ctx.db
-      .query("authAccounts")
-      .withIndex("userIdAndProvider", (q) =>
-        q.eq("userId", user._id).eq("provider", "password"),
-      )
-      .unique();
 
     return {
       userId: user._id,
@@ -319,32 +320,60 @@ export const assertPendingEmailChangeTarget = internalQuery({
   },
 });
 
+export const createPendingEmailChange = internalMutation({
+  args: {
+    accountId: v.id("authAccounts"),
+    codeHash: v.string(),
+    email: v.string(),
+    expirationTime: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existingRequests = await ctx.db
+      .query("pending_email_changes")
+      .withIndex("by_account_id", (q) => q.eq("accountId", args.accountId))
+      .collect();
+
+    for (const existingRequest of existingRequests) {
+      await ctx.db.delete(existingRequest._id);
+    }
+
+    await ctx.db.insert("pending_email_changes", {
+      accountId: args.accountId,
+      codeHash: args.codeHash,
+      expirationTime: args.expirationTime,
+      email: args.email,
+    });
+
+    return null;
+  },
+});
+
 export const confirmPendingEmailChange = internalMutation({
   args: {
     codeHash: v.string(),
     email: v.string(),
   },
   handler: async (ctx, args) => {
-    const verificationCode = await ctx.db
-      .query("authVerificationCodes")
-      .withIndex("code", (q) => q.eq("code", args.codeHash))
+    const pendingEmailChange = await ctx.db
+      .query("pending_email_changes")
+      .withIndex("by_code_hash", (q) => q.eq("codeHash", args.codeHash))
       .unique();
 
-    if (!verificationCode || verificationCode.provider !== EMAIL_CHANGE_PROVIDER_ID) {
+    if (!pendingEmailChange) {
       throw new Error("Invalid or expired email confirmation link.");
     }
 
-    if (verificationCode.expirationTime < Date.now()) {
-      await ctx.db.delete(verificationCode._id);
+    if (pendingEmailChange.expirationTime < Date.now()) {
+      await ctx.db.delete(pendingEmailChange._id);
       throw new Error("Invalid or expired email confirmation link.");
     }
 
-    const nextEmail = verificationCode.emailVerified?.trim().toLowerCase();
+    const nextEmail = pendingEmailChange.email.trim().toLowerCase();
     if (!nextEmail || nextEmail !== args.email) {
       throw new Error("Invalid or expired email confirmation link.");
     }
 
-    const account = await ctx.db.get(verificationCode.accountId);
+    const account = await ctx.db.get(pendingEmailChange.accountId);
     if (!account || account.provider !== "password") {
       throw new Error("Password account not found.");
     }
@@ -368,7 +397,7 @@ export const confirmPendingEmailChange = internalMutation({
       email: nextEmail,
       emailVerificationTime: Date.now(),
     });
-    await ctx.db.delete(verificationCode._id);
+    await ctx.db.delete(pendingEmailChange._id);
 
     return {
       email: nextEmail,
@@ -488,17 +517,15 @@ export const changeEmail = action({
       userId: user.userId,
     });
     const confirmationToken = generateEmailChangeToken();
-    await ctx.runMutation("auth:store" as any, {
-      args: {
-        type: "createVerificationCode",
+    const createPendingEmailChangeResult: null = await ctx.runMutation(
+      (internal as any).businesses.catalog.createPendingEmailChange,
+      {
         accountId: user.passwordAccountId,
-        provider: EMAIL_CHANGE_PROVIDER_ID,
+        codeHash: await hashVerificationCode(confirmationToken),
         email: nextEmail,
-        code: confirmationToken,
         expirationTime: Date.now() + EMAIL_CHANGE_MAX_AGE_SECONDS * 1000,
-        allowExtraProviders: true,
       },
-    });
+    );
     await sendEmailChangeConfirmation(
       ctx as unknown as Pick<ActionCtx, "runMutation">,
       {
@@ -506,6 +533,7 @@ export const changeEmail = action({
         token: confirmationToken,
       },
     );
+    void createPendingEmailChangeResult;
 
     return {
       email: nextEmail,

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,6 +1,7 @@
 import { defineApp } from "convex/server";
 import agent from "@convex-dev/agent/convex.config";
 import rag from "@convex-dev/rag/convex.config";
+import resend from "@convex-dev/resend/convex.config";
 import persistentTextStreaming from "@convex-dev/persistent-text-streaming/convex.config";
 import workflow from "@convex-dev/workflow/convex.config";
 import workpool from "@convex-dev/workpool/convex.config";
@@ -11,6 +12,7 @@ const app = defineApp();
 
 app.use(agent);
 app.use(rag);
+app.use(resend);
 app.use(persistentTextStreaming);
 app.use(workflow);
 app.use(workpool, { name: "highPriorityWorkpool" });

--- a/convex/lib/accountCredentials.ts
+++ b/convex/lib/accountCredentials.ts
@@ -1,0 +1,74 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+type CredentialsDbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type CredentialsAuthCtx =
+  | Pick<QueryCtx, "auth" | "db">
+  | Pick<MutationCtx, "auth" | "db">;
+
+export async function getPasswordAccountForUser(
+  ctx: CredentialsDbCtx,
+  userId: Id<"users">,
+): Promise<Doc<"authAccounts"> | null> {
+  return await ctx.db
+    .query("authAccounts")
+    .withIndex("userIdAndProvider", (q) =>
+      q.eq("userId", userId).eq("provider", "password"),
+    )
+    .unique();
+}
+
+export async function resolveUserForPasswordCredentials(
+  ctx: CredentialsDbCtx,
+  input: {
+    authSubject: string;
+    authUserId?: string | null;
+  },
+): Promise<{
+  user: Doc<"users"> | null;
+  passwordAccount: Doc<"authAccounts"> | null;
+}> {
+  const authUserId = input.authUserId
+    ? await ctx.db.normalizeId("users", input.authUserId)
+    : null;
+  const authUser = authUserId ? await ctx.db.get(authUserId) : null;
+  const legacyUser = await ctx.db
+    .query("users")
+    .withIndex("by_auth_subject", (q) => q.eq("authSubject", input.authSubject))
+    .unique();
+  const [authPasswordAccount, legacyPasswordAccount] = await Promise.all([
+    authUser ? getPasswordAccountForUser(ctx, authUser._id) : Promise.resolve(null),
+    legacyUser && legacyUser._id !== authUser?._id
+      ? getPasswordAccountForUser(ctx, legacyUser._id)
+      : Promise.resolve(null),
+  ]);
+
+  return {
+    user:
+      authPasswordAccount || !legacyPasswordAccount ? (authUser ?? legacyUser) : legacyUser,
+    passwordAccount: authPasswordAccount ?? legacyPasswordAccount,
+  };
+}
+
+export async function resolveCurrentUserForPasswordCredentials(
+  ctx: CredentialsAuthCtx,
+): Promise<{
+  user: Doc<"users"> | null;
+  passwordAccount: Doc<"authAccounts"> | null;
+}> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    return {
+      user: null,
+      passwordAccount: null,
+    };
+  }
+
+  const authUserId = await getAuthUserId(ctx);
+  return await resolveUserForPasswordCredentials(ctx, {
+    authSubject: identity.subject,
+    ...(authUserId ? { authUserId: String(authUserId) } : {}),
+  });
+}

--- a/convex/lib/emailChange.ts
+++ b/convex/lib/emailChange.ts
@@ -5,6 +5,7 @@ import { sendTransactionalEmail } from "./providers/email";
 
 export const EMAIL_CHANGE_PROVIDER_ID = "email-change";
 export const EMAIL_CHANGE_MAX_AGE_SECONDS = 60 * 30;
+const EMAIL_CHANGE_TOKEN_LENGTH = 32;
 
 const EMAIL_CHANGE_CONFIRMATION_PATH = "/confirm-email-change";
 
@@ -27,7 +28,36 @@ export const emailChangeProvider = Email({
   }) as any,
 });
 
-function buildEmailChangeConfirmationUrl(identifier: string, token: string): string {
+export async function sendEmailChangeConfirmation(
+  ctx: Pick<ActionCtx, "runMutation">,
+  input: {
+    email: string;
+    token: string;
+  },
+): Promise<void> {
+  await sendTransactionalEmail(ctx, {
+    template: "verify_email",
+    to: input.email,
+    subject: "Confirm your new email",
+    variables: {
+      confirmUrl: buildEmailChangeConfirmationUrl(input.email, input.token),
+      expiresMinutes: String(EMAIL_CHANGE_MAX_AGE_SECONDS / 60),
+    },
+  });
+}
+
+export function generateEmailChangeToken(length: number = EMAIL_CHANGE_TOKEN_LENGTH): string {
+  const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+
+  return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join("");
+}
+
+export function buildEmailChangeConfirmationUrl(
+  identifier: string,
+  token: string,
+): string {
   const siteUrl = process.env.SITE_URL;
   if (!siteUrl) {
     throw new Error("SITE_URL is required to build email confirmation links.");

--- a/convex/lib/emailChange.ts
+++ b/convex/lib/emailChange.ts
@@ -1,0 +1,40 @@
+import { Email } from "@convex-dev/auth/providers/Email";
+import type { ActionCtx } from "../_generated/server";
+
+import { sendTransactionalEmail } from "./providers/email";
+
+export const EMAIL_CHANGE_PROVIDER_ID = "email-change";
+export const EMAIL_CHANGE_MAX_AGE_SECONDS = 60 * 30;
+
+const EMAIL_CHANGE_CONFIRMATION_PATH = "/confirm-email-change";
+
+export const emailChangeProvider = Email({
+  id: EMAIL_CHANGE_PROVIDER_ID,
+  maxAge: EMAIL_CHANGE_MAX_AGE_SECONDS,
+  sendVerificationRequest: (async (
+    { identifier, token }: { identifier: string; token: string },
+    ctx: Pick<ActionCtx, "runMutation">,
+  ) => {
+    await sendTransactionalEmail(ctx, {
+      template: "verify_email",
+      to: identifier,
+      subject: "Confirm your new email",
+      variables: {
+        confirmUrl: buildEmailChangeConfirmationUrl(identifier, token),
+        expiresMinutes: String(EMAIL_CHANGE_MAX_AGE_SECONDS / 60),
+      },
+    });
+  }) as any,
+});
+
+function buildEmailChangeConfirmationUrl(identifier: string, token: string): string {
+  const siteUrl = process.env.SITE_URL;
+  if (!siteUrl) {
+    throw new Error("SITE_URL is required to build email confirmation links.");
+  }
+
+  const url = new URL(EMAIL_CHANGE_CONFIRMATION_PATH, siteUrl);
+  url.searchParams.set("token", token);
+  url.searchParams.set("email", identifier);
+  return url.toString();
+}

--- a/convex/lib/emailChange.ts
+++ b/convex/lib/emailChange.ts
@@ -1,4 +1,3 @@
-import { Email } from "@convex-dev/auth/providers/Email";
 import type { ActionCtx } from "../_generated/server";
 
 import { sendTransactionalEmail } from "./providers/email";
@@ -8,25 +7,6 @@ export const EMAIL_CHANGE_MAX_AGE_SECONDS = 60 * 30;
 const EMAIL_CHANGE_TOKEN_LENGTH = 32;
 
 const EMAIL_CHANGE_CONFIRMATION_PATH = "/confirm-email-change";
-
-export const emailChangeProvider = Email({
-  id: EMAIL_CHANGE_PROVIDER_ID,
-  maxAge: EMAIL_CHANGE_MAX_AGE_SECONDS,
-  sendVerificationRequest: (async (
-    { identifier, token }: { identifier: string; token: string },
-    ctx: Pick<ActionCtx, "runMutation">,
-  ) => {
-    await sendTransactionalEmail(ctx, {
-      template: "verify_email",
-      to: identifier,
-      subject: "Confirm your new email",
-      variables: {
-        confirmUrl: buildEmailChangeConfirmationUrl(identifier, token),
-        expiresMinutes: String(EMAIL_CHANGE_MAX_AGE_SECONDS / 60),
-      },
-    });
-  }) as any,
-});
 
 export async function sendEmailChangeConfirmation(
   ctx: Pick<ActionCtx, "runMutation">,

--- a/convex/lib/node/imagePreviews.ts
+++ b/convex/lib/node/imagePreviews.ts
@@ -1,6 +1,6 @@
 "use node";
 
-import { Jimp, JimpMime } from "jimp";
+import sharp from "sharp";
 
 import { MAX_SMS_ATTACHMENT_UPLOAD_BYTES } from "../messageAttachments";
 
@@ -41,33 +41,23 @@ export async function generateImagePreview(
 
   let previewBuffer: Buffer;
   try {
-    const image = await withTimeout(
-      Jimp.fromBuffer(sourceBuffer),
-      MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS,
-    );
-
-    const inputPixels = image.bitmap.width * image.bitmap.height;
-    if (
-      inputPixels === 0 ||
-      inputPixels > MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS
-    ) {
-      return null;
-    }
-
-    if (
-      image.bitmap.width > MESSAGE_IMAGE_PREVIEW_WIDTH ||
-      image.bitmap.height > MESSAGE_IMAGE_PREVIEW_HEIGHT
-    ) {
-      image.scaleToFit({
-        w: MESSAGE_IMAGE_PREVIEW_WIDTH,
-        h: MESSAGE_IMAGE_PREVIEW_HEIGHT,
-      });
-    }
-
-    previewBuffer = await withTimeout(
-      image.getBuffer(JimpMime.jpeg, { quality: MESSAGE_IMAGE_PREVIEW_QUALITY }),
-      MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS,
-    );
+    previewBuffer = await sharp(sourceBuffer, {
+      failOn: "error",
+      limitInputPixels: MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS,
+    })
+      .rotate()
+      .resize({
+        width: MESSAGE_IMAGE_PREVIEW_WIDTH,
+        height: MESSAGE_IMAGE_PREVIEW_HEIGHT,
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .jpeg({
+        quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
+        mozjpeg: true,
+      })
+      .timeout({ seconds: MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS })
+      .toBuffer();
   } catch {
     return null;
   }
@@ -82,23 +72,4 @@ export async function generateImagePreview(
     contentType: "image/jpeg",
     byteLength: previewBuffer.length,
   };
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutSeconds: number): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          reject(new Error("Image preview generation timed out."));
-        }, timeoutSeconds * 1000);
-      }),
-    ]);
-  } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  }
 }

--- a/convex/lib/node/imagePreviews.ts
+++ b/convex/lib/node/imagePreviews.ts
@@ -1,6 +1,6 @@
 "use node";
 
-import sharp from "sharp";
+import { Jimp, JimpMime } from "jimp";
 
 import { MAX_SMS_ATTACHMENT_UPLOAD_BYTES } from "../messageAttachments";
 
@@ -39,23 +39,38 @@ export async function generateImagePreview(
     return null;
   }
 
-  const previewBuffer = await sharp(sourceBuffer, {
-    failOn: "error",
-    limitInputPixels: MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS,
-  })
-    .rotate()
-    .resize({
-      width: MESSAGE_IMAGE_PREVIEW_WIDTH,
-      height: MESSAGE_IMAGE_PREVIEW_HEIGHT,
-      fit: "inside",
-      withoutEnlargement: true,
-    })
-    .jpeg({
-      quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
-      mozjpeg: true,
-    })
-    .timeout({ seconds: MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS })
-    .toBuffer();
+  let previewBuffer: Buffer;
+  try {
+    const image = await withTimeout(
+      Jimp.fromBuffer(sourceBuffer),
+      MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS,
+    );
+
+    const inputPixels = image.bitmap.width * image.bitmap.height;
+    if (
+      inputPixels === 0 ||
+      inputPixels > MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS
+    ) {
+      return null;
+    }
+
+    if (
+      image.bitmap.width > MESSAGE_IMAGE_PREVIEW_WIDTH ||
+      image.bitmap.height > MESSAGE_IMAGE_PREVIEW_HEIGHT
+    ) {
+      image.scaleToFit({
+        w: MESSAGE_IMAGE_PREVIEW_WIDTH,
+        h: MESSAGE_IMAGE_PREVIEW_HEIGHT,
+      });
+    }
+
+    previewBuffer = await withTimeout(
+      image.getBuffer(JimpMime.jpeg, { quality: MESSAGE_IMAGE_PREVIEW_QUALITY }),
+      MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS,
+    );
+  } catch {
+    return null;
+  }
 
   if (previewBuffer.length === 0) {
     return null;
@@ -67,4 +82,23 @@ export async function generateImagePreview(
     contentType: "image/jpeg",
     byteLength: previewBuffer.length,
   };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutSeconds: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error("Image preview generation timed out."));
+        }, timeoutSeconds * 1000);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }

--- a/convex/lib/node/imagePreviews.ts
+++ b/convex/lib/node/imagePreviews.ts
@@ -1,6 +1,6 @@
 "use node";
 
-import sharp from "sharp";
+import { Jimp, JimpMime } from "jimp";
 
 import { MAX_SMS_ATTACHMENT_UPLOAD_BYTES } from "../messageAttachments";
 
@@ -39,23 +39,19 @@ export async function generateImagePreview(
     return null;
   }
 
-  const previewBuffer = await sharp(sourceBuffer, {
-    failOn: "error",
-    limitInputPixels: MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS,
-  })
-    .rotate()
-    .resize({
-      width: MESSAGE_IMAGE_PREVIEW_WIDTH,
-      height: MESSAGE_IMAGE_PREVIEW_HEIGHT,
-      fit: "inside",
-      withoutEnlargement: true,
-    })
-    .jpeg({
-      quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
-      mozjpeg: true,
-    })
-    .timeout({ seconds: MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS })
-    .toBuffer();
+  const image = await Jimp.fromBuffer(sourceBuffer);
+  if (image.bitmap.width * image.bitmap.height > MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS) {
+    return null;
+  }
+
+  image.scaleToFit({
+    w: MESSAGE_IMAGE_PREVIEW_WIDTH,
+    h: MESSAGE_IMAGE_PREVIEW_HEIGHT,
+  });
+
+  const previewBuffer = await image.getBuffer(JimpMime.jpeg, {
+    quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
+  });
 
   if (previewBuffer.length === 0) {
     return null;

--- a/convex/lib/node/imagePreviews.ts
+++ b/convex/lib/node/imagePreviews.ts
@@ -1,6 +1,6 @@
 "use node";
 
-import sharp from "sharp";
+import { Jimp, JimpMime } from "jimp";
 
 import { MAX_SMS_ATTACHMENT_UPLOAD_BYTES } from "../messageAttachments";
 
@@ -41,23 +41,33 @@ export async function generateImagePreview(
 
   let previewBuffer: Buffer;
   try {
-    previewBuffer = await sharp(sourceBuffer, {
-      failOn: "error",
-      limitInputPixels: MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS,
-    })
-      .rotate()
-      .resize({
-        width: MESSAGE_IMAGE_PREVIEW_WIDTH,
-        height: MESSAGE_IMAGE_PREVIEW_HEIGHT,
-        fit: "inside",
-        withoutEnlargement: true,
-      })
-      .jpeg({
-        quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
-        mozjpeg: true,
-      })
-      .timeout({ seconds: MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS })
-      .toBuffer();
+    const image = await withTimeout(
+      Jimp.fromBuffer(sourceBuffer),
+      MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS,
+    );
+
+    const inputPixels = image.bitmap.width * image.bitmap.height;
+    if (
+      inputPixels === 0 ||
+      inputPixels > MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS
+    ) {
+      return null;
+    }
+
+    if (
+      image.bitmap.width > MESSAGE_IMAGE_PREVIEW_WIDTH ||
+      image.bitmap.height > MESSAGE_IMAGE_PREVIEW_HEIGHT
+    ) {
+      image.scaleToFit({
+        w: MESSAGE_IMAGE_PREVIEW_WIDTH,
+        h: MESSAGE_IMAGE_PREVIEW_HEIGHT,
+      });
+    }
+
+    previewBuffer = await withTimeout(
+      image.getBuffer(JimpMime.jpeg, { quality: MESSAGE_IMAGE_PREVIEW_QUALITY }),
+      MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS,
+    );
   } catch {
     return null;
   }
@@ -72,4 +82,23 @@ export async function generateImagePreview(
     contentType: "image/jpeg",
     byteLength: previewBuffer.length,
   };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutSeconds: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error("Image preview generation timed out."));
+        }, timeoutSeconds * 1000);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }

--- a/convex/lib/node/imagePreviews.ts
+++ b/convex/lib/node/imagePreviews.ts
@@ -1,6 +1,6 @@
 "use node";
 
-import { Jimp, JimpMime } from "jimp";
+import sharp from "sharp";
 
 import { MAX_SMS_ATTACHMENT_UPLOAD_BYTES } from "../messageAttachments";
 
@@ -39,19 +39,23 @@ export async function generateImagePreview(
     return null;
   }
 
-  const image = await Jimp.fromBuffer(sourceBuffer);
-  if (image.bitmap.width * image.bitmap.height > MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS) {
-    return null;
-  }
-
-  image.scaleToFit({
-    w: MESSAGE_IMAGE_PREVIEW_WIDTH,
-    h: MESSAGE_IMAGE_PREVIEW_HEIGHT,
-  });
-
-  const previewBuffer = await image.getBuffer(JimpMime.jpeg, {
-    quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
-  });
+  const previewBuffer = await sharp(sourceBuffer, {
+    failOn: "error",
+    limitInputPixels: MESSAGE_IMAGE_PREVIEW_MAX_INPUT_PIXELS,
+  })
+    .rotate()
+    .resize({
+      width: MESSAGE_IMAGE_PREVIEW_WIDTH,
+      height: MESSAGE_IMAGE_PREVIEW_HEIGHT,
+      fit: "inside",
+      withoutEnlargement: true,
+    })
+    .jpeg({
+      quality: MESSAGE_IMAGE_PREVIEW_QUALITY,
+      mozjpeg: true,
+    })
+    .timeout({ seconds: MESSAGE_IMAGE_PREVIEW_TIMEOUT_SECONDS })
+    .toBuffer();
 
   if (previewBuffer.length === 0) {
     return null;

--- a/convex/lib/passwordReset.ts
+++ b/convex/lib/passwordReset.ts
@@ -1,0 +1,35 @@
+import { Email } from "@convex-dev/auth/providers/Email";
+import type { ActionCtx } from "../_generated/server";
+
+import { sendTransactionalEmail } from "./providers/email";
+
+export const PASSWORD_RESET_CODE_LENGTH = 8;
+export const PASSWORD_RESET_MAX_AGE_SECONDS = 60 * 15;
+
+export const passwordResetProvider = Email({
+  maxAge: PASSWORD_RESET_MAX_AGE_SECONDS,
+  async generateVerificationToken() {
+    return generateNumericCode(PASSWORD_RESET_CODE_LENGTH);
+  },
+  sendVerificationRequest: (async (
+    { identifier, token }: { identifier: string; token: string },
+    ctx: Pick<ActionCtx, "runMutation">,
+  ) => {
+    await sendTransactionalEmail(ctx, {
+      template: "password_reset",
+      to: identifier,
+      subject: "Reset your password",
+      variables: {
+        code: token,
+        expiresMinutes: String(PASSWORD_RESET_MAX_AGE_SECONDS / 60),
+      },
+    });
+  }) as any,
+});
+
+function generateNumericCode(length: number): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+
+  return Array.from(bytes, (byte) => String(byte % 10)).join("");
+}

--- a/convex/lib/providers/email.ts
+++ b/convex/lib/providers/email.ts
@@ -1,0 +1,136 @@
+import type { EmailProvider } from "@ai-receptionist/providers";
+import { Resend, type ResendOptions } from "@convex-dev/resend";
+
+import { components } from "../../_generated/api";
+import type { ActionCtx, MutationCtx } from "../../_generated/server";
+
+type TransactionalTemplateInput = Parameters<EmailProvider["sendTemplate"]>[0];
+type TransactionalTemplateName = TransactionalTemplateInput["template"];
+type SendEmailCtx = Pick<ActionCtx, "runMutation"> | Pick<MutationCtx, "runMutation">;
+
+const DEFAULT_PASSWORD_RESET_SUBJECT = "Reset your password";
+
+export type TransactionalEmailConfig = {
+  fromAddress: string;
+  resendOptions: ResendOptions;
+};
+
+export function getTransactionalEmailConfig(
+  env: Record<string, string | undefined> = process.env,
+): TransactionalEmailConfig {
+  const fromAddress = env.EMAIL_FROM_ADDRESS;
+  if (!fromAddress) {
+    throw new Error("EMAIL_FROM_ADDRESS is required to send transactional email.");
+  }
+
+  const deploymentMode = env.DEPLOYMENT_MODE ?? "development";
+  const apiKey = env.RESEND_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      deploymentMode === "development"
+        ? "RESEND_API_KEY is required to send email in development test mode."
+        : "RESEND_API_KEY is required to send email outside development.",
+    );
+  }
+
+  return {
+    fromAddress,
+    resendOptions: {
+      apiKey,
+      testMode: deploymentMode === "development",
+    },
+  };
+}
+
+export function renderTransactionalEmail(
+  input: TransactionalTemplateInput,
+): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  switch (input.template) {
+    case "password_reset":
+      return renderPasswordResetEmail(input);
+    case "verify_email":
+    case "operator_alert":
+      throw new Error(`Email template "${input.template}" is not implemented yet.`);
+    default: {
+      const exhaustiveTemplate: never = input.template;
+      throw new Error(`Unsupported email template "${exhaustiveTemplate}".`);
+    }
+  }
+}
+
+export async function sendTransactionalEmail(
+  ctx: SendEmailCtx,
+  input: TransactionalTemplateInput,
+): Promise<{ messageId: string }> {
+  const { fromAddress, resendOptions } = getTransactionalEmailConfig();
+  const email = renderTransactionalEmail(input);
+  const resend = new Resend((components as any).resend, resendOptions);
+
+  const messageId = await resend.sendEmail(ctx, {
+    from: fromAddress,
+    to: input.to,
+    subject: input.subject || email.subject,
+    html: email.html,
+    text: email.text,
+  });
+
+  return { messageId: String(messageId) };
+}
+
+function renderPasswordResetEmail(input: TransactionalTemplateInput): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const code = requireTemplateVariable(input.template, input.variables, "code");
+  const expiresMinutes = requireTemplateVariable(
+    input.template,
+    input.variables,
+    "expiresMinutes",
+  );
+
+  const subject = input.subject || DEFAULT_PASSWORD_RESET_SUBJECT;
+  const escapedCode = escapeHtml(code);
+  const escapedExpiresMinutes = escapeHtml(expiresMinutes);
+
+  return {
+    subject,
+    html: [
+      "<p>You requested a password reset for your AI Receptionist account.</p>",
+      `<p>Your reset code is <strong>${escapedCode}</strong>.</p>`,
+      `<p>This code expires in ${escapedExpiresMinutes} minutes.</p>`,
+      "<p>If you did not request this, you can safely ignore this email.</p>",
+    ].join(""),
+    text: [
+      "You requested a password reset for your AI Receptionist account.",
+      `Your reset code is ${code}.`,
+      `This code expires in ${expiresMinutes} minutes.`,
+      "If you did not request this, you can safely ignore this email.",
+    ].join("\n\n"),
+  };
+}
+
+function requireTemplateVariable(
+  template: TransactionalTemplateName,
+  variables: Record<string, string>,
+  key: string,
+): string {
+  const value = variables[key];
+  if (!value) {
+    throw new Error(`Email template "${template}" requires variable "${key}".`);
+  }
+  return value;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/convex/lib/providers/email.ts
+++ b/convex/lib/providers/email.ts
@@ -1,12 +1,18 @@
-import type { EmailProvider } from "@ai-receptionist/providers";
 import { Resend, type ResendOptions } from "@convex-dev/resend";
 
 import { components } from "../../_generated/api";
 import type { ActionCtx, MutationCtx } from "../../_generated/server";
 
-type TransactionalTemplateInput = Parameters<EmailProvider["sendTemplate"]>[0];
-type TransactionalTemplateName = TransactionalTemplateInput["template"];
 type SendEmailCtx = Pick<ActionCtx, "runMutation"> | Pick<MutationCtx, "runMutation">;
+
+type TransactionalTemplateName = "verify_email" | "password_reset" | "operator_alert";
+
+type TransactionalTemplateInput = {
+  template: TransactionalTemplateName;
+  to: string;
+  subject: string;
+  variables: Record<string, string>;
+};
 
 const DEFAULT_PASSWORD_RESET_SUBJECT = "Reset your password";
 

--- a/convex/lib/providers/email.ts
+++ b/convex/lib/providers/email.ts
@@ -15,6 +15,7 @@ type TransactionalTemplateInput = {
 };
 
 const DEFAULT_PASSWORD_RESET_SUBJECT = "Reset your password";
+const DEFAULT_VERIFY_EMAIL_SUBJECT = "Confirm your new email";
 
 export type TransactionalEmailConfig = {
   fromAddress: string;
@@ -56,9 +57,10 @@ export function renderTransactionalEmail(
   text: string;
 } {
   switch (input.template) {
+    case "verify_email":
+      return renderVerifyEmailTemplate(input);
     case "password_reset":
       return renderPasswordResetEmail(input);
-    case "verify_email":
     case "operator_alert":
       throw new Error(`Email template "${input.template}" is not implemented yet.`);
     default: {
@@ -85,6 +87,39 @@ export async function sendTransactionalEmail(
   });
 
   return { messageId: String(messageId) };
+}
+
+function renderVerifyEmailTemplate(input: TransactionalTemplateInput): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const confirmUrl = requireTemplateVariable(input.template, input.variables, "confirmUrl");
+  const expiresMinutes = requireTemplateVariable(
+    input.template,
+    input.variables,
+    "expiresMinutes",
+  );
+
+  const subject = input.subject || DEFAULT_VERIFY_EMAIL_SUBJECT;
+  const escapedConfirmUrl = escapeHtml(confirmUrl);
+  const escapedExpiresMinutes = escapeHtml(expiresMinutes);
+
+  return {
+    subject,
+    html: [
+      "<p>You requested to change the sign-in email for your AI Receptionist account.</p>",
+      `<p><a href="${escapedConfirmUrl}">Confirm your new email</a></p>`,
+      `<p>This confirmation link expires in ${escapedExpiresMinutes} minutes.</p>`,
+      "<p>If you did not request this change, you can safely ignore this email.</p>",
+    ].join(""),
+    text: [
+      "You requested to change the sign-in email for your AI Receptionist account.",
+      `Confirm your new email: ${confirmUrl}`,
+      `This confirmation link expires in ${expiresMinutes} minutes.`,
+      "If you did not request this change, you can safely ignore this email.",
+    ].join("\n\n"),
+  };
 }
 
 function renderPasswordResetEmail(input: TransactionalTemplateInput): {

--- a/convex/lib/providers/email.ts
+++ b/convex/lib/providers/email.ts
@@ -30,12 +30,7 @@ export function getTransactionalEmailConfig(
     throw new Error("EMAIL_FROM_ADDRESS is required to send transactional email.");
   }
 
-  const deploymentMode = env.DEPLOYMENT_MODE;
-  if (!deploymentMode) {
-    throw new Error(
-      "DEPLOYMENT_MODE is required to determine whether auth email should use Resend test mode.",
-    );
-  }
+  const deploymentMode = env.DEPLOYMENT_MODE ?? "development";
   const apiKey = env.RESEND_API_KEY;
   if (!apiKey) {
     throw new Error(

--- a/convex/lib/providers/email.ts
+++ b/convex/lib/providers/email.ts
@@ -30,7 +30,12 @@ export function getTransactionalEmailConfig(
     throw new Error("EMAIL_FROM_ADDRESS is required to send transactional email.");
   }
 
-  const deploymentMode = env.DEPLOYMENT_MODE ?? "development";
+  const deploymentMode = env.DEPLOYMENT_MODE;
+  if (!deploymentMode) {
+    throw new Error(
+      "DEPLOYMENT_MODE is required to determine whether auth email should use Resend test mode.",
+    );
+  }
   const apiKey = env.RESEND_API_KEY;
   if (!apiKey) {
     throw new Error(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -87,6 +87,15 @@ export default defineSchema({
     .index("email", ["email"])
     .index("phone", ["phone"]),
 
+  pending_email_changes: defineTable({
+    accountId: v.id("authAccounts"),
+    codeHash: v.string(),
+    email: v.string(),
+    expirationTime: v.number(),
+  })
+    .index("by_account_id", ["accountId"])
+    .index("by_code_hash", ["codeHash"]),
+
   businesses: defineTable({
     slug: v.string(),
     name: v.string(),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -6,7 +6,26 @@ import { getCurrentUser } from "./lib/auth";
 export const current = query({
   args: {},
   handler: async (ctx) => {
-    return await getCurrentUser(ctx);
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return null;
+    }
+
+    const passwordAccount = await ctx.db
+      .query("authAccounts")
+      .withIndex("userIdAndProvider", (q) =>
+        q.eq("userId", user._id).eq("provider", "password"),
+      )
+      .unique();
+
+    if (!passwordAccount || passwordAccount.providerAccountId === user.email) {
+      return user;
+    }
+
+    return {
+      ...user,
+      email: passwordAccount.providerAccountId,
+    };
   },
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,14 @@
 import { v } from "convex/values";
 
-import { internalQuery } from "./_generated/server";
+import { internalQuery, query } from "./_generated/server";
+import { getCurrentUser } from "./lib/auth";
+
+export const current = query({
+  args: {},
+  handler: async (ctx) => {
+    return await getCurrentUser(ctx);
+  },
+});
 
 export const resolveAuthenticatedUserForBusiness = internalQuery({
   args: {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -2,21 +2,15 @@ import { v } from "convex/values";
 
 import { internalQuery, query } from "./_generated/server";
 import { getCurrentUser } from "./lib/auth";
+import { resolveCurrentUserForPasswordCredentials } from "./lib/accountCredentials";
 
 export const current = query({
   args: {},
   handler: async (ctx) => {
-    const user = await getCurrentUser(ctx);
+    const { user, passwordAccount } = await resolveCurrentUserForPasswordCredentials(ctx);
     if (!user) {
       return null;
     }
-
-    const passwordAccount = await ctx.db
-      .query("authAccounts")
-      .withIndex("userIdAndProvider", (q) =>
-        q.eq("userId", user._id).eq("provider", "password"),
-      )
-      .unique();
 
     if (!passwordAccount || passwordAccount.providerAccountId === user.email) {
       return user;

--- a/docs/providers/resend.md
+++ b/docs/providers/resend.md
@@ -1,6 +1,7 @@
 # Resend Auth Email Setup
 
 This repo sends auth email through the official `@convex-dev/resend` Convex component.
+The current auth flows are password reset and email-change confirmation.
 
 ## Required Environment
 
@@ -11,7 +12,7 @@ Set these variables before testing auth email:
 - `SITE_URL`
 
 Development keeps the Resend component in test mode by default because the repo uses `DEPLOYMENT_MODE=development`.
-Convex Auth uses `SITE_URL` internally for password reset. Set it on the Convex deployment to your web app origin, for example `http://localhost:5173` in local development.
+Convex Auth uses `SITE_URL` internally for password reset and email confirmation links. Set it on the Convex deployment to your web app origin, for example `http://localhost:5173` in local development.
 
 ## Local Verification
 
@@ -22,9 +23,12 @@ Convex Auth uses `SITE_URL` internally for password reset. Set it on the Convex 
 5. Confirm the reset code email is accepted in Resend test mode.
 6. Complete the reset flow with the emailed code and a new password.
 7. Confirm the updated password can sign in successfully.
+8. Open Settings, request an email change for an existing password account, and submit a Resend test inbox such as `delivered+email-change@resend.dev`.
+9. Open the confirmation email in Resend, click the confirmation link, and finish the confirmation screen.
+10. Confirm the updated email can sign in successfully.
 
 ## Production Notes
 
 - Real delivery requires `DEPLOYMENT_MODE` to be something other than `development`.
 - The configured `EMAIL_FROM_ADDRESS` must be a sender that your Resend account can use.
-- This first pass wires only password reset email. Signup verification and other transactional templates are reserved for follow-up work.
+- Signup verification and other transactional templates are still reserved for follow-up work.

--- a/docs/providers/resend.md
+++ b/docs/providers/resend.md
@@ -1,0 +1,28 @@
+# Resend Auth Email Setup
+
+This repo sends auth email through the official `@convex-dev/resend` Convex component.
+
+## Required Environment
+
+Set these variables before testing auth email:
+
+- `RESEND_API_KEY`
+- `EMAIL_FROM_ADDRESS`
+
+Development keeps the Resend component in test mode by default because the repo uses `DEPLOYMENT_MODE=development`.
+
+## Local Verification
+
+1. Start or refresh Convex codegen with `pnpm convex dev`.
+2. Run the web app with `pnpm dev`.
+3. Open `/forgot-password` in the dashboard.
+4. Submit a Resend test inbox such as `delivered@resend.dev` or a labeled variant like `delivered+ope55@resend.dev`.
+5. Confirm the reset code email is accepted in Resend test mode.
+6. Complete the reset flow with the emailed code and a new password.
+7. Confirm the updated password can sign in successfully.
+
+## Production Notes
+
+- Real delivery requires `DEPLOYMENT_MODE` to be something other than `development`.
+- The configured `EMAIL_FROM_ADDRESS` must be a sender that your Resend account can use.
+- This first pass wires only password reset email. Signup verification and other transactional templates are reserved for follow-up work.

--- a/docs/providers/resend.md
+++ b/docs/providers/resend.md
@@ -8,8 +8,10 @@ Set these variables before testing auth email:
 
 - `RESEND_API_KEY`
 - `EMAIL_FROM_ADDRESS`
+- `SITE_URL`
 
 Development keeps the Resend component in test mode by default because the repo uses `DEPLOYMENT_MODE=development`.
+Convex Auth uses `SITE_URL` internally for password reset. Set it on the Convex deployment to your web app origin, for example `http://localhost:5173` in local development.
 
 ## Local Verification
 

--- a/docs/providers/resend.md
+++ b/docs/providers/resend.md
@@ -7,11 +7,12 @@ The current auth flows are password reset and email-change confirmation.
 
 Set these variables before testing auth email:
 
+- `DEPLOYMENT_MODE`
 - `RESEND_API_KEY`
 - `EMAIL_FROM_ADDRESS`
 - `SITE_URL`
 
-Development keeps the Resend component in test mode by default because the repo uses `DEPLOYMENT_MODE=development`.
+Development keeps the Resend component in test mode when `DEPLOYMENT_MODE=development`.
 Convex Auth uses `SITE_URL` internally for password reset and email confirmation links. Set it on the Convex deployment to your web app origin, for example `http://localhost:5173` in local development.
 
 ## Local Verification

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@convex-dev/crons": "latest",
     "@convex-dev/persistent-text-streaming": "latest",
     "@convex-dev/rag": "latest",
+    "@convex-dev/resend": "^0.2.3",
     "@convex-dev/workflow": "latest",
     "@convex-dev/workpool": "latest",
     "ai": "latest",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,20 @@
     "overrides": {
       "hono": "4.12.7"
     },
+    "supportedArchitectures": {
+      "os": [
+        "current",
+        "linux"
+      ],
+      "cpu": [
+        "current",
+        "arm64"
+      ],
+      "libc": [
+        "current",
+        "glibc"
+      ]
+    },
     "onlyBuiltDependencies": [
       "sharp"
     ]
@@ -28,6 +42,7 @@
     "@convex-dev/workpool": "latest",
     "ai": "latest",
     "convex": "^1.31.2",
+    "jimp": "^1.6.0",
     "luxon": "^3.7.2",
     "sharp": "^0.34.4",
     "twilio": "^5.12.2",
@@ -50,7 +65,6 @@
     "@types/node": "^24.0.0",
     "concurrently": "^9.1.2",
     "convex-test": "^0.0.41",
-    "jimp": "^1.6.0",
     "tsx": "^4.20.3",
     "typescript": "^5.8.2",
     "vitest": "^3.2.4"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "@ai-receptionist/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "lucia": "^3.2.2"
   }
 }

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -40,6 +40,37 @@ describe("account credential settings", () => {
     });
   });
 
+  it("returns the legacy password-account email for migrated users", async () => {
+    const t = convexTest(schema, convexModules);
+
+    const seeded = await t.run(async (ctx) => {
+      const authUserId: Id<"users"> = await ctx.db.insert("users", {
+        email: "auth-user@example.com",
+      });
+      const authSubject = `${String(authUserId)}|session-1`;
+
+      const legacyUserId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject,
+        email: "legacy-user@example.com",
+      });
+
+      await ctx.db.insert("authAccounts", {
+        userId: legacyUserId,
+        provider: "password",
+        providerAccountId: "legacy-login@example.com",
+        secret: "hashed-secret",
+      });
+
+      return { authSubject };
+    });
+
+    const asOwner = t.withIdentity({ subject: seeded.authSubject });
+
+    await expect(asOwner.query(api.users.current, {})).resolves.toMatchObject({
+      email: "legacy-login@example.com",
+    });
+  });
+
   it("resolves credential changes from the row that owns the password account", async () => {
     const t = convexTest(schema, convexModules);
 

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -2,9 +2,8 @@ import { convexTest } from "convex-test";
 import { Scrypt } from "lucia";
 import { describe, expect, it } from "vitest";
 
-import { api } from "../../../convex/_generated/api";
+import { api, internal } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
-import { EMAIL_CHANGE_PROVIDER_ID } from "../../../convex/lib/emailChange";
 import schema from "../../../convex/schema";
 
 declare global {
@@ -41,6 +40,41 @@ describe("account credential settings", () => {
     });
   });
 
+  it("resolves credential changes from the row that owns the password account", async () => {
+    const t = convexTest(schema, convexModules);
+
+    const seeded = await t.run(async (ctx) => {
+      const authUserId: Id<"users"> = await ctx.db.insert("users", {
+        email: "auth-user@example.com",
+      });
+      const authSubject = `${String(authUserId)}|session-1`;
+      const legacyUserId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject,
+        email: "legacy-user@example.com",
+      });
+      const passwordAccountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId: legacyUserId,
+        provider: "password",
+        providerAccountId: "legacy-user@example.com",
+        secret: "hashed-secret",
+      });
+
+      return { authSubject, authUserId, legacyUserId, passwordAccountId };
+    });
+
+    await expect(
+      t.query((internal as any).businesses.catalog.getCurrentUserForPasswordChange, {
+        authSubject: seeded.authSubject,
+        authUserId: String(seeded.authUserId),
+      }),
+    ).resolves.toMatchObject({
+      userId: seeded.legacyUserId,
+      passwordAccountId: seeded.passwordAccountId,
+      passwordAccountEmail: "legacy-user@example.com",
+      email: "legacy-user@example.com",
+    });
+  });
+
   it("confirms an email change link and updates the password account email", async () => {
     const t = convexTest(schema, convexModules);
     const subject = "account-owner";
@@ -64,12 +98,11 @@ describe("account credential settings", () => {
         secret,
       });
 
-      await ctx.db.insert("authVerificationCodes", {
+      await ctx.db.insert("pending_email_changes", {
         accountId,
-        provider: EMAIL_CHANGE_PROVIDER_ID,
-        code: await hashCode(confirmationCode),
+        codeHash: await hashCode(confirmationCode),
         expirationTime: Date.now() + 5 * 60 * 1000,
-        emailVerified: nextEmail,
+        email: nextEmail,
       });
 
       return { userId };
@@ -114,10 +147,101 @@ describe("account credential settings", () => {
       expect(newAccount?.secret).not.toBe(secret);
       expect(
         await ctx.db
-          .query("authVerificationCodes")
-          .withIndex("accountId", (q) => q.eq("accountId", newAccount!._id))
+          .query("pending_email_changes")
+          .withIndex("by_account_id", (q) => q.eq("accountId", newAccount!._id))
           .unique(),
       ).toBeNull();
+    });
+  });
+
+  it("stores a pending email change without updating the current user email", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentEmail = "owner@example.com";
+    const nextEmail = "updated@example.com";
+    const confirmationCode = "confirm-email-change";
+
+    const seeded = await t.run(async (ctx) => {
+      const userId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-owner",
+        email: currentEmail,
+      });
+      const accountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId,
+        provider: "password",
+        providerAccountId: currentEmail,
+        secret: "hashed-secret",
+      });
+
+      return { accountId, userId };
+    });
+
+    await t.mutation((internal as any).businesses.catalog.createPendingEmailChange, {
+      accountId: seeded.accountId,
+      codeHash: await hashCode(confirmationCode),
+      email: nextEmail,
+      expirationTime: Date.now() + 5 * 60 * 1000,
+    });
+
+    await t.run(async (ctx) => {
+      const user = await ctx.db.get(seeded.userId);
+      const pendingEmailChange = await ctx.db
+        .query("pending_email_changes")
+        .withIndex("by_account_id", (q) => q.eq("accountId", seeded.accountId))
+        .unique();
+
+      expect(user?.email).toBe(currentEmail);
+      expect(pendingEmailChange?.email).toBe(nextEmail);
+    });
+  });
+
+  it("keeps password reset verification codes when storing a pending email change", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentEmail = "owner@example.com";
+    const nextEmail = "updated@example.com";
+    const resetCode = "12345678";
+    const confirmationCode = "confirm-email-change";
+
+    const seeded = await t.run(async (ctx) => {
+      const userId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-owner",
+        email: currentEmail,
+      });
+      const accountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId,
+        provider: "password",
+        providerAccountId: currentEmail,
+        secret: "hashed-secret",
+      });
+      const resetVerificationCodeId: Id<"authVerificationCodes"> = await ctx.db.insert(
+        "authVerificationCodes",
+        {
+          accountId,
+          provider: "email",
+          code: await hashCode(resetCode),
+          expirationTime: Date.now() + 5 * 60 * 1000,
+          emailVerified: currentEmail,
+        },
+      );
+
+      return { accountId, resetVerificationCodeId };
+    });
+
+    await t.mutation((internal as any).businesses.catalog.createPendingEmailChange, {
+      accountId: seeded.accountId,
+      codeHash: await hashCode(confirmationCode),
+      email: nextEmail,
+      expirationTime: Date.now() + 5 * 60 * 1000,
+    });
+
+    await t.run(async (ctx) => {
+      const resetVerificationCode = await ctx.db.get(seeded.resetVerificationCodeId);
+      const pendingEmailChange = await ctx.db
+        .query("pending_email_changes")
+        .withIndex("by_account_id", (q) => q.eq("accountId", seeded.accountId))
+        .unique();
+
+      expect(resetVerificationCode).not.toBeNull();
+      expect(pendingEmailChange?.codeHash).toBe(await hashCode(confirmationCode));
     });
   });
 

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -105,6 +105,15 @@ describe("account credential settings", () => {
         email: nextEmail,
       });
 
+      await ctx.db.insert("authSessions", {
+        userId,
+        expirationTime: Date.now() + 60 * 60 * 1000,
+      });
+      await ctx.db.insert("authSessions", {
+        userId,
+        expirationTime: Date.now() + 60 * 60 * 1000,
+      });
+
       return { userId };
     });
 
@@ -138,6 +147,10 @@ describe("account credential settings", () => {
           q.eq("provider", "password").eq("providerAccountId", nextEmail),
         )
         .unique();
+      const sessions = await ctx.db
+        .query("authSessions")
+        .withIndex("userId", (q) => q.eq("userId", seeded.userId))
+        .collect();
 
       expect(user?.email).toBe(nextEmail);
       expect(oldAccount).toBeNull();
@@ -145,6 +158,7 @@ describe("account credential settings", () => {
       expect(newAccount?.providerAccountId).toBe(nextEmail);
       expect(newAccount?.emailVerified).toBe(nextEmail);
       expect(newAccount?.secret).not.toBe(secret);
+      expect(sessions).toHaveLength(0);
       expect(
         await ctx.db
           .query("pending_email_changes")
@@ -245,13 +259,13 @@ describe("account credential settings", () => {
     });
   });
 
-  it("rejects changing to an email that already belongs to another password account", async () => {
+  it("does not reveal whether a target email already belongs to another password account", async () => {
     const t = convexTest(schema, convexModules);
     const currentPassword = "CurrentPass123!";
     const currentSecret = await new Scrypt().hash(currentPassword);
     const takenSecret = await new Scrypt().hash("AnotherPass123!");
 
-    await t.run(async (ctx) => {
+    const seeded = await t.run(async (ctx) => {
       const ownerId: Id<"users"> = await ctx.db.insert("users", {
         authSubject: "account-owner",
         email: "owner@example.com",
@@ -273,6 +287,8 @@ describe("account credential settings", () => {
         providerAccountId: "taken@example.com",
         secret: takenSecret,
       });
+
+      return { ownerId };
     });
 
     const asOwner = t.withIdentity({ subject: "account-owner" });
@@ -282,7 +298,26 @@ describe("account credential settings", () => {
         currentPassword,
         newEmail: "taken@example.com",
       }),
-    ).rejects.toThrow("already exists");
+    ).resolves.toEqual({ email: "taken@example.com" });
+
+    await t.run(async (ctx) => {
+      const ownerUser = await ctx.db.get(seeded.ownerId);
+      const ownerAccount = await ctx.db
+        .query("authAccounts")
+        .withIndex("providerAndAccountId", (accountQuery) =>
+          accountQuery
+            .eq("provider", "password")
+            .eq("providerAccountId", "owner@example.com"),
+        )
+        .unique();
+      const ownerPendingEmailChange = await ctx.db
+        .query("pending_email_changes")
+        .withIndex("by_account_id", (q) => q.eq("accountId", ownerAccount!._id))
+        .unique();
+
+      expect(ownerUser?.email).toBe("owner@example.com");
+      expect(ownerPendingEmailChange).toBeNull();
+    });
   });
 });
 

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -1,0 +1,121 @@
+import { convexTest } from "convex-test";
+import { Scrypt } from "lucia";
+import { describe, expect, it } from "vitest";
+
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import schema from "../../../convex/schema";
+
+declare global {
+  interface ImportMeta {
+    glob(pattern: string): Record<string, () => Promise<unknown>>;
+  }
+}
+
+const convexModules = import.meta.glob("../../../convex/**/*.ts");
+
+describe("account credential settings", () => {
+  it("lets an authenticated user change the email on their password account", async () => {
+    const t = convexTest(schema, convexModules);
+    const subject = "account-owner";
+    const currentPassword = "CurrentPass123!";
+    const currentEmail = "owner@example.com";
+    const nextEmail = "updated@example.com";
+    const nextPassword = "ChangedPass123!";
+    const secret = await new Scrypt().hash(currentPassword);
+
+    const seeded = await t.run(async (ctx) => {
+      const userId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: subject,
+        email: currentEmail,
+      });
+
+      await ctx.db.insert("authAccounts", {
+        userId,
+        provider: "password",
+        providerAccountId: currentEmail,
+        secret,
+      });
+
+      return { userId };
+    });
+
+    const asOwner = t.withIdentity({ subject });
+
+    await expect(
+      asOwner.action(api.businesses.catalog.changeEmail, {
+        currentPassword,
+        newEmail: nextEmail,
+      }),
+    ).resolves.toEqual({ email: nextEmail });
+
+    await expect(
+      asOwner.action(api.businesses.catalog.changePassword, {
+        currentPassword,
+        newPassword: nextPassword,
+      }),
+    ).resolves.toBeNull();
+
+    await t.run(async (ctx) => {
+      const user = await ctx.db.get(seeded.userId);
+      const oldAccount = await ctx.db
+        .query("authAccounts")
+        .withIndex("providerAndAccountId", (q) =>
+          q.eq("provider", "password").eq("providerAccountId", currentEmail),
+        )
+        .unique();
+      const newAccount = await ctx.db
+        .query("authAccounts")
+        .withIndex("providerAndAccountId", (q) =>
+          q.eq("provider", "password").eq("providerAccountId", nextEmail),
+        )
+        .unique();
+
+      expect(user?.email).toBe(nextEmail);
+      expect(oldAccount).toBeNull();
+      expect(newAccount?.userId).toBe(seeded.userId);
+      expect(newAccount?.providerAccountId).toBe(nextEmail);
+      expect(newAccount?.secret).not.toBe(secret);
+    });
+  });
+
+  it("rejects changing to an email that already belongs to another password account", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentPassword = "CurrentPass123!";
+    const currentSecret = await new Scrypt().hash(currentPassword);
+    const takenSecret = await new Scrypt().hash("AnotherPass123!");
+
+    await t.run(async (ctx) => {
+      const ownerId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-owner",
+        email: "owner@example.com",
+      });
+      const otherId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-other",
+        email: "taken@example.com",
+      });
+
+      await ctx.db.insert("authAccounts", {
+        userId: ownerId,
+        provider: "password",
+        providerAccountId: "owner@example.com",
+        secret: currentSecret,
+      });
+      await ctx.db.insert("authAccounts", {
+        userId: otherId,
+        provider: "password",
+        providerAccountId: "taken@example.com",
+        secret: takenSecret,
+      });
+    });
+
+    const asOwner = t.withIdentity({ subject: "account-owner" });
+
+    await expect(
+      asOwner.action(api.businesses.catalog.changeEmail, {
+        currentPassword,
+        newEmail: "taken@example.com",
+      }),
+    ).rejects.toThrow("already exists");
+  });
+});

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
+import { EMAIL_CHANGE_PROVIDER_ID } from "../../../convex/lib/emailChange";
 import schema from "../../../convex/schema";
 
 declare global {
@@ -15,13 +16,14 @@ declare global {
 const convexModules = import.meta.glob("../../../convex/**/*.ts");
 
 describe("account credential settings", () => {
-  it("lets an authenticated user change the email on their password account", async () => {
+  it("confirms an email change link and updates the password account email", async () => {
     const t = convexTest(schema, convexModules);
     const subject = "account-owner";
     const currentPassword = "CurrentPass123!";
     const currentEmail = "owner@example.com";
     const nextEmail = "updated@example.com";
     const nextPassword = "ChangedPass123!";
+    const confirmationCode = "confirm-email-change";
     const secret = await new Scrypt().hash(currentPassword);
 
     const seeded = await t.run(async (ctx) => {
@@ -30,11 +32,19 @@ describe("account credential settings", () => {
         email: currentEmail,
       });
 
-      await ctx.db.insert("authAccounts", {
+      const accountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
         userId,
         provider: "password",
         providerAccountId: currentEmail,
         secret,
+      });
+
+      await ctx.db.insert("authVerificationCodes", {
+        accountId,
+        provider: EMAIL_CHANGE_PROVIDER_ID,
+        code: await hashCode(confirmationCode),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        emailVerified: nextEmail,
       });
 
       return { userId };
@@ -43,9 +53,9 @@ describe("account credential settings", () => {
     const asOwner = t.withIdentity({ subject });
 
     await expect(
-      asOwner.action(api.businesses.catalog.changeEmail, {
-        currentPassword,
-        newEmail: nextEmail,
+      t.action(api.businesses.catalog.confirmEmailChange, {
+        code: confirmationCode,
+        email: nextEmail,
       }),
     ).resolves.toEqual({ email: nextEmail });
 
@@ -76,6 +86,12 @@ describe("account credential settings", () => {
       expect(newAccount?.userId).toBe(seeded.userId);
       expect(newAccount?.providerAccountId).toBe(nextEmail);
       expect(newAccount?.secret).not.toBe(secret);
+      expect(
+        await ctx.db
+          .query("authVerificationCodes")
+          .withIndex("accountId", (q) => q.eq("accountId", newAccount!._id))
+          .unique(),
+      ).toBeNull();
     });
   });
 
@@ -119,3 +135,11 @@ describe("account credential settings", () => {
     ).rejects.toThrow("already exists");
   });
 });
+
+async function hashCode(code: string): Promise<string> {
+  const encoded = new TextEncoder().encode(code);
+  const hash = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(hash), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -110,6 +110,7 @@ describe("account credential settings", () => {
       expect(oldAccount).toBeNull();
       expect(newAccount?.userId).toBe(seeded.userId);
       expect(newAccount?.providerAccountId).toBe(nextEmail);
+      expect(newAccount?.emailVerified).toBe(nextEmail);
       expect(newAccount?.secret).not.toBe(secret);
       expect(
         await ctx.db

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -16,6 +16,31 @@ declare global {
 const convexModules = import.meta.glob("../../../convex/**/*.ts");
 
 describe("account credential settings", () => {
+  it("returns the password credential email as the current email", async () => {
+    const t = convexTest(schema, convexModules);
+    const subject = "account-owner";
+
+    await t.run(async (ctx) => {
+      const userId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: subject,
+        email: "stale@example.com",
+      });
+
+      await ctx.db.insert("authAccounts", {
+        userId,
+        provider: "password",
+        providerAccountId: "current@example.com",
+        secret: "hashed-secret",
+      });
+    });
+
+    const asOwner = t.withIdentity({ subject });
+
+    await expect(asOwner.query(api.users.current, {})).resolves.toMatchObject({
+      email: "current@example.com",
+    });
+  });
+
   it("confirms an email change link and updates the password account email", async () => {
     const t = convexTest(schema, convexModules);
     const subject = "account-owner";

--- a/packages/testing/src/accountCredentials.test.ts
+++ b/packages/testing/src/accountCredentials.test.ts
@@ -168,6 +168,62 @@ describe("account credential settings", () => {
     });
   });
 
+  it("revokes outstanding reset codes when confirming an email change", async () => {
+    const t = convexTest(schema, convexModules);
+    const subject = "account-owner";
+    const currentEmail = "owner@example.com";
+    const nextEmail = "updated@example.com";
+    const confirmationCode = "confirm-email-change";
+    const resetCode = "12345678";
+
+    const seeded = await t.run(async (ctx) => {
+      const userId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: subject,
+        email: currentEmail,
+      });
+
+      const accountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId,
+        provider: "password",
+        providerAccountId: currentEmail,
+        secret: "hashed-secret",
+      });
+
+      await ctx.db.insert("pending_email_changes", {
+        accountId,
+        codeHash: await hashCode(confirmationCode),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        email: nextEmail,
+      });
+
+      await ctx.db.insert("authVerificationCodes", {
+        accountId,
+        provider: "email",
+        code: await hashCode(resetCode),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        emailVerified: currentEmail,
+      });
+
+      return { accountId };
+    });
+
+    await expect(
+      t.action(api.businesses.catalog.confirmEmailChange, {
+        code: confirmationCode,
+        email: nextEmail,
+      }),
+    ).resolves.toEqual({ email: nextEmail });
+
+    await t.run(async (ctx) => {
+      const remainingResetCode = await ctx.db
+        .query("authVerificationCodes")
+        .withIndex("accountId", (q) => q.eq("accountId", seeded.accountId))
+        .unique();
+
+      expect(remainingResetCode).toBeNull();
+    });
+  });
+
   it("stores a pending email change without updating the current user email", async () => {
     const t = convexTest(schema, convexModules);
     const currentEmail = "owner@example.com";
@@ -316,6 +372,63 @@ describe("account credential settings", () => {
         .unique();
 
       expect(ownerUser?.email).toBe("owner@example.com");
+      expect(ownerPendingEmailChange).toBeNull();
+    });
+  });
+
+  it("clears existing pending email changes when masking a taken target email", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentPassword = "CurrentPass123!";
+    const currentSecret = await new Scrypt().hash(currentPassword);
+    const takenSecret = await new Scrypt().hash("AnotherPass123!");
+
+    const seeded = await t.run(async (ctx) => {
+      const ownerId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-owner",
+        email: "owner@example.com",
+      });
+      const otherId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-other",
+        email: "taken@example.com",
+      });
+
+      const ownerAccountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId: ownerId,
+        provider: "password",
+        providerAccountId: "owner@example.com",
+        secret: currentSecret,
+      });
+      await ctx.db.insert("authAccounts", {
+        userId: otherId,
+        provider: "password",
+        providerAccountId: "taken@example.com",
+        secret: takenSecret,
+      });
+      await ctx.db.insert("pending_email_changes", {
+        accountId: ownerAccountId,
+        codeHash: await hashCode("previous-request"),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        email: "first-target@example.com",
+      });
+
+      return { ownerAccountId };
+    });
+
+    const asOwner = t.withIdentity({ subject: "account-owner" });
+
+    await expect(
+      asOwner.action(api.businesses.catalog.changeEmail, {
+        currentPassword,
+        newEmail: "taken@example.com",
+      }),
+    ).resolves.toEqual({ email: "taken@example.com" });
+
+    await t.run(async (ctx) => {
+      const ownerPendingEmailChange = await ctx.db
+        .query("pending_email_changes")
+        .withIndex("by_account_id", (q) => q.eq("accountId", seeded.ownerAccountId))
+        .unique();
+
       expect(ownerPendingEmailChange).toBeNull();
     });
   });

--- a/packages/testing/src/emailProvider.test.ts
+++ b/packages/testing/src/emailProvider.test.ts
@@ -30,6 +30,26 @@ describe("transactional email provider", () => {
     expect(email.html).toContain("<strong>12345678</strong>");
   });
 
+  it("renders the email confirmation template with the requested link", async () => {
+    const { renderTransactionalEmail } = await import("../../../convex/lib/providers/email");
+
+    const email = renderTransactionalEmail({
+      template: "verify_email",
+      to: "updated@example.com",
+      subject: "Confirm your new email",
+      variables: {
+        confirmUrl: "https://example.com/confirm-email-change?token=test&email=updated%40example.com",
+        expiresMinutes: "30",
+      },
+    });
+
+    expect(email.subject).toBe("Confirm your new email");
+    expect(email.text).toContain("confirm-email-change");
+    expect(email.text).toContain("30 minutes");
+    expect(email.html).toContain("Confirm your new email");
+    expect(email.html).toContain("href=\"https://example.com/confirm-email-change?token=test&amp;email=updated%40example.com\"");
+  });
+
   it("uses Resend test mode in development", async () => {
     vi.stubEnv("DEPLOYMENT_MODE", "development");
     vi.stubEnv("EMAIL_FROM_ADDRESS", "noreply@example.com");

--- a/packages/testing/src/emailProvider.test.ts
+++ b/packages/testing/src/emailProvider.test.ts
@@ -66,6 +66,17 @@ describe("transactional email provider", () => {
     });
   });
 
+  it("fails closed when deployment mode is unset", async () => {
+    vi.stubEnv("EMAIL_FROM_ADDRESS", "noreply@example.com");
+    vi.stubEnv("RESEND_API_KEY", "re_test_123");
+
+    const { getTransactionalEmailConfig } = await import("../../../convex/lib/providers/email");
+
+    expect(() => getTransactionalEmailConfig()).toThrow(
+      "DEPLOYMENT_MODE is required to determine whether auth email should use Resend test mode.",
+    );
+  });
+
   it("fails clearly when Resend credentials are missing outside development", async () => {
     vi.stubEnv("DEPLOYMENT_MODE", "cloud");
     vi.stubEnv("EMAIL_FROM_ADDRESS", "noreply@example.com");

--- a/packages/testing/src/emailProvider.test.ts
+++ b/packages/testing/src/emailProvider.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("transactional email provider", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders the password reset template with the requested variables", async () => {
+    const { renderTransactionalEmail } = await import("../../../convex/lib/providers/email");
+
+    const email = renderTransactionalEmail({
+      template: "password_reset",
+      to: "owner@example.com",
+      subject: "Reset your password",
+      variables: {
+        code: "12345678",
+        expiresMinutes: "15",
+      },
+    });
+
+    expect(email.subject).toBe("Reset your password");
+    expect(email.text).toContain("12345678");
+    expect(email.text).toContain("15 minutes");
+    expect(email.html).toContain("<strong>12345678</strong>");
+  });
+
+  it("uses Resend test mode in development", async () => {
+    vi.stubEnv("DEPLOYMENT_MODE", "development");
+    vi.stubEnv("EMAIL_FROM_ADDRESS", "noreply@example.com");
+    vi.stubEnv("RESEND_API_KEY", "re_test_123");
+
+    const { getTransactionalEmailConfig } = await import("../../../convex/lib/providers/email");
+
+    expect(getTransactionalEmailConfig()).toEqual({
+      fromAddress: "noreply@example.com",
+      resendOptions: {
+        apiKey: "re_test_123",
+        testMode: true,
+      },
+    });
+  });
+
+  it("fails clearly when Resend credentials are missing outside development", async () => {
+    vi.stubEnv("DEPLOYMENT_MODE", "cloud");
+    vi.stubEnv("EMAIL_FROM_ADDRESS", "noreply@example.com");
+
+    const { getTransactionalEmailConfig } = await import("../../../convex/lib/providers/email");
+
+    expect(() => getTransactionalEmailConfig()).toThrow(
+      "RESEND_API_KEY is required to send email outside development.",
+    );
+  });
+});

--- a/packages/testing/src/emailProvider.test.ts
+++ b/packages/testing/src/emailProvider.test.ts
@@ -66,15 +66,19 @@ describe("transactional email provider", () => {
     });
   });
 
-  it("fails closed when deployment mode is unset", async () => {
+  it("defaults to development test mode when deployment mode is unset", async () => {
     vi.stubEnv("EMAIL_FROM_ADDRESS", "noreply@example.com");
     vi.stubEnv("RESEND_API_KEY", "re_test_123");
 
     const { getTransactionalEmailConfig } = await import("../../../convex/lib/providers/email");
 
-    expect(() => getTransactionalEmailConfig()).toThrow(
-      "DEPLOYMENT_MODE is required to determine whether auth email should use Resend test mode.",
-    );
+    expect(getTransactionalEmailConfig()).toEqual({
+      fromAddress: "noreply@example.com",
+      resendOptions: {
+        apiKey: "re_test_123",
+        testMode: true,
+      },
+    });
   });
 
   it("fails clearly when Resend credentials are missing outside development", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       convex:
         specifier: ^1.31.2
         version: 1.32.0(react@19.2.4)
+      jimp:
+        specifier: ^1.6.0
+        version: 1.6.0
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
@@ -75,9 +78,6 @@ importers:
       convex-test:
         specifier: ^0.0.41
         version: 0.0.41(convex@1.32.0(react@19.2.4))
-      jimp:
-        specifier: ^1.6.0
-        version: 1.6.0
       tsx:
         specifier: ^4.20.3
         version: 4.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,10 @@ importers:
       '@ai-receptionist/shared':
         specifier: workspace:*
         version: link:../shared
+    devDependencies:
+      lucia:
+        specifier: ^3.2.2
+        version: 3.2.2
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@convex-dev/rag':
         specifier: latest
         version: 0.7.2(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(zod@3.25.76)
+      '@convex-dev/resend':
+        specifier: ^0.2.3
+        version: 0.2.3(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(react@19.2.4)
       '@convex-dev/workflow':
         specifier: latest
         version: 0.3.6(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
@@ -83,7 +86,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)
 
   apps/voice-gateway:
     dependencies:
@@ -236,6 +239,12 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.10
         version: 19.2.14
@@ -245,6 +254,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.2
         version: 5.1.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@1.8.0)
       vite:
         specifier: ^7.1.3
         version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
@@ -324,6 +336,17 @@ packages:
   '@antfu/ni@25.0.0':
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@auth/core@0.37.4':
     resolution: {integrity: sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==}
@@ -505,6 +528,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@convex-dev/action-retrier@0.3.0':
     resolution: {integrity: sha512-opBNsgOPSuVY3qSARNub98XqPzSpSS7Jga0oGeWFhO+DcWBMt2gD3ssUeEA1Gi7wTNiZBX+T6OBfBnqMfv6Tuw==}
     peerDependencies:
@@ -552,6 +579,21 @@ packages:
       convex: ^1.24.8
       convex-helpers: ^0.1.94
 
+  '@convex-dev/rate-limiter@0.3.2':
+    resolution: {integrity: sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA==}
+    peerDependencies:
+      convex: ^1.24.8
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@convex-dev/resend@0.2.3':
+    resolution: {integrity: sha512-eH7xmj49u0nZVvHyztxg3BLrBq2hJAVxJDBdmFFK07zgUCblGq+Pp6k7X+YtmBHcj8Eie4J0kUFeElu8L4KtBg==}
+    peerDependencies:
+      convex: ^1.24.8
+      convex-helpers: ^0.1.106
+
   '@convex-dev/workflow@0.3.6':
     resolution: {integrity: sha512-qLPOZ5lXleCRFlVGchC9Q9v9L72dCNgjF3+GLaPnS03Up7RusNLZxdszgAeyKjY6a02DBQQWPdc1RWn8WCWQDw==}
     peerDependencies:
@@ -559,11 +601,53 @@ packages:
       convex: ^1.31.7
       convex-helpers: ^0.1.99
 
+  '@convex-dev/workpool@0.3.2':
+    resolution: {integrity: sha512-jNPBHLCmZQXaztbBntZgIoM8JhKDmGwaIezZS/zPmX74PzON0Fgysgd9u+NOjJ04Dx2pN8ppBH9ElpsKxCOBpA==}
+    peerDependencies:
+      convex: ^1.31.7
+      convex-helpers: ^0.1.94
+
   '@convex-dev/workpool@0.4.2':
     resolution: {integrity: sha512-lNFFouUeCVPAzT6OVDZSqN17sw+MiJSzXwet2CevVzbec6snt0IXf/qazYmhQkbGl6SIfqT3y8yL7sxw+7gEfA==}
     peerDependencies:
       convex: ^1.31.7
       convex-helpers: ^0.1.94
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1':
+    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -925,6 +1009,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
@@ -2197,6 +2290,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2305,11 +2401,39 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2475,6 +2599,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
@@ -2488,6 +2616,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2528,6 +2659,9 @@ packages:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bmp-ts@1.0.9:
     resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
@@ -2738,6 +2872,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2794,6 +2932,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
@@ -2808,6 +2950,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -2860,6 +3005,9 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
@@ -2903,6 +3051,10 @@ packages:
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -3022,6 +3174,9 @@ packages:
 
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -3191,6 +3346,10 @@ packages:
     resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
@@ -3317,6 +3476,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -3377,6 +3539,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3543,6 +3714,10 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3559,12 +3734,19 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -3757,6 +3939,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3826,6 +4011,9 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  postal-mime@2.7.3:
+    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -3850,6 +4038,10 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -3878,6 +4070,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -3933,6 +4129,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4034,6 +4233,9 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  remeda@2.33.6:
+    resolution: {integrity: sha512-tazDGH7s75kUPGBKLvhgBEHMgW+TdDFhjUAMdQj57IoWz6HsGa5D2RX5yDUz6IIqiRRvZiaEHzCzWdTeixc/Kg==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4044,6 +4246,15 @@ packages:
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  resend@6.9.4:
+    resolution: {integrity: sha512-/M3dsJzu5OgozqVsA4Psd/1L7EdePgOIIxClas453GOQYFG3VHc2ZyCHZFlvqsc9aZCCd2BJRRqZgWC8D9c7/g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4105,6 +4316,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4219,6 +4434,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4285,6 +4503,15 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  svix@1.86.0:
+    resolution: {integrity: sha512-/HTvXwjLJe1l/MsLXAO1ddCYxElJk4eNR4DzOjDOEmGrPN/3BtBE8perGwMAaJ2sT5T172VkBYzmHcjUfM1JRQ==}
+
+  svix@1.89.0:
+    resolution: {integrity: sha512-Yg/5OtdjN3zjWoQSoX+mkauUtLKiW/+DQWKcG2VaEfWoBBB9NmZoKMw7rQQVU5Nn/Wko3kNbo4cvo/ms48d2KQ==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -4366,8 +4593,16 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4410,6 +4645,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -4462,6 +4701,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -4557,12 +4800,28 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4621,6 +4880,10 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
 
@@ -4635,6 +4898,9 @@ packages:
   xmlbuilder@13.0.2:
     resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
     engines: {node: '>=6.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4699,6 +4965,24 @@ snapshots:
       fzf: 0.5.2
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@auth/core@0.37.4':
     dependencies:
@@ -4930,6 +5214,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@convex-dev/action-retrier@0.3.0(convex@1.32.0(react@19.2.4))':
     dependencies:
       convex: 1.32.0(react@19.2.4)
@@ -4981,6 +5269,25 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@convex-dev/rate-limiter@0.3.2(convex@1.32.0(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      convex: 1.32.0(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+
+  '@convex-dev/resend@0.2.3(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@convex-dev/rate-limiter': 0.3.2(convex@1.32.0(react@19.2.4))(react@19.2.4)
+      '@convex-dev/workpool': 0.3.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
+      convex: 1.32.0(react@19.2.4)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      remeda: 2.33.6
+      resend: 6.9.4
+      svix: 1.89.0
+    transitivePeerDependencies:
+      - '@react-email/render'
+      - react
+
   '@convex-dev/workflow@0.3.6(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
     dependencies:
       '@convex-dev/workpool': 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))
@@ -4988,10 +5295,39 @@ snapshots:
       convex: 1.32.0(react@19.2.4)
       convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
 
+  '@convex-dev/workpool@0.3.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
+    dependencies:
+      convex: 1.32.0(react@19.2.4)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+
   '@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.32.0(react@19.2.4))':
     dependencies:
       convex: 1.32.0(react@19.2.4)
       convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.32.0(react@19.2.4))(hono@4.12.7)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -5207,6 +5543,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
@@ -6507,6 +6847,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.1':
@@ -6585,6 +6927,31 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/token@0.3.0': {}
 
   '@ts-morph/common@0.27.0':
@@ -6592,6 +6959,8 @@ snapshots:
       fast-glob: 3.3.3
       minimatch: 10.2.4
       path-browserify: 1.0.1
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6777,6 +7146,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansis@4.2.0: {}
 
   any-base@1.1.0: {}
@@ -6786,6 +7157,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -6819,6 +7194,10 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bmp-ts@1.0.9: {}
 
@@ -7010,6 +7389,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -7054,6 +7438,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   dayjs@1.11.19: {}
 
   debug@4.4.3:
@@ -7061,6 +7452,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   dedent@1.7.2: {}
 
@@ -7088,6 +7481,8 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   diff@8.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -7138,6 +7533,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -7340,6 +7737,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastify-plugin@5.1.0: {}
@@ -7509,6 +7908,12 @@ snapshots:
 
   hono@4.12.7: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
@@ -7612,6 +8017,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
@@ -7677,6 +8084,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.5
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -7814,6 +8247,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -7829,11 +8264,15 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -8010,6 +8449,10 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -8064,6 +8507,8 @@ snapshots:
 
   pngjs@7.0.0: {}
 
+  postal-mime@2.7.3: {}
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
@@ -8084,6 +8529,12 @@ snapshots:
   preact@10.24.3: {}
 
   prettier@3.8.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-ms@9.3.0:
     dependencies:
@@ -8112,6 +8563,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  punycode@2.3.1: {}
 
   qs@6.15.0:
     dependencies:
@@ -8210,6 +8663,8 @@ snapshots:
       typescript: 5.9.3
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -8320,11 +8775,18 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  remeda@2.33.6: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
   reselect@5.1.1: {}
+
+  resend@6.9.4:
+    dependencies:
+      postal-mime: 2.7.3
+      svix: 1.86.0
 
   resolve-from@4.0.0: {}
 
@@ -8405,6 +8867,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -8585,6 +9051,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -8648,6 +9119,18 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  svix@1.86.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
+
+  svix@1.89.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
+
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
@@ -8706,7 +9189,15 @@ snapshots:
     dependencies:
       tldts: 7.0.25
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.25
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -8759,6 +9250,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@7.24.5: {}
+
   unicorn-magic@0.3.0: {}
 
   universalify@2.0.1: {}
@@ -8797,6 +9290,8 @@ snapshots:
       pako: 1.0.11
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   validate-npm-package-name@7.0.2: {}
 
@@ -8864,7 +9359,7 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -8892,6 +9387,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
       '@types/node': 24.12.0
+      jsdom: 29.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -8908,9 +9404,25 @@ snapshots:
 
   void-elements@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -8953,6 +9465,8 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  xml-name-validator@5.0.0: {}
+
   xml-parse-from-string@1.0.1: {}
 
   xml2js@0.5.0:
@@ -8963,6 +9477,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@13.0.2: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,104 +1,106 @@
 # Security Best Practices Report
 
-Date: 2026-03-20
-
-Scope reviewed:
-- Frontend: `apps/web`
-- Voice gateway: `apps/voice-gateway`
-- Backend and file handling: `convex`
-- Dependency tree: `package.json`, `pnpm-lock.yaml`
-
 ## Executive Summary
 
-This audit found 4 actionable security issues: 2 high severity, 1 medium severity, and 1 low severity. The most important risks are an unauthenticated websocket upgrade path on the Twilio media-stream endpoint and an untrusted image preview pipeline that currently depends on a vulnerable transitive parser. I did not find an obvious broken authorization boundary in the reviewed dashboard-facing Convex functions; the strongest issues are around ingress hardening, file processing, and secure authentication defaults.
+I reviewed the auth and email-delivery changes introduced on `feature/ope-55-resend-auth-email-delivery`, with emphasis on Convex Auth password reset, custom email-change confirmation, Resend integration, and the new settings/auth frontend surfaces.
 
-## High Severity
+I found 2 security issues worth addressing during the audit, and both have now been remediated on this branch:
 
-### S-001: Validate Twilio signatures before accepting `/media-stream` websocket upgrades
+1. An authenticated user can enumerate whether an email address already belongs to another account through the change-email flow.
+2. Email-change confirmation updates a sensitive login credential without invalidating existing sessions, unlike the password-change flow.
 
-Severity: High
-
-Evidence:
-- `apps/voice-gateway/src/http/server.ts:25-41` upgrades any request whose path is `/media-stream` by calling `mediaStreamServer.handleUpgrade(...)` immediately after the pathname check.
-- `apps/voice-gateway/src/telephony/mediaStream.ts:984-988` performs `ensureMediaStreamRequestIsAllowed()` only after the websocket is already established and the first message arrives.
-- `apps/voice-gateway/src/telephony/mediaStream.ts:1115-1137` contains the actual Twilio signature validation and closes invalid sockets after the upgrade has already consumed a websocket connection.
-- `apps/voice-gateway/src/telephony/twilioRequest.ts:35-62` shows the signature helper only needs the URL and header, so this validation can happen during the HTTP upgrade phase.
-
-Why this matters:
-An unauthenticated internet client can complete the websocket upgrade and hold an idle `/media-stream` connection open without ever sending a valid Twilio-signed frame. That creates an avoidable socket and memory exhaustion path on the voice gateway, especially if the service is directly reachable from the public internet.
-
-Recommended fix:
-- Validate the `X-Twilio-Signature` inside the `upgrade` handler before calling `handleUpgrade(...)`.
-- Reject invalid or missing signatures with an HTTP error response and destroy the socket immediately.
-- Keep the in-session validation as defense in depth if desired, but do not rely on message-time validation as the first gate.
-
-### S-002: Remove the vulnerable `file-type` parser from the untrusted image preview path
-
-Severity: High
-
-Evidence:
-- `package.json:18-33` pulls in `jimp` as a production dependency.
-- `pnpm-lock.yaml:2896-2898` locks `file-type@16.5.4`.
-- `convex/integrations/messageMedia.ts:32-45` fetches stored user/Twilio media and passes it into the preview pipeline.
-- `convex/lib/node/imagePreviews.ts:30-45` decodes untrusted blobs with `Jimp.fromBuffer(...)`.
-- `pnpm audit --prod` reports `GHSA-5v7r-6r5c-r473` for `file-type >=13.0.0 <21.3.1`, and `pnpm why file-type` shows that dependency is brought in through `jimp`.
-
-Why this matters:
-The application decodes untrusted uploaded images and inbound message media in a production code path, and that path currently depends on a transitive parser version with a published infinite-loop advisory. A malformed file can therefore tie up preview generation workers and degrade attachment handling availability.
-
-Recommended fix:
-- Upgrade or replace the preview stack so the vulnerable `file-type` version is no longer reachable from production code.
-- Add an explicit dependency override if needed to force a patched version while evaluating a longer-term library change.
-- Keep strict file-size and image-dimension limits ahead of decode so malformed inputs are rejected before expensive parsing work begins.
+I did not find evidence in the changed frontend code of client-side secret exposure, raw HTML injection, or dangerous DOM execution sinks.
 
 ## Medium Severity
 
-### S-003: Enforce server-side per-file upload limits before storage and preview generation
+### SEC-001: Authenticated email enumeration in the change-email flow
 
-Severity: Medium
+- Status: Fixed on this branch. The change-email action now returns the same outward success response for duplicate target emails and suppresses pending-change creation/email delivery when the target is unavailable.
 
-Evidence:
-- `convex/dashboard/messages.ts:582-590` issues upload URLs for attachments without attaching or checking any byte-size constraint.
-- `apps/web/src/features/messages/MessagesPage.tsx:476-535` uploads each selected file as-is and does not apply a client-side size gate before sending it to storage.
-- `convex/dashboard/messages.ts:618-626` reads the uploaded object metadata, but only returns the size instead of enforcing one.
-- `convex/dashboard/messages.ts:693-726` validates content type and immediately generates previews for images, even though no hard per-file limit has been enforced.
-- `convex/lib/messageAttachments.ts:115-150` enforces Twilio's 5 MB MMS total only later when resolving delivery modes, after storage and optional preview work have already happened.
+- Rule ID: REACT-CONFIG-001 / application auth privacy best practice
+- Severity: Medium
+- Location:
+  - [convex/businesses/catalog.ts:123](/Users/raphael/Coding/ai-receptionist/convex/businesses/catalog.ts#L123)
+  - [convex/businesses/catalog.ts:142](/Users/raphael/Coding/ai-receptionist/convex/businesses/catalog.ts#L142)
+  - [apps/web/src/features/settings/SettingsBusinessPage.tsx:200](/Users/raphael/Coding/ai-receptionist/apps/web/src/features/settings/SettingsBusinessPage.tsx#L200)
+  - [apps/web/public/locales/en/settings.json:153](/Users/raphael/Coding/ai-receptionist/apps/web/public/locales/en/settings.json#L153)
+- Evidence:
 
-Why this matters:
-Any authenticated operator can upload arbitrarily large supported files into storage, and images can then be fed into the preview decoder before the system ever rejects them for delivery. That increases storage costs and creates an easy resource-exhaustion path against the preview pipeline, especially when combined with the parser issue above.
+```ts
+if (
+  duplicateAccount &&
+  (!input.currentAccountId || duplicateAccount._id !== input.currentAccountId)
+) {
+  throw new Error("An account with that email already exists.");
+}
+```
 
-Recommended fix:
-- Add a hard server-side per-file maximum in the finalize path and delete oversized blobs immediately.
-- Mirror the same limit in the web client for better UX, but keep the server-side check authoritative.
-- Consider separate limits for image previews versus link-only document attachments.
+```ts
+if (message.includes("already exists")) {
+  return t("account.changeEmail.errors.alreadyExists");
+}
+```
+
+```json
+"alreadyExists": "An account with that email already exists."
+```
+
+- Impact: Any authenticated user can test arbitrary email addresses and learn whether they are already registered in the system, which can aid targeted phishing, credential-stuffing preparation, or user discovery across tenants.
+- Fix: Return the same generic success/error response for both “email already registered” and “confirmation link sent,” while still suppressing the actual email send internally when the target is unavailable.
+- Mitigation: If product UX requires a specific message, restrict visibility to trusted admin roles only and add request telemetry plus throttling for repeated change-email attempts.
+- False positive notes: This is still a privacy/security issue even though the attacker must already be logged in; the question is whether any normal user should be able to probe account existence for arbitrary email addresses.
 
 ## Low Severity
 
-### S-004: Strengthen the password policy beyond a bare 8-character minimum
+### SEC-002: Email-change confirmation does not revoke existing sessions
 
-Severity: Low
+- Status: Fixed on this branch. The confirm-email action now invalidates existing sessions after the email credential change is applied.
 
-Evidence:
-- `convex/lib/passwordPolicy.ts:1-4` accepts any non-empty password with length 8 or more.
-- `convex/auth.ts:1-10` wires that check directly into the live password provider.
+- Rule ID: session hardening after credential changes
+- Severity: Low
+- Location:
+  - [convex/businesses/catalog.ts:322](/Users/raphael/Coding/ai-receptionist/convex/businesses/catalog.ts#L322)
+  - [convex/businesses/catalog.ts:363](/Users/raphael/Coding/ai-receptionist/convex/businesses/catalog.ts#L363)
+  - [convex/businesses/catalog.ts:456](/Users/raphael/Coding/ai-receptionist/convex/businesses/catalog.ts#L456)
+- Evidence:
 
-Why this matters:
-The current rule allows extremely weak passwords such as common dictionary words or low-entropy repeated characters. That leaves account security overly dependent on users choosing strong secrets on their own and weakens the baseline protection against credential stuffing and password reuse.
+The password-change flow explicitly revokes sessions:
 
-Recommended fix:
-- Raise the minimum length and add a blocklist or strength check for common and compromised passwords.
-- Consider adding rate limiting and MFA in the authentication flow if those controls are not already enforced outside this repo.
+```ts
+const sessionId = await getAuthSessionId(authCtx);
+await invalidateSessions(authCtx, {
+  userId: user.userId,
+  ...(sessionId ? { except: [sessionId] } : {}),
+});
+```
 
-## Runtime Verification Notes
+But the email-change confirmation flow updates the credential and returns without any session invalidation:
 
-These items were not scored as formal findings because they may be enforced outside this repository, but they should be verified explicitly:
+```ts
+await ctx.db.patch(account._id, {
+  providerAccountId: nextEmail,
+  emailVerified: nextEmail,
+});
+await ctx.db.patch(user._id, {
+  email: nextEmail,
+  emailVerificationTime: Date.now(),
+});
+await ctx.db.delete(verificationCode._id);
+```
 
-- I did not find repo-visible configuration for `Content-Security-Policy`, `frame-ancestors` / `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, or `X-Content-Type-Options`. `apps/web/index.html:1-12` contains no meta-based fallback either. If these headers are set at the CDN or hosting layer, document that ownership; if not, add them there.
-- `apps/voice-gateway/src/http/server.ts:12-24` creates the Fastify server without repo-visible hardening middleware such as `@fastify/helmet`. If the gateway is directly internet-facing, verify that equivalent headers and request size limits are enforced upstream.
+- Impact: Existing sessions remain valid after a sensitive sign-in identifier change, so a previously stolen session continues to work even after the account’s email login is moved.
+- Fix: Invalidate all other sessions after successful email confirmation, mirroring the password-change behavior and optionally keeping only the confirming session if there is one.
+- Mitigation: At minimum, log and alert on email-change events and force re-authentication before additional sensitive actions.
+- False positive notes: This does not make email change unauthenticated; the confirmation link is still required. The issue is reduced containment after a credential update.
 
-## Suggested Remediation Order
+## What I Checked
 
-1. Fix S-001 by validating Twilio signatures before websocket upgrade.
-2. Fix S-002 by removing or overriding the vulnerable parser chain in the preview pipeline.
-3. Fix S-003 by adding authoritative server-side upload size limits and early cleanup.
-4. Fix S-004 by hardening password policy and confirming authentication rate-limiting controls.
+- Password reset uses Convex Auth `Password({ reset: ... })` rather than a custom ad hoc endpoint.
+- Reset-code verification inherits Convex Auth rate limiting for failed code attempts.
+- Email templates are rendered from plain strings with HTML escaping, not from raw user HTML.
+- The changed frontend code does not use `dangerouslySetInnerHTML`, `innerHTML`, `eval`, or other obvious XSS sinks.
+- I did not see secrets added to `VITE_*` variables or other browser-exposed config in this branch.
+
+## Remaining Recommendation
+
+1. Consider refactoring email-change onto a more first-class Convex Auth flow over time, since the current implementation still relies on custom auth-table handling.


### PR DESCRIPTION
## Summary
- add Resend-based auth email delivery support across Convex auth and provider configuration
- wire up password reset and email change flows, including related schema and user/account handling updates
- update web auth and settings UI copy and behavior for the new email delivery flow
- add documentation, environment examples, and supporting test coverage

## Testing
- Not run (not requested)