### PR TITLE
Harden pricing bypass handling across voice runtime and billing flows

### DIFF
--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -167,24 +167,13 @@ export async function reconcileVoiceCallStatus(input: {
   ignored: boolean;
   reason?: string;
   callId?: string;
-  usageEventId?: string;
 }> {
   return await postJson<{
     ignored: boolean;
     reason?: string;
     callId?: string;
-    usageEventId?: string;
   }>(
     "/voice/call/reconcile-status",
-    input,
-  );
-}
-
-export async function syncUsageEventToPolar(input: {
-  usageEventId: string;
-}): Promise<{ synced: boolean; error?: string }> {
-  return await postJson<{ synced: boolean; error?: string }>(
-    "/billing/usage/sync",
     input,
   );
 }

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -148,11 +148,20 @@ export async function prepareVoiceTransfer(input: {
   await postJson("/voice/call/prepare-transfer", input);
 }
 
+export async function releaseVoiceTransfer(input: {
+  callId?: string;
+  twilioCallSid?: string;
+  recordedAt: string;
+}): Promise<void> {
+  await postJson("/voice/call/release-transfer", input);
+}
+
 export async function completeVoiceCall(input: {
   callId: string;
   status: string;
   endedAt: string;
   disposition?: string;
+  providerDurationSeconds?: number;
 }): Promise<void> {
   await postJson("/voice/call/complete", input);
 }

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -140,6 +140,13 @@ export async function updateVoiceTransferState(input: {
   await postJson("/voice/call/transfer-state", input);
 }
 
+export async function prepareVoiceTransfer(input: {
+  callId: string;
+  recordedAt: string;
+}): Promise<void> {
+  await postJson("/voice/call/prepare-transfer", input);
+}
+
 export async function completeVoiceCall(input: {
   callId: string;
   status: string;

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -141,7 +141,8 @@ export async function updateVoiceTransferState(input: {
 }
 
 export async function prepareVoiceTransfer(input: {
-  callId: string;
+  callId?: string;
+  twilioCallSid?: string;
   recordedAt: string;
 }): Promise<void> {
   await postJson("/voice/call/prepare-transfer", input);

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -762,15 +762,15 @@ async function performTransfer(
   if (
     !session.pendingTransferDestination ||
     session.transferExecuted ||
-    !session.callSid ||
-    !session.callId
+    !session.callSid
   ) {
     return;
   }
 
   try {
     await prepareVoiceTransfer({
-      callId: session.callId,
+      ...(session.callId ? { callId: session.callId } : {}),
+      ...(!session.callId ? { twilioCallSid: session.callSid } : {}),
       recordedAt: new Date().toISOString(),
     });
     session.transferExecuted = true;
@@ -975,12 +975,11 @@ async function recoverFromProviderFailure(
       }
 
       try {
-        if (session.callId) {
-          await prepareVoiceTransfer({
-            callId: session.callId,
-            recordedAt: new Date().toISOString(),
-          });
-        }
+        await prepareVoiceTransfer({
+          ...(session.callId ? { callId: session.callId } : {}),
+          ...(!session.callId ? { twilioCallSid: session.callSid } : {}),
+          recordedAt: new Date().toISOString(),
+        });
         await transferLiveCall({
           callSid: session.callSid,
           destination: transferDestination,

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -7,8 +7,10 @@ import WebSocket from "ws";
 
 import { buildStereoCallRecording, type TimedAudioChunk } from "../audio/wav";
 import {
+  RuntimeRequestError,
   appendVoiceTranscript,
   completeVoiceCall,
+  prepareVoiceTransfer,
   startVoiceCall,
   updateVoiceTransferState,
   uploadVoiceRecording,
@@ -194,6 +196,16 @@ type RealtimePricingConfig = {
   audioOutputTokenPriceUsd?: number;
   cachedInputTokenPriceUsd?: number;
 };
+
+function isTransferQuotaError(error: unknown): boolean {
+  return (
+    error instanceof RuntimeRequestError &&
+    error.code === "outbound_call_attempt_limit_reached"
+  );
+}
+
+const TRANSFER_QUOTA_REACHED_MESSAGE =
+  "This business has reached its transfer limit for this billing period. Please try again later.";
 
 function asUnknownRecord(
   value: unknown,
@@ -747,12 +759,21 @@ async function performTransfer(
   server: FastifyInstance,
   session: ActiveVoiceSession,
 ): Promise<void> {
-  if (!session.pendingTransferDestination || session.transferExecuted || !session.callSid) {
+  if (
+    !session.pendingTransferDestination ||
+    session.transferExecuted ||
+    !session.callSid ||
+    !session.callId
+  ) {
     return;
   }
 
-  session.transferExecuted = true;
   try {
+    await prepareVoiceTransfer({
+      callId: session.callId,
+      recordedAt: new Date().toISOString(),
+    });
+    session.transferExecuted = true;
     await transferLiveCall({
       callSid: session.callSid,
       destination: session.pendingTransferDestination,
@@ -774,6 +795,12 @@ async function performTransfer(
       await updateVoiceTransferState({
         callId: session.callId,
         transferState: "failed",
+      });
+    }
+    if (isTransferQuotaError(error)) {
+      await endLiveCallWithMessage({
+        callSid: session.callSid,
+        sayMessage: TRANSFER_QUOTA_REACHED_MESSAGE,
       });
     }
   }
@@ -948,6 +975,12 @@ async function recoverFromProviderFailure(
       }
 
       try {
+        if (session.callId) {
+          await prepareVoiceTransfer({
+            callId: session.callId,
+            recordedAt: new Date().toISOString(),
+          });
+        }
         await transferLiveCall({
           callSid: session.callSid,
           destination: transferDestination,
@@ -973,6 +1006,13 @@ async function recoverFromProviderFailure(
                 : "Failed to persist failed transfer state during provider recovery",
             );
           }
+        }
+        if (isTransferQuotaError(error)) {
+          await endLiveCallWithMessage({
+            callSid: session.callSid,
+            sayMessage: TRANSFER_QUOTA_REACHED_MESSAGE,
+          });
+          return;
         }
         throw error;
       }

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -11,6 +11,7 @@ import {
   appendVoiceTranscript,
   completeVoiceCall,
   prepareVoiceTransfer,
+  releaseVoiceTransfer,
   startVoiceCall,
   updateVoiceTransferState,
   uploadVoiceRecording,
@@ -767,12 +768,15 @@ async function performTransfer(
     return;
   }
 
+  let reservationPrepared = false;
+  let transferSubmitted = false;
   try {
     await prepareVoiceTransfer({
       ...(session.callId ? { callId: session.callId } : {}),
       ...(!session.callId ? { twilioCallSid: session.callSid } : {}),
       recordedAt: new Date().toISOString(),
     });
+    reservationPrepared = true;
     session.transferExecuted = true;
     await transferLiveCall({
       callSid: session.callSid,
@@ -783,6 +787,7 @@ async function performTransfer(
           }
         : {}),
     });
+    transferSubmitted = true;
     if (session.callId) {
       await updateVoiceTransferState({
         callId: session.callId,
@@ -796,6 +801,24 @@ async function performTransfer(
         callId: session.callId,
         transferState: "failed",
       });
+    }
+    if (reservationPrepared && !transferSubmitted) {
+      try {
+        await releaseVoiceTransfer({
+          ...(session.callId ? { callId: session.callId } : {}),
+          ...(!session.callId ? { twilioCallSid: session.callSid } : {}),
+          recordedAt: new Date().toISOString(),
+        });
+      } catch (releaseError) {
+        server.log.error(
+          {
+            err: releaseError,
+            callId: session.callId,
+            callSid: session.callSid,
+          },
+          "Failed to release reserved transfer usage after handoff submission error",
+        );
+      }
     }
     if (isTransferQuotaError(error)) {
       await endLiveCallWithMessage({
@@ -903,6 +926,7 @@ async function finalizeCall(
         status: finalDisposition === "transferred" ? "transferred" : "completed",
         endedAt: new Date().toISOString(),
         disposition: finalDisposition,
+        providerDurationSeconds: Math.max(0, Math.ceil(durationMs / 1000)),
       });
     }
   } catch (error) {
@@ -974,18 +998,22 @@ async function recoverFromProviderFailure(
         }
       }
 
+      let reservationPrepared = false;
+      let transferSubmitted = false;
       try {
         await prepareVoiceTransfer({
           ...(session.callId ? { callId: session.callId } : {}),
           ...(!session.callId ? { twilioCallSid: session.callSid } : {}),
           recordedAt: new Date().toISOString(),
         });
+        reservationPrepared = true;
         await transferLiveCall({
           callSid: session.callSid,
           destination: transferDestination,
           sayMessage: fallbackMessage,
           ...(session.callId ? { actionUrl: getTransferActionUrl(server, session.callId) } : {}),
         });
+        transferSubmitted = true;
       } catch (error) {
         if (session.callId) {
           try {
@@ -1003,6 +1031,24 @@ async function recoverFromProviderFailure(
               stateError instanceof Error
                 ? stateError.message
                 : "Failed to persist failed transfer state during provider recovery",
+            );
+          }
+        }
+        if (reservationPrepared && !transferSubmitted) {
+          try {
+            await releaseVoiceTransfer({
+              ...(session.callId ? { callId: session.callId } : {}),
+              ...(!session.callId ? { twilioCallSid: session.callSid } : {}),
+              recordedAt: new Date().toISOString(),
+            });
+          } catch (releaseError) {
+            server.log.error(
+              {
+                err: releaseError,
+                callId: session.callId,
+                callSid: session.callSid,
+              },
+              "Failed to release transfer usage after provider recovery handoff error",
             );
           }
         }

--- a/apps/voice-gateway/src/telephony/routes.test.ts
+++ b/apps/voice-gateway/src/telephony/routes.test.ts
@@ -12,7 +12,6 @@ const {
   startVoiceCallMock,
   completeVoiceCallMock,
   reconcileVoiceCallStatusMock,
-  syncUsageEventToPolarMock,
   updateVoiceTransferStateMock,
 } = vi.hoisted(() => ({
   fetchSnapshotForPhoneNumberMock: vi.fn(),
@@ -32,7 +31,6 @@ const {
   startVoiceCallMock: vi.fn(),
   completeVoiceCallMock: vi.fn(),
   reconcileVoiceCallStatusMock: vi.fn(),
-  syncUsageEventToPolarMock: vi.fn(),
   updateVoiceTransferStateMock: vi.fn(),
 }));
 
@@ -45,7 +43,6 @@ vi.mock("../convex/runtimeClient", () => ({
   startVoiceCall: startVoiceCallMock,
   completeVoiceCall: completeVoiceCallMock,
   reconcileVoiceCallStatus: reconcileVoiceCallStatusMock,
-  syncUsageEventToPolar: syncUsageEventToPolarMock,
   updateVoiceTransferState: updateVoiceTransferStateMock,
 }));
 
@@ -106,9 +103,6 @@ describe("voice routes", () => {
     reconcileVoiceCallStatusMock.mockResolvedValue({
       ignored: false,
       callId: "call_123",
-    });
-    syncUsageEventToPolarMock.mockResolvedValue({
-      synced: true,
     });
     updateVoiceTransferStateMock.mockResolvedValue(undefined);
   });
@@ -212,7 +206,7 @@ describe("voice routes", () => {
     await server.close();
   });
 
-  it("syncs recorded voice usage to Polar after terminal call reconciliation", async () => {
+  it("reconciles terminal call status without requiring a separate billing sync request", async () => {
     const server = createServer();
     const payload = {
       CallSid: "CA123",
@@ -222,7 +216,6 @@ describe("voice routes", () => {
     reconcileVoiceCallStatusMock.mockResolvedValueOnce({
       ignored: false,
       callId: "call_123",
-      usageEventId: "usage_event_123",
     });
 
     const response = await server.inject({
@@ -236,8 +229,10 @@ describe("voice routes", () => {
     });
 
     expect(response.statusCode).toBe(204);
-    expect(syncUsageEventToPolarMock).toHaveBeenCalledWith({
-      usageEventId: "usage_event_123",
+    expect(reconcileVoiceCallStatusMock).toHaveBeenCalledWith({
+      twilioCallSid: "CA123",
+      callStatus: "completed",
+      providerUpdatedAt: expect.any(String),
     });
 
     await server.close();

--- a/apps/voice-gateway/src/telephony/routes.ts
+++ b/apps/voice-gateway/src/telephony/routes.ts
@@ -9,7 +9,6 @@ import { fetchSnapshotForPhoneNumber } from "../context/fetchSnapshot";
 import {
   completeVoiceCall,
   RuntimeRequestError,
-  syncUsageEventToPolar,
   startVoiceCall,
   reconcileVoiceCallStatus,
   updateVoiceTransferState,
@@ -270,12 +269,6 @@ export function registerVoiceRoutes(server: FastifyInstance): void {
         ? { providerDurationSeconds: normalized.durationSeconds }
         : {}),
     });
-
-    if (!result.ignored && result.usageEventId) {
-      await syncUsageEventToPolar({
-        usageEventId: result.usageEventId,
-      });
-    }
 
     if (result.ignored && result.reason === "unknown_call") {
       server.log.warn(

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -16,6 +16,10 @@ import type {
   SmsSenderRole,
 } from "../packages/shared/src/billing";
 import {
+  getPostHogBusinessGroupKey,
+  getPostHogDistinctIdForBusinessSystem,
+} from "./telemetry/shared";
+import {
   billingAddonCatalog,
   billingErrorCodes,
   billingPlanCatalog,
@@ -53,6 +57,7 @@ import {
   getProProductId,
   isAiSmsEnabled,
 } from "./lib/billing";
+import { enqueuePostHogEventBestEffort } from "./telemetry/posthog";
 
 type BillingContact = {
   email: string | null;
@@ -110,6 +115,10 @@ type SmsCapabilityPolicy = {
   errorCode: BillingErrorCode | null;
 };
 
+type UsageSyncTelemetryEventName =
+  | "ops.billing.usage_sync_failed"
+  | "ops.billing.usage_sync_recovered";
+
 const BILLING_ADMIN_ROLES = new Set([
   "business_owner",
   "business_admin",
@@ -122,6 +131,42 @@ const USAGE_SYNC_RETRY_DELAYS_MS = [
   600_000,
   1_800_000,
 ] as const;
+
+async function emitUsageSyncTelemetry(
+  ctx: Pick<ActionCtx, "runMutation">,
+  input: {
+    eventName: UsageSyncTelemetryEventName;
+    businessId: Id<"businesses">;
+    usageKind: BillingUsageKind;
+    quantity: number;
+    sourceKey: string;
+    attemptNumber: number;
+    retryScheduled?: boolean;
+    retryDelayMs?: number;
+    errorType?: string;
+    recovered?: boolean;
+  },
+): Promise<void> {
+  await enqueuePostHogEventBestEffort(ctx, {
+    eventName: input.eventName,
+    businessId: input.businessId,
+    distinctId: getPostHogDistinctIdForBusinessSystem(String(input.businessId)),
+    groupKey: getPostHogBusinessGroupKey(String(input.businessId)),
+    provider: "polar",
+    properties: {
+      usageKind: input.usageKind,
+      quantity: input.quantity,
+      sourceKey: input.sourceKey,
+      attemptNumber: input.attemptNumber,
+      ...(input.retryScheduled !== undefined
+        ? { retryScheduled: input.retryScheduled }
+        : {}),
+      ...(input.retryDelayMs !== undefined ? { retryDelayMs: input.retryDelayMs } : {}),
+      ...(input.errorType ? { errorType: input.errorType } : {}),
+      ...(input.recovered !== undefined ? { recovered: input.recovered } : {}),
+    },
+  });
+}
 
 const billingPolar = new ConvexPolar(components.polar, {
   getUserInfo: async () => ({
@@ -1448,13 +1493,26 @@ export const syncUsageEventToPolar = internalAction({
         syncedAt: syncAttemptedAt,
       });
 
+      if (attempt > 0) {
+        await emitUsageSyncTelemetry(ctx, {
+          eventName: "ops.billing.usage_sync_recovered",
+          businessId: payload.businessId,
+          usageKind: payload.usageKind,
+          quantity: payload.quantity,
+          sourceKey: payload.sourceKey,
+          attemptNumber: attempt + 1,
+          recovered: true,
+        });
+      }
+
       return { synced: true };
     } catch (error) {
       const errorMessage = getErrorMessage(error);
       let scheduledRetry = false;
+      let retryDelayMs: number | undefined;
 
       if (attempt < USAGE_SYNC_RETRY_DELAYS_MS.length) {
-        const retryDelayMs = USAGE_SYNC_RETRY_DELAYS_MS[attempt];
+        retryDelayMs = USAGE_SYNC_RETRY_DELAYS_MS[attempt];
         if (retryDelayMs !== undefined) {
           await ctx.scheduler.runAfter(  // Best-effort retry for transient Polar failures.
             retryDelayMs,
@@ -1473,6 +1531,18 @@ export const syncUsageEventToPolar = internalAction({
         syncStatus: "failed",
         syncAttemptedAt,
         syncError: errorMessage,
+      });
+
+      await emitUsageSyncTelemetry(ctx, {
+        eventName: "ops.billing.usage_sync_failed",
+        businessId: payload.businessId,
+        usageKind: payload.usageKind,
+        quantity: payload.quantity,
+        sourceKey: payload.sourceKey,
+        attemptNumber: attempt + 1,
+        retryScheduled: scheduledRetry,
+        ...(retryDelayMs !== undefined ? { retryDelayMs } : {}),
+        errorType: error instanceof Error ? error.name : "UnknownError",
       });
 
       return { synced: false, scheduledRetry, error: errorMessage };

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -1779,7 +1779,7 @@ export const reserveAlertSmsUsage = internalMutation({
         q.eq("businessId", args.businessId).eq("sourceKey", sourceKey),
       )
       .unique();
-    if (existingUsageEvent) {
+    if (existingUsageEvent && existingUsageEvent.quantity > 0) {
       return {
         allowed: true,
         errorCode: null,

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -1685,6 +1685,22 @@ export const reserveVoiceUsageAtCallStart = internalMutation({
     syncNeeded: v.optional(v.boolean()),
   }),
   handler: async (ctx, args): Promise<UsageReservationResult> => {
+    const sourceKey = `voice:${String(args.callId)}`;
+    const existingUsageEvent = await ctx.db
+      .query("billing_usage_events")
+      .withIndex("by_business_id_and_source_key", (q) =>
+        q.eq("businessId", args.businessId).eq("sourceKey", sourceKey),
+      )
+      .unique();
+    if (existingUsageEvent) {
+      return {
+        allowed: true,
+        errorCode: null,
+        usageEventId: existingUsageEvent._id,
+        syncNeeded: false,
+      };
+    }
+
     const snapshot = await getBillingSnapshot(ctx, {
       businessId: args.businessId,
       at: args.recordedAt,
@@ -1723,7 +1739,7 @@ export const reserveVoiceUsageAtCallStart = internalMutation({
       businessId: args.businessId,
       usageKind: "voice_seconds",
       quantity: reserveQuantity,
-      sourceKey: `voice:${String(args.callId)}`,
+      sourceKey,
       recordedAt: args.recordedAt,
     });
 
@@ -1766,6 +1782,7 @@ export const reserveAlertSmsUsage = internalMutation({
       usage: snapshot.usage,
     });
     const normalizedSegments = Math.max(1, Math.trunc(args.estimatedSegments));
+    const overagesBillable = billingPlanCatalog[snapshot.plan].overagesBillable;
 
     if (usage.alertSmsBlocked) {
       return {
@@ -1774,6 +1791,7 @@ export const reserveAlertSmsUsage = internalMutation({
       };
     }
     if (
+      !overagesBillable &&
       usage.alertSmsSegmentsRemaining !== null &&
       normalizedSegments > usage.alertSmsSegmentsRemaining
     ) {
@@ -1828,6 +1846,7 @@ export const reserveOutboundCallAttemptUsage = internalMutation({
       periodKey: snapshot.periodKey,
       usage: snapshot.usage,
     });
+    const overagesBillable = billingPlanCatalog[snapshot.plan].overagesBillable;
 
     if (usage.outboundCallAttemptsBlocked) {
       return {
@@ -1836,6 +1855,7 @@ export const reserveOutboundCallAttemptUsage = internalMutation({
       };
     }
     if (
+      !overagesBillable &&
       usage.outboundCallAttemptsRemaining !== null &&
       usage.outboundCallAttemptsRemaining < 1
     ) {

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -1882,6 +1882,53 @@ export const reserveOutboundCallAttemptUsage = internalMutation({
   },
 });
 
+export const releaseOutboundCallAttemptReservation = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+    callId: v.id("calls"),
+    recordedAt: v.string(),
+  },
+  returns: v.object({
+    released: v.boolean(),
+    usageEventId: v.optional(v.id("billing_usage_events")),
+    syncNeeded: v.optional(v.boolean()),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    released: boolean;
+    usageEventId?: Id<"billing_usage_events">;
+    syncNeeded?: boolean;
+  }> => {
+    const sourceKey = `outbound_attempt:voice_call:${String(args.callId)}`;
+    const existingUsageEvent = await ctx.db
+      .query("billing_usage_events")
+      .withIndex("by_business_id_and_source_key", (q) =>
+        q.eq("businessId", args.businessId).eq("sourceKey", sourceKey),
+      )
+      .unique();
+
+    if (!existingUsageEvent) {
+      return { released: false };
+    }
+
+    const usageResult = await upsertUsageEventInTx(ctx, {
+      businessId: args.businessId,
+      usageKind: "outbound_call_attempts",
+      quantity: 0,
+      sourceKey,
+      recordedAt: args.recordedAt,
+    });
+
+    return {
+      released: true,
+      usageEventId: usageResult.usageEventId,
+      syncNeeded: usageResult.syncNeeded,
+    };
+  },
+});
+
 export const getSmsCapabilityPolicy = internalQuery({
   args: {
     businessId: v.id("businesses"),

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -1772,6 +1772,22 @@ export const reserveAlertSmsUsage = internalMutation({
     syncNeeded: v.optional(v.boolean()),
   }),
   handler: async (ctx, args): Promise<UsageReservationResult> => {
+    const sourceKey = `alert_sms:${String(args.notificationId)}`;
+    const existingUsageEvent = await ctx.db
+      .query("billing_usage_events")
+      .withIndex("by_business_id_and_source_key", (q) =>
+        q.eq("businessId", args.businessId).eq("sourceKey", sourceKey),
+      )
+      .unique();
+    if (existingUsageEvent) {
+      return {
+        allowed: true,
+        errorCode: null,
+        usageEventId: existingUsageEvent._id,
+        syncNeeded: false,
+      };
+    }
+
     const snapshot = await getBillingSnapshot(ctx, {
       businessId: args.businessId,
       at: args.recordedAt,
@@ -1805,7 +1821,7 @@ export const reserveAlertSmsUsage = internalMutation({
       businessId: args.businessId,
       usageKind: "alert_sms_segments",
       quantity: normalizedSegments,
-      sourceKey: `alert_sms:${String(args.notificationId)}`,
+      sourceKey,
       recordedAt: args.recordedAt,
     });
 
@@ -1837,6 +1853,22 @@ export const reserveOutboundCallAttemptUsage = internalMutation({
     syncNeeded: v.optional(v.boolean()),
   }),
   handler: async (ctx, args): Promise<UsageReservationResult> => {
+    const sourceKey = `outbound_attempt:voice_call:${String(args.callId)}`;
+    const existingUsageEvent = await ctx.db
+      .query("billing_usage_events")
+      .withIndex("by_business_id_and_source_key", (q) =>
+        q.eq("businessId", args.businessId).eq("sourceKey", sourceKey),
+      )
+      .unique();
+    if (existingUsageEvent) {
+      return {
+        allowed: true,
+        errorCode: null,
+        usageEventId: existingUsageEvent._id,
+        syncNeeded: false,
+      };
+    }
+
     const snapshot = await getBillingSnapshot(ctx, {
       businessId: args.businessId,
       at: args.recordedAt,
@@ -1869,7 +1901,7 @@ export const reserveOutboundCallAttemptUsage = internalMutation({
       businessId: args.businessId,
       usageKind: "outbound_call_attempts",
       quantity: 1,
-      sourceKey: `outbound_attempt:voice_call:${String(args.callId)}`,
+      sourceKey,
       recordedAt: args.recordedAt,
     });
 

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -87,6 +87,13 @@ type UpsertUsageResult = {
   syncNeeded: boolean;
 };
 
+type UsageReservationResult = {
+  allowed: boolean;
+  errorCode: BillingErrorCode | null;
+  usageEventId?: Id<"billing_usage_events">;
+  syncNeeded?: boolean;
+};
+
 type PricingSummary = {
   plan: BillingPlanSlug;
   activeAddons: Array<BillingAddonSlug>;
@@ -386,6 +393,146 @@ function buildUsageMonthPatch(args: {
       nextOutboundCallAttempts >= entitlements.outboundCallAttemptsIncluded,
     lastRecordedAt: args.recordedAt,
   };
+}
+
+async function upsertUsageEventInTx(
+  ctx: MutationCtx,
+  args: {
+    businessId: Id<"businesses">;
+    usageKind: BillingUsageKind;
+    quantity: number;
+    sourceKey: string;
+    recordedAt: string;
+  },
+): Promise<UpsertUsageResult> {
+  const snapshot = await getBillingSnapshot(ctx, {
+    businessId: args.businessId,
+    at: args.recordedAt,
+  });
+  const syncNeeded = shouldSyncUsageEvent({
+    plan: snapshot.plan,
+    activeAddons: snapshot.activeAddons,
+    usageKind: args.usageKind,
+  });
+
+  const existingUsageEvent = await ctx.db
+    .query("billing_usage_events")
+    .withIndex("by_business_id_and_source_key", (q) =>
+      q.eq("businessId", args.businessId).eq("sourceKey", args.sourceKey),
+    )
+    .unique();
+
+  const deltaQuantity = args.quantity - (existingUsageEvent?.quantity ?? 0);
+  const existingPeriodKey = existingUsageEvent?.periodKey ?? null;
+  const periodChanged =
+    existingPeriodKey !== null && existingPeriodKey !== snapshot.periodKey;
+
+  if (periodChanged && existingUsageEvent) {
+    const previousUsageMonth = await getBillingUsageMonth(ctx, {
+      businessId: args.businessId,
+      periodKey: existingUsageEvent.periodKey,
+    });
+    if (previousUsageMonth) {
+      const previousMonthPatch = buildUsageMonthPatch({
+        plan:
+          previousUsageMonth.planAtSnapshot ??
+          existingUsageEvent.planAtRecordTime ??
+          snapshot.plan,
+        usage: previousUsageMonth,
+        usageKind: args.usageKind,
+        deltaQuantity: -existingUsageEvent.quantity,
+        recordedAt: existingUsageEvent.recordedAt,
+      });
+      await ctx.db.patch(previousUsageMonth._id, previousMonthPatch);
+    }
+  }
+
+  if (!snapshot.usage) {
+    const monthPatch = buildUsageMonthPatch({
+      plan: snapshot.plan,
+      usage: null,
+      usageKind: args.usageKind,
+      deltaQuantity: args.quantity,
+      recordedAt: args.recordedAt,
+    });
+
+    await ctx.db.insert("billing_usage_months", {
+      businessId: args.businessId,
+      periodKey: snapshot.periodKey,
+      ...monthPatch,
+    });
+  } else if (periodChanged) {
+    const monthPatch = buildUsageMonthPatch({
+      plan: snapshot.plan,
+      usage: snapshot.usage,
+      usageKind: args.usageKind,
+      deltaQuantity: args.quantity,
+      recordedAt: args.recordedAt,
+    });
+    await ctx.db.patch(snapshot.usage._id, monthPatch);
+  } else if (deltaQuantity !== 0) {
+    const monthPatch = buildUsageMonthPatch({
+      plan: snapshot.plan,
+      usage: snapshot.usage,
+      usageKind: args.usageKind,
+      deltaQuantity,
+      recordedAt: args.recordedAt,
+    });
+    await ctx.db.patch(snapshot.usage._id, monthPatch);
+  } else if (snapshot.usage.lastRecordedAt !== args.recordedAt) {
+    await ctx.db.patch(snapshot.usage._id, {
+      lastRecordedAt: args.recordedAt,
+    });
+  }
+
+  if (existingUsageEvent) {
+    await ctx.db.patch(existingUsageEvent._id, {
+      periodKey: snapshot.periodKey,
+      quantity: args.quantity,
+      planAtRecordTime: snapshot.plan,
+      activeAddonsAtRecordTime: snapshot.activeAddons,
+      recordedAt: args.recordedAt,
+      syncStatus: syncNeeded ? "pending" : "skipped",
+    });
+
+    return {
+      usageEventId: existingUsageEvent._id,
+      plan: snapshot.plan,
+      activeAddons: snapshot.activeAddons,
+      syncNeeded,
+    };
+  }
+
+  const usageEventId = await ctx.db.insert("billing_usage_events", {
+    businessId: args.businessId,
+    periodKey: snapshot.periodKey,
+    sourceKey: args.sourceKey,
+    usageKind: args.usageKind,
+    quantity: args.quantity,
+    planAtRecordTime: snapshot.plan,
+    activeAddonsAtRecordTime: snapshot.activeAddons,
+    recordedAt: args.recordedAt,
+    syncStatus: syncNeeded ? "pending" : "skipped",
+  });
+
+  return {
+    usageEventId,
+    plan: snapshot.plan,
+    activeAddons: snapshot.activeAddons,
+    syncNeeded,
+  };
+}
+
+function reserveVoiceSecondsForStart(args: {
+  plan: BillingPlanSlug;
+  usage: ReturnType<typeof getBillingUsageSnapshotData>;
+}): number | null {
+  const entitlements = billingPlanCatalog[args.plan];
+  if (entitlements.overagesBillable || entitlements.voiceSecondsIncluded === null) {
+    return null;
+  }
+
+  return args.usage.voiceSecondsRemaining;
 }
 
 function getPlatformAlertSmsSenderFromEnv(): string | null {
@@ -1169,124 +1316,8 @@ export const upsertUsageEvent = internalMutation({
     activeAddons: v.array(v.union(v.literal("ai_sms"))),
     syncNeeded: v.boolean(),
   }),
-  handler: async (ctx, args): Promise<UpsertUsageResult> => {
-    const snapshot = await getBillingSnapshot(ctx, {
-      businessId: args.businessId,
-      at: args.recordedAt,
-    });
-    const syncNeeded = shouldSyncUsageEvent({
-      plan: snapshot.plan,
-      activeAddons: snapshot.activeAddons,
-      usageKind: args.usageKind,
-    });
-
-    const existingUsageEvent = await ctx.db
-      .query("billing_usage_events")
-      .withIndex("by_business_id_and_source_key", (q) =>
-        q.eq("businessId", args.businessId).eq("sourceKey", args.sourceKey),
-      )
-      .unique();
-
-    const deltaQuantity = args.quantity - (existingUsageEvent?.quantity ?? 0);
-    const existingPeriodKey = existingUsageEvent?.periodKey ?? null;
-    const periodChanged =
-      existingPeriodKey !== null && existingPeriodKey !== snapshot.periodKey;
-
-    if (periodChanged && existingUsageEvent) {
-      const previousUsageMonth = await getBillingUsageMonth(ctx, {
-        businessId: args.businessId,
-        periodKey: existingUsageEvent.periodKey,
-      });
-      if (previousUsageMonth) {
-        const previousMonthPatch = buildUsageMonthPatch({
-          plan:
-            previousUsageMonth.planAtSnapshot ??
-            existingUsageEvent.planAtRecordTime ??
-            snapshot.plan,
-          usage: previousUsageMonth,
-          usageKind: args.usageKind,
-          deltaQuantity: -existingUsageEvent.quantity,
-          recordedAt: existingUsageEvent.recordedAt,
-        });
-        await ctx.db.patch(previousUsageMonth._id, previousMonthPatch);
-      }
-    }
-
-    if (!snapshot.usage) {
-      const monthPatch = buildUsageMonthPatch({
-        plan: snapshot.plan,
-        usage: null,
-        usageKind: args.usageKind,
-        deltaQuantity: args.quantity,
-        recordedAt: args.recordedAt,
-      });
-
-      await ctx.db.insert("billing_usage_months", {
-        businessId: args.businessId,
-        periodKey: snapshot.periodKey,
-        ...monthPatch,
-      });
-    } else if (periodChanged) {
-      const monthPatch = buildUsageMonthPatch({
-        plan: snapshot.plan,
-        usage: snapshot.usage,
-        usageKind: args.usageKind,
-        deltaQuantity: args.quantity,
-        recordedAt: args.recordedAt,
-      });
-      await ctx.db.patch(snapshot.usage._id, monthPatch);
-    } else if (deltaQuantity !== 0) {
-      const monthPatch = buildUsageMonthPatch({
-        plan: snapshot.plan,
-        usage: snapshot.usage,
-        usageKind: args.usageKind,
-        deltaQuantity,
-        recordedAt: args.recordedAt,
-      });
-      await ctx.db.patch(snapshot.usage._id, monthPatch);
-    } else if (snapshot.usage.lastRecordedAt !== args.recordedAt) {
-      await ctx.db.patch(snapshot.usage._id, {
-        lastRecordedAt: args.recordedAt,
-      });
-    }
-
-    if (existingUsageEvent) {
-      await ctx.db.patch(existingUsageEvent._id, {
-        periodKey: snapshot.periodKey,
-        quantity: args.quantity,
-        planAtRecordTime: snapshot.plan,
-        activeAddonsAtRecordTime: snapshot.activeAddons,
-        recordedAt: args.recordedAt,
-        syncStatus: syncNeeded ? "pending" : "skipped",
-      });
-
-      return {
-        usageEventId: existingUsageEvent._id,
-        plan: snapshot.plan,
-        activeAddons: snapshot.activeAddons,
-        syncNeeded,
-      };
-    }
-
-    const usageEventId = await ctx.db.insert("billing_usage_events", {
-      businessId: args.businessId,
-      periodKey: snapshot.periodKey,
-      sourceKey: args.sourceKey,
-      usageKind: args.usageKind,
-      quantity: args.quantity,
-      planAtRecordTime: snapshot.plan,
-      activeAddonsAtRecordTime: snapshot.activeAddons,
-      recordedAt: args.recordedAt,
-      syncStatus: syncNeeded ? "pending" : "skipped",
-    });
-
-    return {
-      usageEventId,
-      plan: snapshot.plan,
-      activeAddons: snapshot.activeAddons,
-      syncNeeded,
-    };
-  },
+  handler: async (ctx, args): Promise<UpsertUsageResult> =>
+    await upsertUsageEventInTx(ctx, args),
 });
 
 export const getUsageSyncPayload = internalQuery({
@@ -1468,7 +1499,7 @@ export const recordVoiceUsage = internalMutation({
     syncNeeded: v.boolean(),
   }),
   handler: async (ctx, args): Promise<UpsertUsageResult> => {
-    return await ctx.runMutation(internal.billing.upsertUsageEvent, {
+    return await upsertUsageEventInTx(ctx, {
       businessId: args.businessId,
       usageKind: "voice_seconds",
       quantity: args.quantity,
@@ -1497,7 +1528,7 @@ export const recordAlertSmsUsage = internalMutation({
     syncNeeded: v.boolean(),
   }),
   handler: async (ctx, args): Promise<UpsertUsageResult> => {
-    return await ctx.runMutation(internal.billing.upsertUsageEvent, {
+    return await upsertUsageEventInTx(ctx, {
       businessId: args.businessId,
       usageKind: "alert_sms_segments",
       quantity: args.quantity,
@@ -1526,7 +1557,7 @@ export const recordAiSmsUsage = internalMutation({
     syncNeeded: v.boolean(),
   }),
   handler: async (ctx, args): Promise<UpsertUsageResult> => {
-    return await ctx.runMutation(internal.billing.upsertUsageEvent, {
+    return await upsertUsageEventInTx(ctx, {
       businessId: args.businessId,
       usageKind: "ai_sms_segments",
       quantity: args.quantity,
@@ -1555,13 +1586,209 @@ export const recordOutboundCallAttemptUsage = internalMutation({
     syncNeeded: v.boolean(),
   }),
   handler: async (ctx, args): Promise<UpsertUsageResult> => {
-    return await ctx.runMutation(internal.billing.upsertUsageEvent, {
+    return await upsertUsageEventInTx(ctx, {
       businessId: args.businessId,
       usageKind: "outbound_call_attempts",
       quantity: args.quantity,
       sourceKey: args.sourceKey,
       recordedAt: args.recordedAt,
     });
+  },
+});
+
+export const reserveVoiceUsageAtCallStart = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+    callId: v.id("calls"),
+    recordedAt: v.string(),
+  },
+  returns: v.object({
+    allowed: v.boolean(),
+    errorCode: v.union(
+      v.literal("voice_limit_reached"),
+      v.literal("alert_sms_limit_reached"),
+      v.literal("outbound_call_attempt_limit_reached"),
+      v.literal("ai_sms_not_enabled"),
+      v.null(),
+    ),
+    usageEventId: v.optional(v.id("billing_usage_events")),
+    syncNeeded: v.optional(v.boolean()),
+  }),
+  handler: async (ctx, args): Promise<UsageReservationResult> => {
+    const snapshot = await getBillingSnapshot(ctx, {
+      businessId: args.businessId,
+      at: args.recordedAt,
+    });
+    const usage = getBillingUsageSnapshotData({
+      plan: snapshot.plan,
+      periodKey: snapshot.periodKey,
+      usage: snapshot.usage,
+    });
+
+    if (usage.voiceBlocked) {
+      return {
+        allowed: false,
+        errorCode: billingErrorCodes.voiceLimitReached,
+      };
+    }
+
+    const reserveQuantity = reserveVoiceSecondsForStart({
+      plan: snapshot.plan,
+      usage,
+    });
+    if (reserveQuantity === null) {
+      return {
+        allowed: true,
+        errorCode: null,
+      };
+    }
+    if (reserveQuantity <= 0) {
+      return {
+        allowed: false,
+        errorCode: billingErrorCodes.voiceLimitReached,
+      };
+    }
+
+    const usageResult = await upsertUsageEventInTx(ctx, {
+      businessId: args.businessId,
+      usageKind: "voice_seconds",
+      quantity: reserveQuantity,
+      sourceKey: `voice:${String(args.callId)}`,
+      recordedAt: args.recordedAt,
+    });
+
+    return {
+      allowed: true,
+      errorCode: null,
+      usageEventId: usageResult.usageEventId,
+      syncNeeded: usageResult.syncNeeded,
+    };
+  },
+});
+
+export const reserveAlertSmsUsage = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+    notificationId: v.id("notifications"),
+    estimatedSegments: v.number(),
+    recordedAt: v.string(),
+  },
+  returns: v.object({
+    allowed: v.boolean(),
+    errorCode: v.union(
+      v.literal("voice_limit_reached"),
+      v.literal("alert_sms_limit_reached"),
+      v.literal("outbound_call_attempt_limit_reached"),
+      v.literal("ai_sms_not_enabled"),
+      v.null(),
+    ),
+    usageEventId: v.optional(v.id("billing_usage_events")),
+    syncNeeded: v.optional(v.boolean()),
+  }),
+  handler: async (ctx, args): Promise<UsageReservationResult> => {
+    const snapshot = await getBillingSnapshot(ctx, {
+      businessId: args.businessId,
+      at: args.recordedAt,
+    });
+    const usage = getBillingUsageSnapshotData({
+      plan: snapshot.plan,
+      periodKey: snapshot.periodKey,
+      usage: snapshot.usage,
+    });
+    const normalizedSegments = Math.max(1, Math.trunc(args.estimatedSegments));
+
+    if (usage.alertSmsBlocked) {
+      return {
+        allowed: false,
+        errorCode: billingErrorCodes.alertSmsLimitReached,
+      };
+    }
+    if (
+      usage.alertSmsSegmentsRemaining !== null &&
+      normalizedSegments > usage.alertSmsSegmentsRemaining
+    ) {
+      return {
+        allowed: false,
+        errorCode: billingErrorCodes.alertSmsLimitReached,
+      };
+    }
+
+    const usageResult = await upsertUsageEventInTx(ctx, {
+      businessId: args.businessId,
+      usageKind: "alert_sms_segments",
+      quantity: normalizedSegments,
+      sourceKey: `alert_sms:${String(args.notificationId)}`,
+      recordedAt: args.recordedAt,
+    });
+
+    return {
+      allowed: true,
+      errorCode: null,
+      usageEventId: usageResult.usageEventId,
+      syncNeeded: usageResult.syncNeeded,
+    };
+  },
+});
+
+export const reserveOutboundCallAttemptUsage = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+    callId: v.id("calls"),
+    recordedAt: v.string(),
+  },
+  returns: v.object({
+    allowed: v.boolean(),
+    errorCode: v.union(
+      v.literal("voice_limit_reached"),
+      v.literal("alert_sms_limit_reached"),
+      v.literal("outbound_call_attempt_limit_reached"),
+      v.literal("ai_sms_not_enabled"),
+      v.null(),
+    ),
+    usageEventId: v.optional(v.id("billing_usage_events")),
+    syncNeeded: v.optional(v.boolean()),
+  }),
+  handler: async (ctx, args): Promise<UsageReservationResult> => {
+    const snapshot = await getBillingSnapshot(ctx, {
+      businessId: args.businessId,
+      at: args.recordedAt,
+    });
+    const usage = getBillingUsageSnapshotData({
+      plan: snapshot.plan,
+      periodKey: snapshot.periodKey,
+      usage: snapshot.usage,
+    });
+
+    if (usage.outboundCallAttemptsBlocked) {
+      return {
+        allowed: false,
+        errorCode: billingErrorCodes.outboundCallAttemptLimitReached,
+      };
+    }
+    if (
+      usage.outboundCallAttemptsRemaining !== null &&
+      usage.outboundCallAttemptsRemaining < 1
+    ) {
+      return {
+        allowed: false,
+        errorCode: billingErrorCodes.outboundCallAttemptLimitReached,
+      };
+    }
+
+    const usageResult = await upsertUsageEventInTx(ctx, {
+      businessId: args.businessId,
+      usageKind: "outbound_call_attempts",
+      quantity: 1,
+      sourceKey: `outbound_attempt:voice_call:${String(args.callId)}`,
+      recordedAt: args.recordedAt,
+    });
+
+    return {
+      allowed: true,
+      errorCode: null,
+      usageEventId: usageResult.usageEventId,
+      syncNeeded: usageResult.syncNeeded,
+    };
   },
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -64,6 +64,11 @@ const transferStateSchema = z.object({
   transferState: z.string().min(1),
 });
 
+const prepareTransferSchema = z.object({
+  callId: z.string().min(1),
+  recordedAt: z.string().min(1),
+});
+
 const completeCallSchema = z.object({
   callId: z.string().min(1),
   status: z.string().min(1),
@@ -673,16 +678,33 @@ http.route({
       );
     }
 
-    const result = await ctx.runMutation(internal.voice.runtime.startCall, {
-      businessId: asId("businesses", body.data.businessId),
-      twilioCallSid: body.data.twilioCallSid,
-      ...(body.data.gatewaySessionId !== undefined
-        ? { gatewaySessionId: body.data.gatewaySessionId }
-        : {}),
-      from: body.data.from,
-      to: body.data.to,
-      startedAt: body.data.startedAt,
-    });
+    let result;
+    try {
+      result = await ctx.runMutation(internal.voice.runtime.startCall, {
+        businessId: asId("businesses", body.data.businessId),
+        twilioCallSid: body.data.twilioCallSid,
+        ...(body.data.gatewaySessionId !== undefined
+          ? { gatewaySessionId: body.data.gatewaySessionId }
+          : {}),
+        from: body.data.from,
+        to: body.data.to,
+        startedAt: body.data.startedAt,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === billingErrorCodes.voiceLimitReached
+      ) {
+        return Response.json(
+          {
+            code: billingErrorCodes.voiceLimitReached,
+            message: "Voice quota reached for this billing period.",
+          },
+          { status: 402 },
+        );
+      }
+      throw error;
+    }
 
     return Response.json(result);
   }),
@@ -713,6 +735,40 @@ http.route({
     });
 
     return Response.json({ transcriptId });
+  }),
+});
+
+http.route({
+  path: "/voice/call/prepare-transfer",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const unauthorized = requireServiceToken(request);
+    if (unauthorized) {
+      return unauthorized;
+    }
+
+    const body = await parseJsonBody(request, prepareTransferSchema);
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const result = await ctx.runMutation(internal.voice.runtime.prepareTransferForVoice, {
+      callId: asId("calls", body.data.callId),
+      recordedAt: body.data.recordedAt,
+    });
+
+    if (!result.allowed) {
+      return Response.json(
+        {
+          code:
+            result.errorCode ?? billingErrorCodes.outboundCallAttemptLimitReached,
+          message: "Outbound transfer quota reached for this billing period.",
+        },
+        { status: 402 },
+      );
+    }
+
+    return Response.json({ ok: true });
   }),
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -64,10 +64,15 @@ const transferStateSchema = z.object({
   transferState: z.string().min(1),
 });
 
-const prepareTransferSchema = z.object({
-  callId: z.string().min(1),
-  recordedAt: z.string().min(1),
-});
+const prepareTransferSchema = z
+  .object({
+    callId: z.string().min(1).optional(),
+    twilioCallSid: z.string().min(1).optional(),
+    recordedAt: z.string().min(1),
+  })
+  .refine((value) => value.callId !== undefined || value.twilioCallSid !== undefined, {
+    message: "callId or twilioCallSid is required",
+  });
 
 const completeCallSchema = z.object({
   callId: z.string().min(1),
@@ -665,19 +670,6 @@ http.route({
       return body.response;
     }
 
-    const voicePolicy = await ctx.runQuery(internal.billing.assertVoiceCanStart, {
-      businessId: asId("businesses", body.data.businessId),
-    });
-    if (!voicePolicy.allowed) {
-      return Response.json(
-        {
-          code: voicePolicy.errorCode ?? billingErrorCodes.voiceLimitReached,
-          message: "Voice quota reached for this billing period.",
-        },
-        { status: 402 },
-      );
-    }
-
     let result;
     try {
       result = await ctx.runMutation(internal.voice.runtime.startCall, {
@@ -753,7 +745,10 @@ http.route({
     }
 
     const result = await ctx.runMutation(internal.voice.runtime.prepareTransferForVoice, {
-      callId: asId("calls", body.data.callId),
+      ...(body.data.callId !== undefined ? { callId: asId("calls", body.data.callId) } : {}),
+      ...(body.data.twilioCallSid !== undefined
+        ? { twilioCallSid: body.data.twilioCallSid }
+        : {}),
       recordedAt: body.data.recordedAt,
     });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -79,6 +79,7 @@ const completeCallSchema = z.object({
   status: z.string().min(1),
   endedAt: z.string().min(1),
   disposition: z.string().min(1).optional(),
+  providerDurationSeconds: z.number().optional(),
 });
 
 const reconcileStatusSchema = z.object({
@@ -768,6 +769,32 @@ http.route({
 });
 
 http.route({
+  path: "/voice/call/release-transfer",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const unauthorized = requireServiceToken(request);
+    if (unauthorized) {
+      return unauthorized;
+    }
+
+    const body = await parseJsonBody(request, prepareTransferSchema);
+    if (!body.ok) {
+      return body.response;
+    }
+
+    await ctx.runMutation(internal.voice.runtime.releaseTransferForVoice, {
+      ...(body.data.callId !== undefined ? { callId: asId("calls", body.data.callId) } : {}),
+      ...(body.data.twilioCallSid !== undefined
+        ? { twilioCallSid: body.data.twilioCallSid }
+        : {}),
+      recordedAt: body.data.recordedAt,
+    });
+
+    return Response.json({ ok: true });
+  }),
+});
+
+http.route({
   path: "/voice/call/transfer-state",
   method: "POST",
   handler: httpAction(async (ctx, request) => {
@@ -809,6 +836,9 @@ http.route({
       status: body.data.status,
       endedAt: body.data.endedAt,
       ...(body.data.disposition !== undefined ? { disposition: body.data.disposition } : {}),
+      ...(body.data.providerDurationSeconds !== undefined
+        ? { providerDurationSeconds: body.data.providerDurationSeconds }
+        : {}),
     });
 
     return Response.json({ ok: true });

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -81,7 +81,7 @@ function estimateSmsSegments(body: string): number {
       continue;
     }
 
-    const unicodeLength = characters.length;
+    const unicodeLength = body.length;
     return unicodeLength <= 70 ? 1 : Math.max(1, Math.ceil(unicodeLength / 67));
   }
 

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -59,15 +59,39 @@ function buildTwilioSmsStatusCallbackUrl(): string {
   return new URL("/twilio/sms/status", siteUrl).toString();
 }
 
-function estimateAlertSmsSegmentsUpperBound(body: string): number {
-  const normalizedLength = Array.from(body).length;
-  if (normalizedLength <= 70) {
-    return 1;
+const GSM_7_BASIC_CHARACTERS = new Set(
+  Array.from(
+    "@\u00a3$\u00a5\u00e8\u00e9\u00f9\u00ec\u00f2\u00c7\n\u00d8\u00f8\r\u00c5\u00e5\u0394_\u03a6\u0393\u039b\u03a9\u03a0\u03a8\u03a3\u0398\u039e\u00c6\u00e6\u00df\u00c9 !\"#\u00a4%&'()*+,-./0123456789:;<=>?\u00a1ABCDEFGHIJKLMNOPQRSTUVWXYZ\u00c4\u00d6\u00d1\u00dc`\u00bfabcdefghijklmnopqrstuvwxyz\u00e4\u00f6\u00f1\u00fc\u00e0",
+  ),
+);
+const GSM_7_EXTENDED_CHARACTERS = new Set(["^", "{", "}", "\\", "[", "~", "]", "|", "\u20ac"]);
+
+function estimateSmsSegments(body: string): number {
+  const characters = Array.from(body);
+  let gsmSeptetLength = 0;
+
+  for (const character of characters) {
+    if (GSM_7_BASIC_CHARACTERS.has(character)) {
+      gsmSeptetLength += 1;
+      continue;
+    }
+
+    if (GSM_7_EXTENDED_CHARACTERS.has(character)) {
+      gsmSeptetLength += 2;
+      continue;
+    }
+
+    const unicodeLength = characters.length;
+    return unicodeLength <= 70 ? 1 : Math.max(1, Math.ceil(unicodeLength / 67));
   }
 
-  // Reserve against the worst-case UCS-2 concatenation size and let Twilio status
-  // callbacks reconcile the exact segment count later.
-  return Math.max(1, Math.ceil(normalizedLength / 67));
+  return gsmSeptetLength <= 160
+    ? 1
+    : Math.max(1, Math.ceil(gsmSeptetLength / 153));
+}
+
+function estimateAlertSmsSegmentsUpperBound(body: string): number {
+  return estimateSmsSegments(body);
 }
 
 export const getNotification = internalQuery({
@@ -385,6 +409,12 @@ export const deliverNotification = internalAction({
     }
 
     let messageAcceptedByProvider = false;
+    let reservedAlertUsage:
+      | {
+          usageEventId?: Id<"billing_usage_events">;
+          syncNeeded?: boolean;
+        }
+      | null = null;
     try {
       const localizedServiceName = await ctx.runAction(
         internal.services.localizedNames.ensureLocalizedServiceName,
@@ -414,6 +444,12 @@ export const deliverNotification = internalAction({
         if (!reservedUsage.allowed) {
           throw new Error("Alert SMS quota reached. Upgrade to continue sending notifications.");
         }
+        reservedAlertUsage = {
+          ...(reservedUsage.usageEventId ? { usageEventId: reservedUsage.usageEventId } : {}),
+          ...(reservedUsage.syncNeeded !== undefined
+            ? { syncNeeded: reservedUsage.syncNeeded }
+            : {}),
+        };
         if (reservedUsage.syncNeeded && reservedUsage.usageEventId) {
           await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
             usageEventId: reservedUsage.usageEventId,
@@ -443,14 +479,18 @@ export const deliverNotification = internalAction({
         providerMessageId: result.providerMessageSid,
       };
     } catch (error) {
-      if (deliveryContext.senderRole === "platform_alert" && !messageAcceptedByProvider) {
+      if (
+        deliveryContext.senderRole === "platform_alert" &&
+        !messageAcceptedByProvider &&
+        reservedAlertUsage?.usageEventId
+      ) {
         const releasedUsage = await ctx.runMutation(internal.billing.recordAlertSmsUsage, {
           businessId: deliveryContext.businessId,
           notificationId: args.notificationId,
           quantity: 0,
           recordedAt: new Date().toISOString(),
         });
-        if (releasedUsage.syncNeeded) {
+        if (releasedUsage.syncNeeded && releasedUsage.usageEventId) {
           await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
             usageEventId: releasedUsage.usageEventId,
           });

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -59,6 +59,17 @@ function buildTwilioSmsStatusCallbackUrl(): string {
   return new URL("/twilio/sms/status", siteUrl).toString();
 }
 
+function estimateAlertSmsSegmentsUpperBound(body: string): number {
+  const normalizedLength = Array.from(body).length;
+  if (normalizedLength <= 70) {
+    return 1;
+  }
+
+  // Reserve against the worst-case UCS-2 concatenation size and let Twilio status
+  // callbacks reconcile the exact segment count later.
+  return Math.max(1, Math.ceil(normalizedLength / 67));
+}
+
 export const getNotification = internalQuery({
   args: {
     notificationId: v.id("notifications"),
@@ -373,6 +384,7 @@ export const deliverNotification = internalAction({
       throw new Error("Notification not found.");
     }
 
+    let messageAcceptedByProvider = false;
     try {
       const localizedServiceName = await ctx.runAction(
         internal.services.localizedNames.ensureLocalizedServiceName,
@@ -388,6 +400,26 @@ export const deliverNotification = internalAction({
         timezone: deliveryContext.timezone,
         locale: deliveryContext.locale,
       });
+      const providerUpdatedAt = new Date().toISOString();
+      if (deliveryContext.senderRole === "platform_alert") {
+        const reservedUsage = await ctx.runMutation(
+          internal.billing.reserveAlertSmsUsage,
+          {
+            businessId: deliveryContext.businessId,
+            notificationId: args.notificationId,
+            estimatedSegments: estimateAlertSmsSegmentsUpperBound(body),
+            recordedAt: providerUpdatedAt,
+          },
+        );
+        if (!reservedUsage.allowed) {
+          throw new Error("Alert SMS quota reached. Upgrade to continue sending notifications.");
+        }
+        if (reservedUsage.syncNeeded && reservedUsage.usageEventId) {
+          await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+            usageEventId: reservedUsage.usageEventId,
+          });
+        }
+      }
       const result: { providerMessageSid: string; providerStatus: string } = await ctx.runAction(
         internal.integrations.twilioSms.sendMessage,
         {
@@ -397,12 +429,13 @@ export const deliverNotification = internalAction({
         statusCallbackUrl: buildTwilioSmsStatusCallbackUrl(),
         },
       );
+      messageAcceptedByProvider = true;
 
       await ctx.runMutation(internal.notifications.reminders.markNotificationSent, {
         notificationId: args.notificationId,
         providerMessageId: result.providerMessageSid,
         providerStatus: result.providerStatus,
-        providerUpdatedAt: new Date().toISOString(),
+        providerUpdatedAt,
       });
 
       return {
@@ -410,6 +443,19 @@ export const deliverNotification = internalAction({
         providerMessageId: result.providerMessageSid,
       };
     } catch (error) {
+      if (deliveryContext.senderRole === "platform_alert" && !messageAcceptedByProvider) {
+        const releasedUsage = await ctx.runMutation(internal.billing.recordAlertSmsUsage, {
+          businessId: deliveryContext.businessId,
+          notificationId: args.notificationId,
+          quantity: 0,
+          recordedAt: new Date().toISOString(),
+        });
+        if (releasedUsage.syncNeeded) {
+          await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+            usageEventId: releasedUsage.usageEventId,
+          });
+        }
+      }
       await ctx.runMutation(internal.notifications.reminders.markNotificationSendFailed, {
         notificationId: args.notificationId,
         providerUpdatedAt: new Date().toISOString(),

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -651,6 +651,58 @@ describe("billing", () => {
     });
   });
 
+  it("shrinks a full voice reservation back to the actual duration when the call completes", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-voice-reconcile",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      return await seedUsageAnchors(ctx, { businessId });
+    });
+
+    await t.mutation(internal.billing.reserveVoiceUsageAtCallStart, {
+      businessId,
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:00:00.000Z",
+    });
+    const usageResult = await t.mutation(internal.billing.recordVoiceUsage, {
+      businessId,
+      callId: anchors.callId,
+      quantity: 33,
+      recordedAt: "2026-04-12T14:00:33.000Z",
+    });
+
+    const usageState = await t.run(async (ctx: TestContext) => {
+      const usageMonth = await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+      const usageEvent = await ctx.db
+        .query("billing_usage_events")
+        .withIndex("by_business_id_and_source_key", (q) =>
+          q.eq("businessId", businessId).eq("sourceKey", `voice:${String(anchors.callId)}`),
+        )
+        .unique();
+      return { usageMonth, usageEvent };
+    });
+
+    expect(usageResult).toMatchObject({
+      syncNeeded: false,
+    });
+    expect(usageState.usageMonth).toMatchObject({
+      voiceSecondsUsed: 33,
+      voiceBlocked: false,
+      lastRecordedAt: "2026-04-12T14:00:33.000Z",
+    });
+    expect(usageState.usageEvent).toMatchObject({
+      quantity: 33,
+      recordedAt: "2026-04-12T14:00:33.000Z",
+    });
+  });
+
   it("reserves hosted alert SMS usage before Twilio reports segments", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId } = await seedWorkspace(t, {
@@ -860,6 +912,62 @@ describe("billing", () => {
     expect(reservation).toEqual({
       allowed: false,
       errorCode: "outbound_call_attempt_limit_reached",
+    });
+  });
+
+  it("releases a reserved outbound transfer attempt when the handoff never starts", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-outbound-release",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      return await seedUsageAnchors(ctx, { businessId });
+    });
+
+    const reserved = await t.mutation(internal.voice.runtime.prepareTransferForVoice, {
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:02:00.000Z",
+    });
+
+    const released = await t.mutation(internal.voice.runtime.releaseTransferForVoice, {
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:02:30.000Z",
+    });
+
+    const usageState = await t.run(async (ctx: TestContext) => {
+      const usageMonth = await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+      const usageEvent = await ctx.db
+        .query("billing_usage_events")
+        .withIndex("by_business_id_and_source_key", (q) =>
+          q
+            .eq("businessId", businessId)
+            .eq("sourceKey", `outbound_attempt:voice_call:${String(anchors.callId)}`),
+        )
+        .unique();
+      return { usageMonth, usageEvent };
+    });
+
+    expect(reserved).toEqual({
+      allowed: true,
+      errorCode: null,
+    });
+    expect(released).toEqual({
+      released: true,
+    });
+    expect(usageState.usageMonth).toMatchObject({
+      outboundCallAttemptsUsed: 0,
+      outboundCallAttemptsBlocked: false,
+      lastRecordedAt: "2026-04-12T14:02:30.000Z",
+    });
+    expect(usageState.usageEvent).toMatchObject({
+      quantity: 0,
+      recordedAt: "2026-04-12T14:02:30.000Z",
     });
   });
 

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -526,6 +526,190 @@ describe("billing", () => {
     });
   });
 
+  it("reserves remaining free cloud voice capacity before the call finishes", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-voice-reservation",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondCallId = await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-test-2",
+        status: "in_progress",
+        startedAt: "2026-04-12T14:05:00.000Z",
+      });
+      return { ...seeded, secondCallId };
+    });
+
+    const firstReservation = await t.mutation(internal.billing.reserveVoiceUsageAtCallStart, {
+      businessId,
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:00:00.000Z",
+    });
+    const secondReservation = await t.mutation(internal.billing.reserveVoiceUsageAtCallStart, {
+      businessId,
+      callId: anchors.secondCallId,
+      recordedAt: "2026-04-12T14:00:30.000Z",
+    });
+
+    const usageMonth = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(secondReservation).toEqual({
+      allowed: false,
+      errorCode: "voice_limit_reached",
+    });
+    expect(usageMonth).toMatchObject({
+      voiceSecondsUsed: 600,
+      voiceBlocked: true,
+    });
+  });
+
+  it("reserves hosted alert SMS usage before Twilio reports segments", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-alert-reservation",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondNotificationId = await ctx.db.insert("notifications", {
+        businessId,
+        channel: "sms",
+        kind: "appointment_reminder",
+        scheduledFor: "2026-04-12T14:03:00.000Z",
+        status: "pending",
+      });
+      return { ...seeded, secondNotificationId };
+    });
+
+    const firstReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      estimatedSegments: 8,
+      recordedAt: "2026-04-12T14:01:00.000Z",
+    });
+    const secondReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.secondNotificationId,
+      estimatedSegments: 3,
+      recordedAt: "2026-04-12T14:02:00.000Z",
+    });
+
+    const usageMonth = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(secondReservation).toEqual({
+      allowed: false,
+      errorCode: "alert_sms_limit_reached",
+    });
+    expect(usageMonth).toMatchObject({
+      alertSmsSegmentsUsed: 8,
+      alertSmsBlocked: false,
+    });
+  });
+
+  it("reserves outbound transfer attempts before the live handoff executes", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-outbound-reservation",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondCallId = await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-outbound-2",
+        status: "in_progress",
+        startedAt: "2026-04-12T14:06:00.000Z",
+      });
+      const thirdCallId = await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-outbound-3",
+        status: "in_progress",
+        startedAt: "2026-04-12T14:07:00.000Z",
+      });
+      return { ...seeded, secondCallId, thirdCallId };
+    });
+
+    const firstReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.callId,
+        recordedAt: "2026-04-12T14:02:00.000Z",
+      },
+    );
+    const secondReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.secondCallId,
+        recordedAt: "2026-04-12T14:03:00.000Z",
+      },
+    );
+    const thirdReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.thirdCallId,
+        recordedAt: "2026-04-12T14:04:00.000Z",
+      },
+    );
+
+    const usageMonth = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(secondReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(thirdReservation).toEqual({
+      allowed: false,
+      errorCode: "outbound_call_attempt_limit_reached",
+    });
+    expect(usageMonth).toMatchObject({
+      outboundCallAttemptsUsed: 2,
+      outboundCallAttemptsBlocked: true,
+    });
+  });
+
   it("lets Pro workspaces exceed included usage while keeping AI SMS metered separately", async () => {
     const t = convexTest(schema, convexModules);
     const { authed, businessId } = await seedWorkspace(t, {

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -758,6 +758,85 @@ describe("billing", () => {
     });
   });
 
+  it("treats duplicate hosted alert SMS reservations for the same notification as idempotent", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-alert-idempotent",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondNotificationId = await ctx.db.insert("notifications", {
+        businessId,
+        channel: "sms",
+        kind: "appointment_reminder",
+        scheduledFor: "2026-04-12T14:03:00.000Z",
+        status: "pending",
+      });
+      return { ...seeded, secondNotificationId };
+    });
+
+    const firstReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      estimatedSegments: 8,
+      recordedAt: "2026-04-12T14:01:00.000Z",
+    });
+    const secondReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      estimatedSegments: 8,
+      recordedAt: "2026-04-12T14:01:30.000Z",
+    });
+    const thirdReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.secondNotificationId,
+      estimatedSegments: 3,
+      recordedAt: "2026-04-12T14:02:00.000Z",
+    });
+
+    const usageState = await t.run(async (ctx: TestContext) => {
+      const usageMonth = await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+      const usageEvent = await ctx.db
+        .query("billing_usage_events")
+        .withIndex("by_business_id_and_source_key", (q) =>
+          q.eq("businessId", businessId).eq("sourceKey", `alert_sms:${String(anchors.notificationId)}`),
+        )
+        .unique();
+      return { usageMonth, usageEvent };
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(secondReservation).toEqual({
+      allowed: true,
+      errorCode: null,
+      usageEventId: firstReservation.usageEventId,
+      syncNeeded: false,
+    });
+    expect(thirdReservation).toEqual({
+      allowed: false,
+      errorCode: "alert_sms_limit_reached",
+    });
+    expect(usageState.usageMonth).toMatchObject({
+      alertSmsSegmentsUsed: 8,
+      alertSmsBlocked: false,
+      lastRecordedAt: "2026-04-12T14:01:00.000Z",
+    });
+    expect(usageState.usageEvent).toMatchObject({
+      quantity: 8,
+      recordedAt: "2026-04-12T14:01:00.000Z",
+    });
+  });
+
   it("reserves outbound transfer attempts before the live handoff executes", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId } = await seedWorkspace(t, {
@@ -832,6 +911,93 @@ describe("billing", () => {
     expect(usageMonth).toMatchObject({
       outboundCallAttemptsUsed: 2,
       outboundCallAttemptsBlocked: true,
+    });
+  });
+
+  it("treats duplicate outbound transfer reservations for the same call as idempotent", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-outbound-idempotent",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondCallId = await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-outbound-idempotent-2",
+        status: "in_progress",
+        startedAt: "2026-04-12T14:06:00.000Z",
+      });
+      return { ...seeded, secondCallId };
+    });
+
+    const firstReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.callId,
+        recordedAt: "2026-04-12T14:02:00.000Z",
+      },
+    );
+    const secondReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.callId,
+        recordedAt: "2026-04-12T14:02:30.000Z",
+      },
+    );
+    const thirdReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.secondCallId,
+        recordedAt: "2026-04-12T14:03:00.000Z",
+      },
+    );
+
+    const usageState = await t.run(async (ctx: TestContext) => {
+      const usageMonth = await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+      const usageEvent = await ctx.db
+        .query("billing_usage_events")
+        .withIndex("by_business_id_and_source_key", (q) =>
+          q
+            .eq("businessId", businessId)
+            .eq("sourceKey", `outbound_attempt:voice_call:${String(anchors.callId)}`),
+        )
+        .unique();
+      return { usageMonth, usageEvent };
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(secondReservation).toEqual({
+      allowed: true,
+      errorCode: null,
+      usageEventId: firstReservation.usageEventId,
+      syncNeeded: false,
+    });
+    expect(thirdReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(usageState.usageMonth).toMatchObject({
+      outboundCallAttemptsUsed: 2,
+      outboundCallAttemptsBlocked: true,
+      lastRecordedAt: "2026-04-12T14:03:00.000Z",
+    });
+    expect(usageState.usageEvent).toMatchObject({
+      quantity: 1,
+      recordedAt: "2026-04-12T14:02:00.000Z",
     });
   });
 

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -783,6 +783,86 @@ describe("billing", () => {
     });
   });
 
+  it("prepares transfer reservations by Twilio SID when the gateway has no callId", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-outbound-fallback",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      return await seedUsageAnchors(ctx, { businessId });
+    });
+
+    const reservation = await t.mutation(internal.voice.runtime.prepareTransferForVoice, {
+      twilioCallSid: "CA-billing-test",
+      recordedAt: "2026-04-12T14:02:30.000Z",
+    });
+
+    const usageMonth = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+    });
+
+    expect(anchors.callId).toBeDefined();
+    expect(reservation).toEqual({
+      allowed: true,
+      errorCode: null,
+    });
+    expect(usageMonth).toMatchObject({
+      outboundCallAttemptsUsed: 1,
+      outboundCallAttemptsBlocked: false,
+    });
+  });
+
+  it("still blocks transfer preparation by Twilio SID after free outbound quota is exhausted", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-outbound-fallback-cap",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondCallId = await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-fallback-2",
+        status: "in_progress",
+        startedAt: "2026-04-12T14:06:00.000Z",
+      });
+      await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-fallback-3",
+        status: "in_progress",
+        startedAt: "2026-04-12T14:07:00.000Z",
+      });
+      return { ...seeded, secondCallId };
+    });
+
+    await t.mutation(internal.billing.reserveOutboundCallAttemptUsage, {
+      businessId,
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:02:00.000Z",
+    });
+    await t.mutation(internal.billing.reserveOutboundCallAttemptUsage, {
+      businessId,
+      callId: anchors.secondCallId,
+      recordedAt: "2026-04-12T14:03:00.000Z",
+    });
+
+    const reservation = await t.mutation(internal.voice.runtime.prepareTransferForVoice, {
+      twilioCallSid: "CA-billing-fallback-3",
+      recordedAt: "2026-04-12T14:04:00.000Z",
+    });
+
+    expect(reservation).toEqual({
+      allowed: false,
+      errorCode: "outbound_call_attempt_limit_reached",
+    });
+  });
+
   it("lets Pro workspaces exceed included usage while keeping AI SMS metered separately", async () => {
     const t = convexTest(schema, convexModules);
     const { authed, businessId } = await seedWorkspace(t, {

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -592,6 +592,65 @@ describe("billing", () => {
     });
   });
 
+  it("treats duplicate voice start reservations for the same call as idempotent", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-voice-idempotent",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      return await seedUsageAnchors(ctx, { businessId });
+    });
+
+    const firstReservation = await t.mutation(internal.billing.reserveVoiceUsageAtCallStart, {
+      businessId,
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:00:00.000Z",
+    });
+    const secondReservation = await t.mutation(internal.billing.reserveVoiceUsageAtCallStart, {
+      businessId,
+      callId: anchors.callId,
+      recordedAt: "2026-04-12T14:00:05.000Z",
+    });
+
+    const usageState = await t.run(async (ctx: TestContext) => {
+      const usageMonth = await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+      const usageEvent = await ctx.db
+        .query("billing_usage_events")
+        .withIndex("by_business_id_and_source_key", (q) =>
+          q.eq("businessId", businessId).eq("sourceKey", `voice:${String(anchors.callId)}`),
+        )
+        .unique();
+      return { usageMonth, usageEvent };
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: false,
+    });
+    expect(secondReservation).toEqual({
+      allowed: true,
+      errorCode: null,
+      usageEventId: firstReservation.usageEventId,
+      syncNeeded: false,
+    });
+    expect(usageState.usageMonth).toMatchObject({
+      voiceSecondsUsed: 600,
+      voiceBlocked: true,
+      lastRecordedAt: "2026-04-12T14:00:00.000Z",
+    });
+    expect(usageState.usageEvent).toMatchObject({
+      quantity: 600,
+      recordedAt: "2026-04-12T14:00:00.000Z",
+    });
+  });
+
   it("reserves hosted alert SMS usage before Twilio reports segments", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId } = await seedWorkspace(t, {
@@ -827,6 +886,135 @@ describe("billing", () => {
     expect(outboundPolicy).toEqual({
       allowed: true,
       errorCode: null,
+    });
+  });
+
+  it("allows Pro alert SMS reservations after included segments are exhausted", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-pro-alert-reservation",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondNotificationId = await ctx.db.insert("notifications", {
+        businessId,
+        channel: "sms",
+        kind: "appointment_reminder",
+        scheduledFor: "2026-04-12T16:03:00.000Z",
+        status: "pending",
+      });
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+      });
+      return { ...seeded, secondNotificationId };
+    });
+
+    const firstReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      estimatedSegments: 50,
+      recordedAt: "2026-04-12T16:01:00.000Z",
+    });
+    const secondReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.secondNotificationId,
+      estimatedSegments: 3,
+      recordedAt: "2026-04-12T16:02:00.000Z",
+    });
+
+    const usageMonth = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: true,
+    });
+    expect(secondReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: true,
+    });
+    expect(usageMonth).toMatchObject({
+      alertSmsSegmentsUsed: 53,
+      alertSmsBlocked: false,
+    });
+  });
+
+  it("allows Pro outbound transfer reservations after included attempts are exhausted", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-pro-outbound-reservation",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondCallId = await ctx.db.insert("calls", {
+        businessId,
+        twilioCallSid: "CA-billing-pro-outbound-2",
+        status: "in_progress",
+        startedAt: "2026-04-12T16:06:00.000Z",
+      });
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+      });
+      return { ...seeded, secondCallId };
+    });
+
+    const firstReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.callId,
+        recordedAt: "2026-04-12T16:03:00.000Z",
+      },
+    );
+    await t.mutation(internal.billing.recordOutboundCallAttemptUsage, {
+      businessId,
+      sourceKey: "outbound_attempt:pro-existing-bundle",
+      quantity: 19,
+      recordedAt: "2026-04-12T16:03:30.000Z",
+    });
+    const secondReservation = await t.mutation(
+      internal.billing.reserveOutboundCallAttemptUsage,
+      {
+        businessId,
+        callId: anchors.secondCallId,
+        recordedAt: "2026-04-12T16:04:00.000Z",
+      },
+    );
+
+    const usageMonth = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("billing_usage_months")
+        .withIndex("by_business_id_and_period_key", (q) =>
+          q.eq("businessId", businessId).eq("periodKey", "2026-04"),
+        )
+        .unique();
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: true,
+    });
+    expect(secondReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+      syncNeeded: true,
+    });
+    expect(usageMonth).toMatchObject({
+      outboundCallAttemptsUsed: 21,
+      outboundCallAttemptsBlocked: false,
     });
   });
 

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -5,6 +5,10 @@ const { polarEventsIngestMock } = vi.hoisted(() => ({
   polarEventsIngestMock: vi.fn(),
 }));
 
+const { enqueuePostHogEventBestEffortMock } = vi.hoisted(() => ({
+  enqueuePostHogEventBestEffortMock: vi.fn(async () => {}),
+}));
+
 vi.mock("@polar-sh/sdk", () => ({
   Polar: vi.fn(function MockPolar() {
     return {
@@ -26,6 +30,16 @@ vi.mock("@polar-sh/sdk", () => ({
     };
   }),
 }));
+
+vi.mock("../telemetry/posthog", async () => {
+  const actual = await vi.importActual<typeof import("../telemetry/posthog")>(
+    "../telemetry/posthog",
+  );
+  return {
+    ...actual,
+    enqueuePostHogEventBestEffort: enqueuePostHogEventBestEffortMock,
+  };
+});
 
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
@@ -942,6 +956,100 @@ describe("billing", () => {
         syncError: "temporary polar outage",
       });
     });
+
+    expect(enqueuePostHogEventBestEffortMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventName: "ops.billing.usage_sync_failed",
+        businessId,
+        distinctId: `system:business:${String(businessId)}`,
+        groupKey: `business:${String(businessId)}`,
+        provider: "polar",
+        properties: expect.objectContaining({
+          usageKind: "voice_seconds",
+          quantity: 61,
+          attemptNumber: 1,
+          retryScheduled: true,
+          retryDelayMs: 30000,
+          errorType: "Error",
+        }),
+      }),
+    );
+  });
+
+  it("emits a recovery telemetry event when a retry later succeeds", async () => {
+    process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";
+    polarEventsIngestMock
+      .mockRejectedValueOnce(new Error("temporary polar outage"))
+      .mockResolvedValueOnce(undefined);
+
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-polar-recovery",
+      deploymentMode: "cloud",
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+        polarCustomerId: "cus_polar_recovery",
+      });
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      return await seedUsageAnchors(ctx, { businessId });
+    });
+
+    const usageResult = await t.mutation(internal.billing.recordVoiceUsage, {
+      businessId,
+      callId: anchors.callId,
+      quantity: 61,
+      recordedAt: "2026-04-12T16:00:00.000Z",
+    });
+
+    await t.action(internal.billing.syncUsageEventToPolar, {
+      usageEventId: usageResult.usageEventId,
+    });
+    const recoveryResult = await t.action(internal.billing.syncUsageEventToPolar, {
+      usageEventId: usageResult.usageEventId,
+      attempt: 1,
+    });
+
+    expect(recoveryResult).toEqual({ synced: true });
+
+    await t.run(async (ctx: TestContext) => {
+      const usageEvent = await ctx.db.get(usageResult.usageEventId);
+
+      expect(usageEvent).toMatchObject({
+        syncStatus: "succeeded",
+      });
+    });
+
+    expect(enqueuePostHogEventBestEffortMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        eventName: "ops.billing.usage_sync_failed",
+        businessId,
+      }),
+    );
+    expect(enqueuePostHogEventBestEffortMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        eventName: "ops.billing.usage_sync_recovered",
+        businessId,
+        distinctId: `system:business:${String(businessId)}`,
+        groupKey: `business:${String(businessId)}`,
+        provider: "polar",
+        properties: expect.objectContaining({
+          usageKind: "voice_seconds",
+          quantity: 61,
+          attemptNumber: 2,
+          recovered: true,
+        }),
+      }),
+    );
   });
 
   it("requires admin access for billing checkout and portal actions", async () => {

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -592,6 +592,55 @@ describe("billing", () => {
     });
   });
 
+  it("rejects a blocked voice call before creating contact or call records", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-voice-blocked-start",
+      deploymentMode: "cloud",
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await ctx.db.insert("billing_usage_months", {
+        businessId,
+        periodKey: "2026-04",
+        planAtSnapshot: "free_cloud",
+        voiceSecondsUsed: 600,
+        voiceSecondsIncluded: 600,
+        voiceBlocked: true,
+        lastRecordedAt: "2026-04-12T14:00:00.000Z",
+      });
+    });
+
+    await expect(
+      t.mutation(internal.voice.runtime.startCall, {
+        businessId,
+        twilioCallSid: "CA-blocked-start",
+        from: "+14165550123",
+        to: "+14165550999",
+        startedAt: "2026-04-12T14:00:30.000Z",
+      }),
+    ).rejects.toThrow("voice_limit_reached");
+
+    const persistedState = await t.run(async (ctx: TestContext) => {
+      const contact = await ctx.db
+        .query("contacts")
+        .withIndex("by_business_id_and_phone", (q) =>
+          q.eq("businessId", businessId).eq("phone", "+14165550123"),
+        )
+        .unique();
+      const call = await ctx.db
+        .query("calls")
+        .withIndex("by_twilio_call_sid", (q) => q.eq("twilioCallSid", "CA-blocked-start"))
+        .unique();
+      return { contact, call };
+    });
+
+    expect(persistedState).toEqual({
+      contact: null,
+      call: null,
+    });
+  });
+
   it("treats duplicate voice start reservations for the same call as idempotent", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId } = await seedWorkspace(t, {
@@ -834,6 +883,72 @@ describe("billing", () => {
     expect(usageState.usageEvent).toMatchObject({
       quantity: 8,
       recordedAt: "2026-04-12T14:01:00.000Z",
+    });
+  });
+
+  it("re-checks hosted alert SMS quota after a released notification retries", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-free-alert-retry-quota",
+      deploymentMode: "cloud",
+    });
+    const anchors = await t.run(async (ctx: TestContext) => {
+      const seeded = await seedUsageAnchors(ctx, { businessId });
+      const secondNotificationId = await ctx.db.insert("notifications", {
+        businessId,
+        channel: "sms",
+        kind: "appointment_reminder",
+        scheduledFor: "2026-04-12T14:03:00.000Z",
+        status: "pending",
+      });
+      await ctx.db.insert("billing_usage_months", {
+        businessId,
+        periodKey: "2026-04",
+        planAtSnapshot: "free_cloud",
+        alertSmsSegmentsUsed: 9,
+        alertSmsSegmentsIncluded: 10,
+        alertSmsBlocked: false,
+        lastRecordedAt: "2026-04-12T14:00:00.000Z",
+      });
+      return { ...seeded, secondNotificationId };
+    });
+
+    const firstReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      estimatedSegments: 1,
+      recordedAt: "2026-04-12T14:01:00.000Z",
+    });
+    await t.mutation(internal.billing.recordAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      quantity: 0,
+      recordedAt: "2026-04-12T14:01:30.000Z",
+    });
+    const secondReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.secondNotificationId,
+      estimatedSegments: 1,
+      recordedAt: "2026-04-12T14:02:00.000Z",
+    });
+    const retriedReservation = await t.mutation(internal.billing.reserveAlertSmsUsage, {
+      businessId,
+      notificationId: anchors.notificationId,
+      estimatedSegments: 1,
+      recordedAt: "2026-04-12T14:02:30.000Z",
+    });
+
+    expect(firstReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+    });
+    expect(secondReservation).toMatchObject({
+      allowed: true,
+      errorCode: null,
+    });
+    expect(retriedReservation).toEqual({
+      allowed: false,
+      errorCode: "alert_sms_limit_reached",
     });
   });
 

--- a/convex/tests/twilioSmsDelivery.test.ts
+++ b/convex/tests/twilioSmsDelivery.test.ts
@@ -4,16 +4,19 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
+import { getBillingKey } from "../lib/billing";
 import schema from "../schema";
 import { modules } from "../test.setup";
 
 const {
+  enqueuePostHogOutboxRecordMock,
   fetchTwilioMessageMock,
   generateSmsReplyMock,
   retrierRunMock,
   sendTwilioMessageMock,
   validateTwilioRequestMock,
 } = vi.hoisted(() => ({
+  enqueuePostHogOutboxRecordMock: vi.fn(async () => null),
   fetchTwilioMessageMock: vi.fn(),
   generateSmsReplyMock: vi.fn(),
   retrierRunMock: vi.fn(),
@@ -80,6 +83,17 @@ vi.mock("../lib/components", async () => {
   };
 });
 
+vi.mock("../telemetry/posthog", async () => {
+  const actual = await vi.importActual<typeof import("../telemetry/posthog")>(
+    "../telemetry/posthog",
+  );
+
+  return {
+    ...actual,
+    enqueuePostHogOutboxRecord: enqueuePostHogOutboxRecordMock,
+  };
+});
+
 type TestRunFunction = Parameters<TestConvex<typeof schema>["run"]>[0];
 type TestContext = Parameters<TestRunFunction>[0];
 
@@ -87,6 +101,7 @@ const convexModules = modules;
 const originalConvexSiteUrl = process.env.CONVEX_SITE_URL;
 const originalTwilioAccountSid = process.env.TWILIO_ACCOUNT_SID;
 const originalTwilioAuthToken = process.env.TWILIO_AUTH_TOKEN;
+const originalTwilioAlertSmsFrom = process.env.TWILIO_ALERT_SMS_FROM;
 const originalFetch = globalThis.fetch;
 let tinyPngBuffer: Buffer;
 
@@ -166,10 +181,16 @@ async function postTwilioForm(
   });
 }
 
+async function flushImmediateScheduledFunctions(t: TestConvex<typeof schema>): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await t.finishInProgressScheduledFunctions();
+}
+
 beforeEach(() => {
   process.env.CONVEX_SITE_URL = "https://example.convex.site";
   process.env.TWILIO_ACCOUNT_SID = "ACtestaccountsid";
   process.env.TWILIO_AUTH_TOKEN = "test-auth-token";
+  process.env.TWILIO_ALERT_SMS_FROM = "+14165550999";
 
   vi.clearAllMocks();
   validateTwilioRequestMock.mockReturnValue(true);
@@ -225,6 +246,7 @@ afterAll(() => {
   process.env.CONVEX_SITE_URL = originalConvexSiteUrl;
   process.env.TWILIO_ACCOUNT_SID = originalTwilioAccountSid;
   process.env.TWILIO_AUTH_TOKEN = originalTwilioAuthToken;
+  process.env.TWILIO_ALERT_SMS_FROM = originalTwilioAlertSmsFrom;
   vi.unstubAllGlobals();
 });
 
@@ -1315,6 +1337,108 @@ describe("Twilio SMS delivery flow", () => {
         providerStatus: "delivered",
         providerRawDlrDoneDate: "2606141505",
       });
+    });
+  });
+
+  it("keeps a one-segment GSM reminder sendable when only one hosted segment remains", async () => {
+    const t = convexTest(schema, convexModules);
+    sendTwilioMessageMock.mockResolvedValue({
+      sid: "SM-notification-gsm-boundary",
+      status: "accepted",
+    });
+    const currentPeriodKey = new Date().toISOString().slice(0, 7);
+
+    const notificationId = await t.run(async (ctx) => {
+      const businessId = await ctx.db.insert("businesses", {
+        slug: "twilio-notification-gsm-boundary",
+        name: "Twilio Notification GSM Boundary",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        defaultLocale: "en",
+        deploymentMode: "cloud",
+        status: "active",
+      });
+
+      await ctx.db.insert("billing_usage_months", {
+        businessId,
+        periodKey: currentPeriodKey,
+        planAtSnapshot: "free_cloud",
+        alertSmsSegmentsUsed: 9,
+        alertSmsSegmentsIncluded: 10,
+        alertSmsBlocked: false,
+        lastRecordedAt: `${currentPeriodKey}-01T12:00:00.000Z`,
+      });
+      await ctx.db.insert("billing_accounts", {
+        businessId,
+        billingKey: getBillingKey(businessId),
+        currentPlan: "free_cloud",
+        activeAddons: [],
+        subscriptionState: "inactive",
+        billingContactEmail: "owner@example.com",
+        billingContactName: "Billing Owner",
+        lastSyncedAt: `${currentPeriodKey}-01T12:00:00.000Z`,
+      });
+
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        name: "Taylor Customer",
+        phone: "+14165550158",
+      });
+      const staffId = await ctx.db.insert("staff", {
+        businessId,
+        name: "Jordan Stylist",
+        timezone: "America/Toronto",
+        active: true,
+      });
+      const serviceId = await ctx.db.insert("services", {
+        businessId,
+        name: "Cut",
+        slug: "cut-gsm-boundary",
+        durationMinutes: 45,
+        active: true,
+      });
+      const appointmentId = await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-06-15T15:00:00.000Z",
+        endsAt: "2026-06-15T15:45:00.000Z",
+        timezone: "America/Toronto",
+        status: "booked",
+        sourceChannel: "sms",
+        calendarSyncState: "not_required",
+      });
+
+      return await ctx.db.insert("notifications", {
+        businessId,
+        channel: "sms",
+        kind: "appointment_reminder",
+        relatedId: String(appointmentId),
+        scheduledFor: "2026-06-14T15:00:00.000Z",
+        status: "pending",
+      });
+    });
+
+    const deliveryResult = await t.action(internal.notifications.reminders.deliverNotification, {
+      notificationId,
+    });
+    await flushImmediateScheduledFunctions(t);
+
+    const sentBody = sendTwilioMessageMock.mock.calls[0]?.[0]?.body;
+
+    expect(deliveryResult).toEqual({
+      delivered: true,
+      providerMessageId: "SM-notification-gsm-boundary",
+    });
+    expect(sentBody).toBeDefined();
+    expect(sentBody!.length).toBeGreaterThan(70);
+    expect(sentBody!.length).toBeLessThanOrEqual(160);
+    expect(sendTwilioMessageMock).toHaveBeenCalledWith({
+      to: "+14165550158",
+      from: "+14165550999",
+      body: sentBody,
+      statusCallback: "https://example.convex.site/twilio/sms/status",
     });
   });
 

--- a/convex/tests/twilioSmsDelivery.test.ts
+++ b/convex/tests/twilioSmsDelivery.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { getBillingKey } from "../lib/billing";
+import { buildLocalizedAppointmentNotificationBody } from "../lib/runtimeLocale";
 import schema from "../schema";
 import { modules } from "../test.setup";
 
@@ -1440,6 +1441,102 @@ describe("Twilio SMS delivery flow", () => {
       body: sentBody,
       statusCallback: "https://example.convex.site/twilio/sms/status",
     });
+  });
+
+  it("blocks a hosted reminder when emoji push the UCS-2 body into a third segment", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentPeriodKey = new Date().toISOString().slice(0, 7);
+    const serviceName = "Style AAAAAAAAAAAAAAAAA \ud83e\uddf4";
+    const expectedBody = buildLocalizedAppointmentNotificationBody({
+      kind: "appointment_reminder",
+      serviceName,
+      startsAt: "2026-06-15T15:00:00.000Z",
+      timezone: "America/Toronto",
+      locale: "en",
+    });
+
+    expect(Array.from(expectedBody)).toHaveLength(134);
+    expect(expectedBody.length).toBe(135);
+
+    const notificationId = await t.run(async (ctx) => {
+      const businessId = await ctx.db.insert("businesses", {
+        slug: "twilio-notification-unicode-boundary",
+        name: "Twilio Notification Unicode Boundary",
+        timezone: "America/Toronto",
+        businessType: "service_company",
+        defaultLocale: "en",
+        deploymentMode: "cloud",
+        status: "active",
+      });
+
+      await ctx.db.insert("billing_usage_months", {
+        businessId,
+        periodKey: currentPeriodKey,
+        planAtSnapshot: "free_cloud",
+        alertSmsSegmentsUsed: 8,
+        alertSmsSegmentsIncluded: 10,
+        alertSmsBlocked: false,
+        lastRecordedAt: `${currentPeriodKey}-01T12:00:00.000Z`,
+      });
+      await ctx.db.insert("billing_accounts", {
+        businessId,
+        billingKey: getBillingKey(businessId),
+        currentPlan: "free_cloud",
+        activeAddons: [],
+        subscriptionState: "inactive",
+        billingContactEmail: "owner@example.com",
+        billingContactName: "Billing Owner",
+        lastSyncedAt: `${currentPeriodKey}-01T12:00:00.000Z`,
+      });
+
+      const contactId = await ctx.db.insert("contacts", {
+        businessId,
+        name: "Taylor Customer",
+        phone: "+14165550159",
+      });
+      const staffId = await ctx.db.insert("staff", {
+        businessId,
+        name: "Jordan Stylist",
+        timezone: "America/Toronto",
+        active: true,
+      });
+      const serviceId = await ctx.db.insert("services", {
+        businessId,
+        name: serviceName,
+        slug: "cut-unicode-boundary",
+        durationMinutes: 45,
+        active: true,
+      });
+      const appointmentId = await ctx.db.insert("appointments", {
+        businessId,
+        contactId,
+        staffId,
+        serviceId,
+        startsAt: "2026-06-15T15:00:00.000Z",
+        endsAt: "2026-06-15T15:45:00.000Z",
+        timezone: "America/Toronto",
+        status: "booked",
+        sourceChannel: "sms",
+        calendarSyncState: "not_required",
+      });
+
+      return await ctx.db.insert("notifications", {
+        businessId,
+        channel: "sms",
+        kind: "appointment_reminder",
+        relatedId: String(appointmentId),
+        scheduledFor: "2026-06-14T15:00:00.000Z",
+        status: "pending",
+      });
+    });
+
+    await expect(
+      t.action(internal.notifications.reminders.deliverNotification, {
+        notificationId,
+      }),
+    ).rejects.toThrow("Alert SMS quota reached");
+
+    expect(sendTwilioMessageMock).not.toHaveBeenCalled();
   });
 
   it("localizes reminders to the contact's remembered French preference", async () => {

--- a/convex/tests/twilioSmsDelivery.test.ts
+++ b/convex/tests/twilioSmsDelivery.test.ts
@@ -1,6 +1,6 @@
 import { convexTest, type TestConvex } from "convex-test";
 import { Jimp, JimpMime } from "jimp";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
@@ -104,7 +104,14 @@ const originalTwilioAccountSid = process.env.TWILIO_ACCOUNT_SID;
 const originalTwilioAuthToken = process.env.TWILIO_AUTH_TOKEN;
 const originalTwilioAlertSmsFrom = process.env.TWILIO_ALERT_SMS_FROM;
 const originalFetch = globalThis.fetch;
+const activeHarnesses: Array<TestConvex<typeof schema>> = [];
 let tinyPngBuffer: Buffer;
+
+function createTestHarness(): TestConvex<typeof schema> {
+  const t = convexTest(schema, convexModules);
+  activeHarnesses.push(t);
+  return t;
+}
 
 async function insertBusiness(
   ctx: TestContext,
@@ -251,9 +258,20 @@ afterAll(() => {
   vi.unstubAllGlobals();
 });
 
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  while (activeHarnesses.length > 0) {
+    const harness = activeHarnesses.pop();
+    if (harness) {
+      await harness.finishInProgressScheduledFunctions();
+    }
+  }
+});
+
 describe("Twilio SMS delivery flow", () => {
   it("creates one outbound reply and reuses it on duplicate inbound delivery", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-outbound-reply",
       status: "queued",
@@ -352,7 +370,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("stores STOP messages, marks the contact opted out, and suppresses replies", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
 
     const { businessId, smsNumber } = await t.run(async (ctx) => {
       const businessId = await insertBusiness(ctx, {
@@ -427,7 +445,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("stores inbound SMS during human handoff and suppresses AI replies", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
 
     const { businessId, smsNumber } = await t.run(async (ctx) => {
       const businessId = await insertBusiness(ctx, {
@@ -489,7 +507,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("clears opt-out on START and resumes reply generation", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-outbound-start-reply",
       status: "queued",
@@ -549,7 +567,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("stores inbound MMS attachments without breaking reply delivery", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-outbound-mms-reply",
       status: "queued",
@@ -653,7 +671,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("builds a non-empty AI prompt for media-only inbound MMS", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-outbound-mms-media-only",
       status: "queued",
@@ -698,7 +716,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("falls back to a fresh storage URL after an attachment token expires", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     const subject = "twilio-expired-attachment-token-owner";
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-outbound-expired-token",
@@ -779,7 +797,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("repairs legacy external inbound media into previewable stored attachments", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     const subject = "twilio-legacy-media-repair-owner";
 
     const { businessId, conversationId } = await t.run(async (ctx) => {
@@ -858,7 +876,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("replies from the same inbound business number when multiple SMS numbers are active", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-outbound-multi-number-reply",
       status: "queued",
@@ -896,7 +914,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("applies delivered callbacks and ignores stale regressions", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-status-delivered",
       status: "queued",
@@ -956,7 +974,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("backfills Twilio provider cost when pricing becomes available after delivery", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-status-delayed-pricing",
       status: "queued",
@@ -1068,7 +1086,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("keeps retrying when Twilio returns cost before numSegments", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-status-cost-before-segments",
       status: "queued",
@@ -1134,7 +1152,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("persists undelivered callbacks as terminal failures", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-status-undelivered",
       status: "queued",
@@ -1189,7 +1207,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("supports backend debug lookups by provider SID and counterparty phone", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-debug-1",
       status: "queued",
@@ -1244,7 +1262,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("sends appointment notifications through Twilio and reconciles delivery", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-notification-1",
       status: "accepted",
@@ -1342,7 +1360,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("keeps a one-segment GSM reminder sendable when only one hosted segment remains", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-notification-gsm-boundary",
       status: "accepted",
@@ -1444,7 +1462,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("blocks a hosted reminder when emoji push the UCS-2 body into a third segment", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     const currentPeriodKey = new Date().toISOString().slice(0, 7);
     const serviceName = "Style AAAAAAAAAAAAAAAAA \ud83e\uddf4";
     const expectedBody = buildLocalizedAppointmentNotificationBody({
@@ -1540,7 +1558,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("localizes reminders to the contact's remembered French preference", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-notification-fr-contact",
       status: "accepted",
@@ -1625,7 +1643,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("uses the stored French business locale for booking confirmations with mixed profile text", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockResolvedValue({
       sid: "SM-notification-fr-business",
       status: "accepted",
@@ -1717,7 +1735,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("skips the immediate booking confirmation notification for sms-booked appointments", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     const startsAt = new Date(Date.now() + 49 * 60 * 60 * 1000);
     const endsAt = new Date(startsAt.getTime() + 30 * 60 * 1000);
 
@@ -1802,7 +1820,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("creates one fallback booking confirmation when a conversational booking SMS send fails", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
     sendTwilioMessageMock.mockRejectedValueOnce(new Error("Twilio send failed"));
 
     const messageId = await t.run(async (ctx) => {
@@ -1901,7 +1919,7 @@ describe("Twilio SMS delivery flow", () => {
   });
 
   it("creates one fallback booking confirmation when delivery later becomes undelivered", async () => {
-    const t = convexTest(schema, convexModules);
+    const t = createTestHarness();
 
     const appointmentId = await t.run(async (ctx) => {
       const businessId = await insertBusiness(ctx, {

--- a/convex/tests/twilioVoicePricing.test.ts
+++ b/convex/tests/twilioVoicePricing.test.ts
@@ -87,6 +87,11 @@ async function insertCall(
   });
 }
 
+async function flushImmediateScheduledFunctions(t: ConvexHarness): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await t.finishInProgressScheduledFunctions();
+}
+
 describe("Twilio voice pricing sync", () => {
   beforeEach(() => {
     process.env.TWILIO_ACCOUNT_SID = "ACtestaccountsid";
@@ -146,6 +151,7 @@ describe("Twilio voice pricing sync", () => {
       expect(call?.providerCallDurationSeconds).toBe(33);
       expect(call?.providerUpdatedAt).toBe("2026-04-09T17:00:40.000Z");
     });
+    await flushImmediateScheduledFunctions(t);
   });
 
   it("leaves cost unset when Twilio has not populated call price yet", async () => {
@@ -190,6 +196,7 @@ describe("Twilio voice pricing sync", () => {
       expect(call?.providerCallDurationSeconds).toBe(19);
       expect(call?.providerUpdatedAt).toBe("2026-04-09T18:00:19.000Z");
     });
+    await flushImmediateScheduledFunctions(t);
   });
 
   it("records an estimated provider cost from the terminal status callback before Twilio pricing hydrates", async () => {
@@ -222,6 +229,38 @@ describe("Twilio voice pricing sync", () => {
       expect(call?.providerPriceUnit).toBe("usd");
       expect(call?.providerCallDurationSeconds).toBe(23);
     });
+    await flushImmediateScheduledFunctions(t);
+  });
+
+  it("keeps the provider-reported duration when call finalization arrives later", async () => {
+    const t = convexTest(schema, convexModules);
+
+    const { callId } = await t.run(async (ctx) => {
+      const businessId = await insertBusiness(ctx);
+      const callId = await insertCall(ctx, {
+        businessId,
+        twilioCallSid: "CA-voice-finalize-race",
+      });
+      await ctx.db.patch(callId, {
+        providerCallDurationSeconds: 23,
+        providerUpdatedAt: "2026-04-09T19:00:23.000Z",
+      });
+      return { callId };
+    });
+
+    await t.mutation(internal.voice.runtime.completeCall, {
+      callId,
+      status: "completed",
+      endedAt: "2026-04-09T19:00:25.000Z",
+      providerDurationSeconds: 25,
+    });
+
+    await t.run(async (ctx) => {
+      const call = await ctx.db.get(callId);
+      expect(call?.providerCallDurationSeconds).toBe(23);
+      expect(call?.endedAt).toBe("2026-04-09T19:00:25.000Z");
+    });
+    await flushImmediateScheduledFunctions(t);
   });
 
 });

--- a/convex/tests/twilioVoicePricing.test.ts
+++ b/convex/tests/twilioVoicePricing.test.ts
@@ -9,6 +9,9 @@ import { modules } from "../test.setup";
 const { fetchTwilioCallMock } = vi.hoisted(() => ({
   fetchTwilioCallMock: vi.fn(),
 }));
+const { enqueuePostHogOutboxRecordMock } = vi.hoisted(() => ({
+  enqueuePostHogOutboxRecordMock: vi.fn(async () => null),
+}));
 
 vi.mock("twilio", () => {
   const callsResource = vi.fn((sid?: string) => ({
@@ -20,6 +23,17 @@ vi.mock("twilio", () => {
 
   return {
     default: twilioFactory,
+  };
+});
+
+vi.mock("../telemetry/posthog", async () => {
+  const actual = await vi.importActual<typeof import("../telemetry/posthog")>(
+    "../telemetry/posthog",
+  );
+
+  return {
+    ...actual,
+    enqueuePostHogOutboxRecord: enqueuePostHogOutboxRecordMock,
   };
 });
 
@@ -209,4 +223,5 @@ describe("Twilio voice pricing sync", () => {
       expect(call?.providerCallDurationSeconds).toBe(23);
     });
   });
+
 });

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -495,6 +495,16 @@ export const startCall = internalMutation({
     startedAt: v.string(),
   },
   handler: async (ctx: MutationCtx, args: StartCallArgs): Promise<StartCallResult> => {
+    const voicePolicy: {
+      allowed: boolean;
+      errorCode: BillingErrorCode | null;
+    } = await ctx.runQuery(internal.billing.assertVoiceCanStart, {
+      businessId: args.businessId,
+    });
+    if (!voicePolicy.allowed) {
+      throw new Error(voicePolicy.errorCode ?? billingErrorCodes.voiceLimitReached);
+    }
+
     let contact: Doc<"contacts"> | null = await ctx.db
       .query("contacts")
       .withIndex("by_business_id_and_phone", (q) =>

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -959,7 +959,8 @@ export const completeCall = internalMutation({
       status: args.status,
       endedAt: args.endedAt,
       ...(disposition !== undefined ? { disposition } : {}),
-      ...(args.providerDurationSeconds !== undefined
+      ...(args.providerDurationSeconds !== undefined &&
+      call.providerCallDurationSeconds === undefined
         ? { providerCallDurationSeconds: args.providerDurationSeconds }
         : {}),
     });
@@ -977,7 +978,7 @@ export const completeCall = internalMutation({
 
     if (
       args.providerDurationSeconds !== undefined &&
-      args.providerDurationSeconds !== call.providerCallDurationSeconds
+      call.providerCallDurationSeconds === undefined
     ) {
       const usageResult = await ctx.runMutation(internal.billing.recordVoiceUsage, {
         businessId: call.businessId,

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -76,6 +76,11 @@ type PrepareTransferForVoiceArgs = {
   twilioCallSid?: string;
   recordedAt: string;
 };
+type ReleaseTransferForVoiceArgs = {
+  callId?: Id<"calls">;
+  twilioCallSid?: string;
+  recordedAt: string;
+};
 type TakeMessageForVoiceArgs = {
   businessId: Id<"businesses">;
   callId: Id<"calls">;
@@ -98,6 +103,7 @@ type CompleteCallArgs = {
   status: string;
   endedAt: string;
   disposition?: string;
+  providerDurationSeconds?: number;
 };
 type ReconcileTwilioCallStatusArgs = {
   twilioCallSid: string;
@@ -757,6 +763,53 @@ export const prepareTransferForVoice = internalMutation({
   },
 });
 
+export const releaseTransferForVoice = internalMutation({
+  args: {
+    callId: v.optional(v.id("calls")),
+    twilioCallSid: v.optional(v.string()),
+    recordedAt: v.string(),
+  },
+  returns: v.object({
+    released: v.boolean(),
+  }),
+  handler: async (
+    ctx: MutationCtx,
+    args: ReleaseTransferForVoiceArgs,
+  ): Promise<{ released: boolean }> => {
+    const call =
+      args.callId !== undefined
+        ? await ctx.db.get(args.callId)
+        : args.twilioCallSid !== undefined
+          ? await ctx.db
+              .query("calls")
+              .withIndex("by_twilio_call_sid", (q) => q.eq("twilioCallSid", args.twilioCallSid!))
+              .unique()
+          : null;
+    if (!call) {
+      throw new Error("Call not found.");
+    }
+
+    const releaseResult = await ctx.runMutation(
+      internal.billing.releaseOutboundCallAttemptReservation,
+      {
+        businessId: call.businessId,
+        callId: call._id,
+        recordedAt: args.recordedAt,
+      },
+    );
+
+    if (releaseResult.syncNeeded && releaseResult.usageEventId) {
+      await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+        usageEventId: releaseResult.usageEventId,
+      });
+    }
+
+    return {
+      released: releaseResult.released,
+    };
+  },
+});
+
 // @ts-ignore Deep type instantiation from Convex mutation builder.
 export const takeMessageForVoice = internalMutation({
   args: {
@@ -887,6 +940,7 @@ export const completeCall = internalMutation({
     status: v.string(),
     endedAt: v.string(),
     disposition: v.optional(v.string()),
+    providerDurationSeconds: v.optional(v.number()),
   },
   handler: async (ctx: MutationCtx, args: CompleteCallArgs) => {
     const call: Doc<"calls"> | null = await ctx.db.get(args.callId);
@@ -905,6 +959,9 @@ export const completeCall = internalMutation({
       status: args.status,
       endedAt: args.endedAt,
       ...(disposition !== undefined ? { disposition } : {}),
+      ...(args.providerDurationSeconds !== undefined
+        ? { providerCallDurationSeconds: args.providerDurationSeconds }
+        : {}),
     });
 
     if (call.conversationId) {
@@ -917,6 +974,24 @@ export const completeCall = internalMutation({
       callId: args.callId,
       endedAt: Date.parse(args.endedAt),
     });
+
+    if (
+      args.providerDurationSeconds !== undefined &&
+      args.providerDurationSeconds !== call.providerCallDurationSeconds
+    ) {
+      const usageResult = await ctx.runMutation(internal.billing.recordVoiceUsage, {
+        businessId: call.businessId,
+        callId: call._id,
+        quantity: args.providerDurationSeconds,
+        recordedAt: args.endedAt,
+      });
+
+      if (usageResult.syncNeeded) {
+        await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+          usageEventId: usageResult.usageEventId,
+        });
+      }
+    }
 
     await enqueuePostHogOutboxRecord(
       ctx,

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -72,7 +72,8 @@ type SetTransferStateArgs = {
   transferState: string;
 };
 type PrepareTransferForVoiceArgs = {
-  callId: Id<"calls">;
+  callId?: Id<"calls">;
+  twilioCallSid?: string;
   recordedAt: string;
 };
 type TakeMessageForVoiceArgs = {
@@ -707,7 +708,8 @@ export const setTransferState = internalMutation({
 
 export const prepareTransferForVoice = internalMutation({
   args: {
-    callId: v.id("calls"),
+    callId: v.optional(v.id("calls")),
+    twilioCallSid: v.optional(v.string()),
     recordedAt: v.string(),
   },
   returns: v.object({
@@ -724,7 +726,15 @@ export const prepareTransferForVoice = internalMutation({
     ctx: MutationCtx,
     args: PrepareTransferForVoiceArgs,
   ): Promise<{ allowed: boolean; errorCode: BillingErrorCode | null }> => {
-    const call = await ctx.db.get(args.callId);
+    const call =
+      args.callId !== undefined
+        ? await ctx.db.get(args.callId)
+        : args.twilioCallSid !== undefined
+          ? await ctx.db
+              .query("calls")
+              .withIndex("by_twilio_call_sid", (q) => q.eq("twilioCallSid", args.twilioCallSid!))
+              .unique()
+          : null;
     if (!call) {
       throw new Error("Call not found.");
     }

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -2,6 +2,8 @@ import {
   getTerminalTwilioCallReconciliationFields,
   isTerminalTwilioCallStatus,
 } from "../lib/voiceCallStatus";
+import type { BillingErrorCode } from "../../packages/shared/src/billing";
+import { billingErrorCodes } from "../../packages/shared/src/billing";
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
@@ -68,6 +70,10 @@ type AppendTranscriptArgs = {
 type SetTransferStateArgs = {
   callId: Id<"calls">;
   transferState: string;
+};
+type PrepareTransferForVoiceArgs = {
+  callId: Id<"calls">;
+  recordedAt: string;
 };
 type TakeMessageForVoiceArgs = {
   businessId: Id<"businesses">;
@@ -482,13 +488,6 @@ export const startCall = internalMutation({
     startedAt: v.string(),
   },
   handler: async (ctx: MutationCtx, args: StartCallArgs): Promise<StartCallResult> => {
-    const voicePolicy = await ctx.runQuery(internal.billing.assertVoiceCanStart, {
-      businessId: args.businessId,
-    });
-    if (!voicePolicy.allowed) {
-      throw new Error("Voice quota reached for this billing period.");
-    }
-
     let contact: Doc<"contacts"> | null = await ctx.db
       .query("contacts")
       .withIndex("by_business_id_and_phone", (q) =>
@@ -531,6 +530,8 @@ export const startCall = internalMutation({
       .withIndex("by_twilio_call_sid", (q) => q.eq("twilioCallSid", args.twilioCallSid))
       .unique();
 
+    let callId: Id<"calls">;
+
     if (existingCall) {
       await ctx.db.patch(existingCall._id, {
         conversationId,
@@ -539,29 +540,41 @@ export const startCall = internalMutation({
           ? { gatewaySessionId: args.gatewaySessionId }
           : {}),
       });
-      await ensureVoiceSessionForCall(ctx, {
+      callId = existingCall._id;
+    } else {
+      callId = await ctx.db.insert("calls", {
         businessId: args.businessId,
         conversationId,
-        callId: existingCall._id,
-        startedAt: Date.parse(args.startedAt),
+        twilioCallSid: args.twilioCallSid,
+        ...(args.gatewaySessionId !== undefined
+          ? { gatewaySessionId: args.gatewaySessionId }
+          : {}),
+        status: "in_progress",
+        startedAt: args.startedAt,
       });
-      return {
-        callId: existingCall._id,
-        conversationId,
-        contactId: contact._id,
-      };
     }
 
-    const callId = await ctx.db.insert("calls", {
+    const reservation = await ctx.runMutation(internal.billing.reserveVoiceUsageAtCallStart, {
       businessId: args.businessId,
-      conversationId,
-      twilioCallSid: args.twilioCallSid,
-      ...(args.gatewaySessionId !== undefined
-        ? { gatewaySessionId: args.gatewaySessionId }
-        : {}),
-      status: "in_progress",
-      startedAt: args.startedAt,
+      callId,
+      recordedAt: args.startedAt,
     });
+    if (!reservation.allowed) {
+      await ctx.db.patch(callId, {
+        status: "completed",
+        endedAt: args.startedAt,
+        disposition: reservation.errorCode ?? billingErrorCodes.voiceLimitReached,
+      });
+      await ctx.db.patch(conversationId, {
+        status: "closed",
+      });
+      throw new Error(reservation.errorCode ?? billingErrorCodes.voiceLimitReached);
+    }
+    if (reservation.syncNeeded && reservation.usageEventId) {
+      await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+        usageEventId: reservation.usageEventId,
+      });
+    }
 
     await ensureVoiceSessionForCall(ctx, {
       businessId: args.businessId,
@@ -689,6 +702,48 @@ export const setTransferState = internalMutation({
       );
     }
     return null;
+  },
+});
+
+export const prepareTransferForVoice = internalMutation({
+  args: {
+    callId: v.id("calls"),
+    recordedAt: v.string(),
+  },
+  returns: v.object({
+    allowed: v.boolean(),
+    errorCode: v.union(
+      v.literal("voice_limit_reached"),
+      v.literal("alert_sms_limit_reached"),
+      v.literal("outbound_call_attempt_limit_reached"),
+      v.literal("ai_sms_not_enabled"),
+      v.null(),
+    ),
+  }),
+  handler: async (
+    ctx: MutationCtx,
+    args: PrepareTransferForVoiceArgs,
+  ): Promise<{ allowed: boolean; errorCode: BillingErrorCode | null }> => {
+    const call = await ctx.db.get(args.callId);
+    if (!call) {
+      throw new Error("Call not found.");
+    }
+
+    const reservation = await ctx.runMutation(internal.billing.reserveOutboundCallAttemptUsage, {
+      businessId: call.businessId,
+      callId: call._id,
+      recordedAt: args.recordedAt,
+    });
+    if (reservation.syncNeeded && reservation.usageEventId) {
+      await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+        usageEventId: reservation.usageEventId,
+      });
+    }
+
+    return {
+      allowed: reservation.allowed,
+      errorCode: reservation.errorCode,
+    };
   },
 });
 

--- a/docs/providers/polar.md
+++ b/docs/providers/polar.md
@@ -2,6 +2,13 @@
 
 This repo uses Polar for hosted cloud billing.
 
+The integration is intentionally hosted and backend-driven:
+
+- checkout creation stays in [convex/billing.ts](/Users/raphael/Coding/ai-receptionist/convex/billing.ts)
+- customer self-service uses Polar customer sessions instead of custom billing UI
+- subscription and transaction state are synchronized from Polar webhooks
+- metered usage is emitted from backend usage events, never from the client
+
 ## Products
 
 Create these Polar products:
@@ -66,6 +73,30 @@ For hosted Alert SMS, also configure:
 
 - `TWILIO_ALERT_SMS_FROM`
 
+## Secret handling
+
+Treat these as backend-only secrets:
+
+- `POLAR_ORGANIZATION_TOKEN`
+- `POLAR_WEBHOOK_SECRET`
+
+Do not expose them to the web app, mobile clients, third-party scripts, or browser-visible env vars.
+
+Operational defaults:
+
+- use separate Polar credentials for `sandbox` and `production`
+- keep `POLAR_SERVER` aligned with the matching token, webhook secret, and product IDs
+- store secrets in your deployment platform's secret manager or protected environment configuration
+- never log Polar secrets, paste them into tickets, or include them in analytics payloads
+
+If a Polar secret is exposed:
+
+1. Rotate the affected credential immediately.
+2. Review recent checkout, subscription, transaction, and metered-event activity.
+3. Re-verify webhook delivery and metered usage sync after rotation.
+
+This repo does not assume Stripe-style restricted API keys exist in Polar. Until Polar documents an equivalent scoped credential for this workflow, keep the organization token limited to backend infrastructure you control.
+
 ## Webhook routing
 
 Polar routes are registered from [convex/http.ts](/Users/raphael/Coding/ai-receptionist/convex/http.ts) through [convex/billing.ts](/Users/raphael/Coding/ai-receptionist/convex/billing.ts).
@@ -73,6 +104,44 @@ Polar routes are registered from [convex/http.ts](/Users/raphael/Coding/ai-recep
 Use the Convex HTTP endpoint:
 
 - `/polar/events`
+
+Webhook handling expectations:
+
+- signature verification is enforced by `@convex-dev/polar` before app handlers run
+- webhook updates are the source of truth for hosted plan, add-on, and transaction state
+- do not introduce separate manual renewal loops or invoice polling to drive subscription state
+
+## Metered usage operations
+
+Polar metered usage is driven by rows in the `billing_usage_events` table.
+
+Important fields:
+
+- `syncStatus`
+- `syncAttemptedAt`
+- `syncedAt`
+- `syncError`
+
+Expected retry behavior for `internal.billing.syncUsageEventToPolar`:
+
+- immediate first attempt from the triggering workflow
+- best-effort retries after `30s`, `2m`, `10m`, and `30m`
+
+Operational guidance:
+
+- treat repeated `syncStatus = "failed"` rows as an alertable billing issue
+- check `syncError` first for token, customer-link, or transient Polar API failures
+- after fixing the underlying issue, manually re-run `internal.billing.syncUsageEventToPolar` for the affected usage event IDs
+- do not backfill usage by minting ad hoc Polar events outside this table unless you also reconcile local billing records deliberately
+
+## Validation
+
+Before go-live, confirm:
+
+- checkout creation works only from backend actions and only for billing admins
+- customer portal sessions are created server-side and only for billing admins
+- `/polar/events` rejects missing or invalid webhook signatures
+- metered usage failures are visible through `billing_usage_events.syncStatus`
 
 ## Notes
 

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -265,6 +265,11 @@ describe("telemetry redaction", () => {
       "toolName",
       "latencyBucket",
     ]);
+    expect(getTelemetryRequiredProperties("ops.billing.usage_sync_failed")).toEqual([
+      "businessId",
+      "deploymentMode",
+      "provider",
+    ]);
     expect(getTelemetryRequiredProperties("voice.provider_cost_recorded")).toEqual([
       "businessId",
       "deploymentMode",

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -76,6 +76,8 @@ export const WORKFLOW_EVENT_NAMES = [
 ] as const;
 
 export const OPERATIONS_EVENT_NAMES = [
+  "ops.billing.usage_sync_failed",
+  "ops.billing.usage_sync_recovered",
   "ops.voice.heartbeat",
   "ops.voice.invalid_signature",
   "ops.voice.media_disconnect",
@@ -430,6 +432,16 @@ export const TELEMETRY_REQUIRED_PROPERTIES_BY_EVENT = {
   "business.snapshot_refreshed": ["businessId", "deploymentMode"],
   "workflow.started": ["businessId", "deploymentMode", "workflowName"],
   "workflow.failed": ["businessId", "deploymentMode", "workflowName"],
+  "ops.billing.usage_sync_failed": [
+    "businessId",
+    "deploymentMode",
+    "provider",
+  ],
+  "ops.billing.usage_sync_recovered": [
+    "businessId",
+    "deploymentMode",
+    "provider",
+  ],
   "ops.voice.heartbeat": ["deploymentMode"],
   "ops.voice.invalid_signature": ["deploymentMode", "provider"],
   "ops.voice.media_disconnect": ["deploymentMode", "provider"],


### PR DESCRIPTION
## Summary
- Tighten pricing bypass enforcement for `OPE-92` across voice runtime, telephony routes, and Convex billing paths
- Align reminder and HTTP/runtime behavior with the hardened billing checks
- Update Polar provider docs and telemetry coverage to reflect the new behavior
- Add or update regression tests for telephony, billing, and telemetry paths

## Testing
- Updated `apps/voice-gateway/src/telephony/routes.test.ts`
- Updated `convex/tests/billing.test.ts`
- Updated `packages/telemetry/src/index.test.ts`
- Not run (not requested)