### PR TITLE
Add self-serve 10DLC registration and SMS compliance checks

### DIFF
--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -176,6 +176,8 @@
       },
       "companyTypes": {
         "private": "Private",
+        "nonProfit": "Non-profit",
+        "government": "Government",
         "public": "Public"
       },
       "trafficTier": {
@@ -191,6 +193,8 @@
         "businessRegistrationIdentifier": "Tax ID type",
         "businessRegistrationNumber": "Tax ID number",
         "companyType": "Company type",
+        "stockExchange": "Stock exchange",
+        "stockTicker": "Stock ticker",
         "brandContactEmail": "Brand contact email (required for public companies)",
         "representativeFirstName": "Authorized representative first name",
         "representativeLastName": "Authorized representative last name",

--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -183,6 +183,7 @@
         "mixed": "Mixed / higher volume"
       },
       "fields": {
+        "approvedPhoneNumber": "Business number to register",
         "businessName": "Legal business name",
         "websiteUrl": "Website URL",
         "businessType": "Business type",

--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -119,7 +119,7 @@
     },
     "catalog": {
       "title": "Hosted offers",
-      "description": "Alert SMS uses the shared Noncia sender in hosted cloud. AI SMS stays on the customer's own number.",
+      "description": "Hosted workspaces use the shared sender for alerts until AI SMS registration is approved. After approval, both alerts and AI SMS move onto the business number while billing stays split by usage type.",
       "selfHostDescription": "Free forever. Full product, bring your own AI keys, Twilio account, numbers, and compliance setup.",
       "freeCloudDescription": "$0 per month. No overages and no AI SMS.",
       "freeCloudLimits": "Includes {{voiceMinutes}} voice minutes, {{alertSmsSegments}} Alert SMS segments, and {{outboundAttempts}} outbound call attempts per month.",
@@ -130,13 +130,91 @@
     "addon": {
       "title": "Add-ons",
       "aiSmsName": "AI SMS",
-      "aiSmsDescription": "Allows your agent to send and reply to SMS autonomously.",
+      "aiSmsDescription": "Allows your agent to send and reply to SMS autonomously after 10DLC approval.",
+      "aiSmsSetupRequiredDescription": "AI SMS billing is active, but 10DLC registration still needs to be completed before alerts and AI SMS can use the business number.",
+      "aiSmsSetupRequiredNotice": "Alerts stay on the shared hosted sender until approval. AI SMS remains blocked while Twilio reviews the registration.",
       "enable": "Enable",
       "aiSmsActiveBadge": "Active",
+      "aiSmsSetupRequiredBadge": "Setup required",
       "aiSmsPricing": "{{monthly}}/mo + {{perSegment}}/segment",
       "aiSmsSetup": "One-time setup fee: {{amount}}",
       "aiSmsRequiresProPrefix": "Available on",
       "aiSmsRequiresProLink": "Pro plan"
+    },
+    "compliance": {
+      "title": "AI SMS compliance",
+      "description": "Register your business for A2P 10DLC so hosted alerts and AI replies can use the approved business number.",
+      "cardTitle": "10DLC registration",
+      "routingSummary": "Current sender routing: {{senderMode}}.",
+      "approvedNumber": "Approved business number: {{phoneNumber}}",
+      "senderMode": {
+        "platformPhone": "alerts stay on the shared hosted sender",
+        "businessPhone": "messages send from the business number directly",
+        "businessMessagingService": "alerts and AI SMS send through the approved business Messaging Service"
+      },
+      "status": {
+        "setupRequired": "Setup required",
+        "awaitingVerification": "Awaiting verification",
+        "underReview": "Under review",
+        "approved": "Approved",
+        "failed": "Failed",
+        "suspended": "Suspended"
+      },
+      "actions": {
+        "save": "Save draft",
+        "saving": "Saving...",
+        "submit": "Submit registration",
+        "resume": "Resume registration",
+        "refresh": "Refresh status",
+        "working": "Updating..."
+      },
+      "toast": {
+        "saved": "Saved SMS compliance draft.",
+        "saveFailed": "Unable to save the SMS compliance draft.",
+        "submitted": "Updated SMS compliance registration.",
+        "submitFailed": "Unable to update the SMS compliance registration."
+      },
+      "companyTypes": {
+        "private": "Private",
+        "public": "Public"
+      },
+      "trafficTier": {
+        "lowVolume": "Low volume (recommended)",
+        "mixed": "Mixed / higher volume"
+      },
+      "fields": {
+        "businessName": "Legal business name",
+        "websiteUrl": "Website URL",
+        "businessType": "Business type",
+        "businessIndustry": "Business industry",
+        "businessRegistrationIdentifier": "Tax ID type",
+        "businessRegistrationNumber": "Tax ID number",
+        "companyType": "Company type",
+        "brandContactEmail": "Brand contact email (required for public companies)",
+        "representativeFirstName": "Authorized representative first name",
+        "representativeLastName": "Authorized representative last name",
+        "representativeBusinessTitle": "Authorized representative title",
+        "representativeJobPosition": "Authorized representative role",
+        "representativePhoneNumber": "Authorized representative phone",
+        "representativeEmail": "Authorized representative email",
+        "addressCustomerName": "Mailing name",
+        "addressStreet": "Street address",
+        "addressStreetSecondary": "Address line 2",
+        "addressCity": "City",
+        "addressRegion": "State / province",
+        "addressPostalCode": "Postal code",
+        "addressIsoCountry": "Country code",
+        "trafficTier": "Traffic profile",
+        "campaignDescription": "Campaign description",
+        "messageFlow": "Opt-in flow",
+        "sampleMessageOne": "Sample message 1",
+        "sampleMessageTwo": "Sample message 2",
+        "optInMessage": "Opt-in confirmation message",
+        "optOutMessage": "Opt-out message",
+        "helpMessage": "Help message",
+        "hasEmbeddedLinks": "Messages include links",
+        "hasEmbeddedPhone": "Messages include phone numbers"
+      }
     },
     "spendingCap": {
       "title": "Monthly spending cap",

--- a/apps/web/src/features/settings/SettingsBillingPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.test.tsx
@@ -811,6 +811,64 @@ describe("SettingsBillingPage AI SMS add-on", () => {
     );
   });
 
+  it("allows changing the approved phone number while brand verification is pending", async () => {
+    const user = userEvent.setup();
+    const replacementPhoneNumberId = "phone_456" as Id<"phone_numbers">;
+    saveComplianceFormMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_brand_verification",
+    });
+    resumeRegistrationMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        status: "pending_brand_verification",
+        approvedPhoneNumberId: defaultApprovedPhoneNumberId,
+        availablePhoneNumbers: [
+          {
+            id: replacementPhoneNumberId,
+            e164: "+14165550177",
+          },
+        ],
+      }),
+    });
+
+    const phoneSelectField = screen
+      .getByText("billing.compliance.fields.approvedPhoneNumber")
+      .parentElement;
+    expect(phoneSelectField).toBeTruthy();
+    const phoneSelect = within(phoneSelectField as HTMLElement).getByRole("combobox");
+    expect(phoneSelect.getAttribute("data-disabled")).toBeNull();
+
+    await user.click(phoneSelect);
+    await user.click(screen.getByRole("option", { name: "+14165550177" }));
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.resume" }),
+    );
+
+    await waitFor(() => {
+      expect(saveComplianceFormMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          approvedPhoneNumberId: replacementPhoneNumberId,
+        }),
+      );
+      expect(resumeRegistrationMock).toHaveBeenCalledWith({ businessId });
+    });
+  });
+
   it("renders usage on the dedicated usage page", () => {
     mockQueries({
       status: buildStatus(),

--- a/apps/web/src/features/settings/SettingsBillingPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.test.tsx
@@ -165,6 +165,8 @@ type SmsComplianceState = {
     businessRegistrationNumber?: string;
     websiteUrl?: string;
     companyType?: string;
+    stockExchange?: string;
+    stockTicker?: string;
     brandContactEmail?: string;
     campaignDescription?: string;
     messageFlow?: string;
@@ -235,6 +237,8 @@ function buildCompliance(
       businessRegistrationNumber: "12-3456789",
       websiteUrl: "https://example.com",
       companyType: "private",
+      stockExchange: "",
+      stockTicker: "",
       brandContactEmail: "ops@example.com",
       campaignDescription: "Appointment alerts and AI SMS replies.",
       messageFlow: "Customers opt in during online booking and intake forms.",
@@ -866,6 +870,58 @@ describe("SettingsBillingPage AI SMS add-on", () => {
         }),
       );
       expect(resumeRegistrationMock).toHaveBeenCalledWith({ businessId });
+    });
+  });
+
+  it("sends public-company stock metadata when submitting the compliance form", async () => {
+    const user = userEvent.setup();
+    saveComplianceFormMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "collecting_info",
+    });
+    startRegistrationMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        setupRequired: true,
+        status: "not_started",
+        draft: {
+          ...buildCompliance().draft,
+          companyType: "public",
+          stockExchange: "NASDAQ",
+          stockTicker: "ACME",
+        },
+      }),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.submit" }),
+    );
+
+    await waitFor(() => {
+      expect(saveComplianceFormMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draft: expect.objectContaining({
+            companyType: "public",
+            stockExchange: "NASDAQ",
+            stockTicker: "ACME",
+          }),
+        }),
+      );
+      expect(startRegistrationMock).toHaveBeenCalledWith({ businessId });
     });
   });
 

--- a/apps/web/src/features/settings/SettingsBillingPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.test.tsx
@@ -91,6 +91,7 @@ vi.mock("sonner", () => ({
 }));
 
 const businessId = "business_123" as Id<"businesses">;
+const defaultApprovedPhoneNumberId = "phone_123" as Id<"phone_numbers">;
 
 function buildStatus(overrides: Partial<BillingStatus> = {}): BillingStatus {
   return {
@@ -99,11 +100,13 @@ function buildStatus(overrides: Partial<BillingStatus> = {}): BillingStatus {
     subscriptionState: "inactive",
     activeAddons: [],
     aiSmsEnabled: false,
+    aiSmsReady: false,
     overagesBillable: false,
     monthlyChargeCents: 0,
     billingContactEmail: null,
     billingContactName: null,
     includedBusinessNumbers: 0,
+    hasBillingManagementAccess: true,
     hasCustomerPortalAccess: false,
     hasCheckoutAccess: true,
     availableCheckoutPlans: ["pro"],
@@ -150,6 +153,10 @@ type SmsComplianceState = {
     | "failed"
     | "suspended";
   trafficTier: "low_volume" | "mixed";
+  availablePhoneNumbers: Array<{
+    id: Id<"phone_numbers">;
+    e164: string;
+  }>;
   draft?: {
     businessName?: string;
     businessType?: string;
@@ -191,6 +198,7 @@ type SmsComplianceState = {
   };
   failureCode?: string;
   failureMessage?: string;
+  approvedPhoneNumberId?: Id<"phone_numbers">;
   approvedPhoneNumberE164?: string;
   twilioMessagingServiceSid?: string;
 };
@@ -213,6 +221,12 @@ function buildCompliance(
     senderMode: "platform_phone",
     status: "not_started",
     trafficTier: "low_volume",
+    availablePhoneNumbers: [
+      {
+        id: defaultApprovedPhoneNumberId,
+        e164: "+14165550166",
+      },
+    ],
     draft: {
       businessName: "Acme Clinic LLC",
       businessType: "Corporation",
@@ -272,8 +286,16 @@ function mockQueries(input: {
   compliance?: SmsComplianceState;
   campaignOptions?: SmsComplianceCampaignOption[];
 }) {
-  rememberedQueryMock.mockImplementation((reference: unknown) => {
+  rememberedQueryMock.mockImplementation((reference: unknown, args?: unknown) => {
     const functionName = getFunctionName(reference as never);
+
+    if (args === "skip") {
+      return {
+        data: undefined,
+        isInitialLoading: false,
+        isRefreshing: false,
+      };
+    }
 
     if (functionName === "billing:getStatus") {
       return {
@@ -460,6 +482,7 @@ describe("SettingsBillingPage AI SMS add-on", () => {
         subscriptionState: "active",
         activeAddons: ["ai_sms"],
         aiSmsEnabled: true,
+        aiSmsReady: true,
         monthlyChargeCents: 2_000,
         overagesBillable: true,
       }),
@@ -596,6 +619,33 @@ describe("SettingsBillingPage AI SMS add-on", () => {
     expect(screen.getByText("Twilio is reviewing your campaign.")).toBeTruthy();
   });
 
+  it("hides the hosted AI SMS compliance section for non-admin members", () => {
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+        hasBillingManagementAccess: false,
+        hasCheckoutAccess: false,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        setupRequired: true,
+      }),
+    });
+
+    expect(screen.queryByText("billing.compliance.title")).toBeNull();
+    expect(screen.queryByText("billing.compliance.cardTitle")).toBeNull();
+    expect(screen.queryByText("billing.addon.aiSmsActiveBadge")).toBeNull();
+    expect(screen.getAllByText("billing.addon.aiSmsSetupRequiredBadge").length).toBeGreaterThan(
+      0,
+    );
+  });
+
   it("saves the compliance draft before starting registration", async () => {
     const user = userEvent.setup();
     saveComplianceFormMock.mockResolvedValue({
@@ -633,6 +683,7 @@ describe("SettingsBillingPage AI SMS add-on", () => {
         expect.objectContaining({
           businessId,
           trafficTier: "low_volume",
+          approvedPhoneNumberId: defaultApprovedPhoneNumberId,
           draft: expect.objectContaining({
             businessName: "Acme Clinic LLC",
             campaignDescription: "Appointment alerts and AI SMS replies.",
@@ -646,12 +697,53 @@ describe("SettingsBillingPage AI SMS add-on", () => {
     );
   });
 
-  it("saves the compliance draft before refreshing an in-review registration", async () => {
+  it("falls back to the only active phone number when the saved approved sender is stale", async () => {
     const user = userEvent.setup();
+    const replacementPhoneNumberId = "phone_456" as Id<"phone_numbers">;
     saveComplianceFormMock.mockResolvedValue({
       registrationId: "registration_123",
-      status: "pending_review",
+      status: "collecting_info",
     });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        setupRequired: true,
+        status: "not_started",
+        approvedPhoneNumberId: defaultApprovedPhoneNumberId,
+        availablePhoneNumbers: [
+          {
+            id: replacementPhoneNumberId,
+            e164: "+14165550177",
+          },
+        ],
+      }),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.save" }),
+    );
+
+    await waitFor(() => {
+      expect(saveComplianceFormMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          approvedPhoneNumberId: replacementPhoneNumberId,
+        }),
+      );
+    });
+  });
+
+  it("refreshes an in-review registration without resaving the draft", async () => {
+    const user = userEvent.setup();
     refreshStatusMock.mockResolvedValue({
       registrationId: "registration_123",
       status: "pending_review",
@@ -678,11 +770,44 @@ describe("SettingsBillingPage AI SMS add-on", () => {
     );
 
     await waitFor(() => {
-      expect(saveComplianceFormMock).toHaveBeenCalledTimes(1);
+      expect(saveComplianceFormMock).not.toHaveBeenCalled();
       expect(refreshStatusMock).toHaveBeenCalledWith({ businessId });
     });
-    expect(saveComplianceFormMock.mock.invocationCallOrder[0]).toBeLessThan(
-      refreshStatusMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+  });
+
+  it("shows an error toast instead of success when refresh returns a failed status", async () => {
+    const user = userEvent.setup();
+    refreshStatusMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "failed",
+    });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        status: "pending_review",
+      }),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.refresh" }),
+    );
+
+    await waitFor(() => {
+      expect(refreshStatusMock).toHaveBeenCalledWith({ businessId });
+      expect(toastErrorMock).toHaveBeenCalledWith("billing.compliance.toast.submitFailed");
+    });
+    expect(toastSuccessMock).not.toHaveBeenCalledWith(
+      "billing.compliance.toast.submitted",
     );
   });
 

--- a/apps/web/src/features/settings/SettingsBillingPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.test.tsx
@@ -869,6 +869,66 @@ describe("SettingsBillingPage AI SMS add-on", () => {
     });
   });
 
+  it("persists a replacement phone number before refreshing an approved stale sender", async () => {
+    const user = userEvent.setup();
+    const replacementPhoneNumberId = "phone_456" as Id<"phone_numbers">;
+    saveComplianceFormMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+    refreshStatusMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        status: "approved",
+        senderMode: "platform_phone",
+        approvedPhoneNumberId: defaultApprovedPhoneNumberId,
+        availablePhoneNumbers: [
+          {
+            id: replacementPhoneNumberId,
+            e164: "+14165550177",
+          },
+        ],
+      }),
+    });
+
+    const phoneSelectField = screen
+      .getByText("billing.compliance.fields.approvedPhoneNumber")
+      .parentElement;
+    expect(phoneSelectField).toBeTruthy();
+    const phoneSelect = within(phoneSelectField as HTMLElement).getByRole("combobox");
+    expect(phoneSelect.getAttribute("data-disabled")).toBeNull();
+
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.refresh" }),
+    );
+
+    await waitFor(() => {
+      expect(saveComplianceFormMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          approvedPhoneNumberId: replacementPhoneNumberId,
+        }),
+      );
+      expect(refreshStatusMock).toHaveBeenCalledWith({ businessId });
+    });
+    expect(saveComplianceFormMock.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshStatusMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
   it("renders usage on the dedicated usage page", () => {
     mockQueries({
       status: buildStatus(),

--- a/apps/web/src/features/settings/SettingsBillingPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { getFunctionName } from "convex/server";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import type { BillingStatus } from "../../../../../packages/shared/src/billing";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -13,12 +15,37 @@ import {
   SettingsBillingUsagePage,
 } from "./SettingsBillingPage";
 
-const startCheckoutMock = vi.fn();
+const {
+  locationAssignMock,
+  openPortalMock,
+  refreshStatusMock,
+  resumeRegistrationMock,
+  saveComplianceFormMock,
+  startCheckoutMock,
+  startRegistrationMock,
+  toastErrorMock,
+  toastSuccessMock,
+  useActionMock,
+  useMutationMock,
+} = vi.hoisted(() => ({
+  locationAssignMock: vi.fn(),
+  openPortalMock: vi.fn(),
+  refreshStatusMock: vi.fn(),
+  resumeRegistrationMock: vi.fn(),
+  saveComplianceFormMock: vi.fn(),
+  startCheckoutMock: vi.fn(),
+  startRegistrationMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  useActionMock: vi.fn(),
+  useMutationMock: vi.fn(),
+}));
+
 const rememberedQueryMock = vi.mocked(useRememberedConvexQuery);
-const locationAssignMock = vi.fn();
 
 vi.mock("convex/react", () => ({
-  useAction: () => startCheckoutMock,
+  useAction: (...args: unknown[]) => useActionMock(...args),
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -54,6 +81,13 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/lib/remembered-convex-query", () => ({
   useRememberedConvexQuery: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
 }));
 
 const businessId = "business_123" as Id<"businesses">;
@@ -99,12 +133,186 @@ function buildStatus(overrides: Partial<BillingStatus> = {}): BillingStatus {
   };
 }
 
-function renderBillingPage(status: BillingStatus) {
-  rememberedQueryMock.mockReturnValue({
-    data: status,
-    isInitialLoading: false,
-    isRefreshing: false,
+type SmsComplianceState = {
+  applicable: boolean;
+  aiSmsCommerciallyEnabled: boolean;
+  alertsUseBusinessSender: boolean;
+  aiSmsReady: boolean;
+  setupRequired: boolean;
+  senderMode: "platform_phone" | "business_phone" | "business_messaging_service";
+  status:
+    | "not_started"
+    | "collecting_info"
+    | "submitting"
+    | "pending_brand_verification"
+    | "pending_review"
+    | "approved"
+    | "failed"
+    | "suspended";
+  trafficTier: "low_volume" | "mixed";
+  draft?: {
+    businessName?: string;
+    businessType?: string;
+    businessIndustry?: string;
+    businessRegistrationIdentifier?: string;
+    businessRegistrationNumber?: string;
+    websiteUrl?: string;
+    companyType?: string;
+    brandContactEmail?: string;
+    campaignDescription?: string;
+    messageFlow?: string;
+    sampleMessages?: string[];
+    optInMessage?: string;
+    optOutMessage?: string;
+    helpMessage?: string;
+    hasEmbeddedLinks?: boolean;
+    hasEmbeddedPhone?: boolean;
+    address?: {
+      customerName?: string;
+      street?: string;
+      streetSecondary?: string;
+      city?: string;
+      region?: string;
+      postalCode?: string;
+      isoCountry?: string;
+    };
+    authorizedRepresentative?: {
+      firstName?: string;
+      lastName?: string;
+      businessTitle?: string;
+      jobPosition?: string;
+      phoneNumber?: string;
+      email?: string;
+    };
+  };
+  pendingAction?: {
+    type: string;
+    message: string;
+  };
+  failureCode?: string;
+  failureMessage?: string;
+  approvedPhoneNumberE164?: string;
+  twilioMessagingServiceSid?: string;
+};
+
+type SmsComplianceCampaignOption = {
+  value: "low_volume" | "mixed";
+  twilioUsecaseCode: string;
+  recommended: boolean;
+};
+
+function buildCompliance(
+  overrides: Partial<SmsComplianceState> = {},
+): SmsComplianceState {
+  return {
+    applicable: false,
+    aiSmsCommerciallyEnabled: false,
+    alertsUseBusinessSender: false,
+    aiSmsReady: false,
+    setupRequired: false,
+    senderMode: "platform_phone",
+    status: "not_started",
+    trafficTier: "low_volume",
+    draft: {
+      businessName: "Acme Clinic LLC",
+      businessType: "Corporation",
+      businessIndustry: "HEALTHCARE",
+      businessRegistrationIdentifier: "EIN",
+      businessRegistrationNumber: "12-3456789",
+      websiteUrl: "https://example.com",
+      companyType: "private",
+      brandContactEmail: "ops@example.com",
+      campaignDescription: "Appointment alerts and AI SMS replies.",
+      messageFlow: "Customers opt in during online booking and intake forms.",
+      sampleMessages: [
+        "Acme Clinic: your appointment is tomorrow at 2 PM.",
+        "Acme Clinic: reply YES to confirm or call us at 555-0100.",
+      ],
+      optInMessage: "Reply START to opt in to SMS updates.",
+      optOutMessage: "Reply STOP to unsubscribe.",
+      helpMessage: "Reply HELP for support.",
+      hasEmbeddedLinks: false,
+      hasEmbeddedPhone: true,
+      address: {
+        customerName: "Acme Clinic LLC",
+        street: "123 Main Street",
+        city: "Toronto",
+        region: "ON",
+        postalCode: "M5V 2T6",
+        isoCountry: "CA",
+      },
+      authorizedRepresentative: {
+        firstName: "Jordan",
+        lastName: "Lee",
+        businessTitle: "Operations Manager",
+        jobPosition: "Director",
+        phoneNumber: "+14165550155",
+        email: "jordan@example.com",
+      },
+    },
+    ...overrides,
+  };
+}
+
+const defaultCampaignOptions: SmsComplianceCampaignOption[] = [
+  {
+    value: "low_volume",
+    twilioUsecaseCode: "LOW_VOLUME",
+    recommended: true,
+  },
+  {
+    value: "mixed",
+    twilioUsecaseCode: "MIXED",
+    recommended: false,
+  },
+];
+
+function mockQueries(input: {
+  status: BillingStatus;
+  compliance?: SmsComplianceState;
+  campaignOptions?: SmsComplianceCampaignOption[];
+}) {
+  rememberedQueryMock.mockImplementation((reference: unknown) => {
+    const functionName = getFunctionName(reference as never);
+
+    if (functionName === "billing:getStatus") {
+      return {
+        data: input.status,
+        isInitialLoading: false,
+        isRefreshing: false,
+      };
+    }
+
+    if (functionName === "smsCompliance:getStatus") {
+      return {
+        data: input.compliance,
+        isInitialLoading: false,
+        isRefreshing: false,
+      };
+    }
+
+    if (functionName === "smsCompliance:getCampaignOptions") {
+      return {
+        data: input.campaignOptions ?? defaultCampaignOptions,
+        isInitialLoading: false,
+        isRefreshing: false,
+      };
+    }
+
+    return {
+      data: undefined,
+      isInitialLoading: false,
+      isRefreshing: false,
+    };
   });
+}
+
+function renderBillingPage(input: {
+  status: BillingStatus;
+  compliance?: SmsComplianceState;
+  campaignOptions?: SmsComplianceCampaignOption[];
+}) {
+  mockQueries(input);
 
   return render(
     <MemoryRouter>
@@ -118,6 +326,15 @@ function renderBillingPage(status: BillingStatus) {
 describe("SettingsBillingPage AI SMS add-on", () => {
   beforeEach(() => {
     startCheckoutMock.mockReset();
+    openPortalMock.mockReset();
+    saveComplianceFormMock.mockReset();
+    startRegistrationMock.mockReset();
+    resumeRegistrationMock.mockReset();
+    refreshStatusMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    useActionMock.mockReset();
+    useMutationMock.mockReset();
     rememberedQueryMock.mockReset();
     vi.stubGlobal("open", vi.fn());
     Object.defineProperty(window, "localStorage", {
@@ -137,12 +354,42 @@ describe("SettingsBillingPage AI SMS add-on", () => {
         assign: locationAssignMock,
       },
     });
+
+    useActionMock.mockImplementation((reference: unknown) => {
+      const functionName = getFunctionName(reference as never);
+
+      if (functionName === "billing:startCheckout") {
+        return startCheckoutMock;
+      }
+      if (functionName === "billing:openPortal") {
+        return openPortalMock;
+      }
+      if (functionName === "smsCompliance:startRegistration") {
+        return startRegistrationMock;
+      }
+      if (functionName === "smsCompliance:resumeRegistration") {
+        return resumeRegistrationMock;
+      }
+      if (functionName === "smsCompliance:refreshStatus") {
+        return refreshStatusMock;
+      }
+
+      throw new Error(`Unexpected action reference in SettingsBillingPage test.`);
+    });
+
+    useMutationMock.mockImplementation((reference: unknown) => {
+      if (getFunctionName(reference as never) === "smsCompliance:saveComplianceForm") {
+        return saveComplianceFormMock;
+      }
+
+      throw new Error(`Unexpected mutation reference in SettingsBillingPage test.`);
+    });
   });
 
   it("shows a tooltip for the disabled enable button on the free plan", async () => {
     const user = userEvent.setup();
 
-    renderBillingPage(buildStatus());
+    renderBillingPage({ status: buildStatus() });
 
     const enableButton = screen.getByRole("button", {
       name: "billing.addon.aiSmsName",
@@ -158,12 +405,12 @@ describe("SettingsBillingPage AI SMS add-on", () => {
   it("does not render the Pro upgrade tooltip action when checkout is unavailable", async () => {
     const user = userEvent.setup();
 
-    renderBillingPage(
-      buildStatus({
+    renderBillingPage({
+      status: buildStatus({
         hasCheckoutAccess: false,
         availableCheckoutPlans: [],
       }),
-    );
+    });
 
     const enableButton = screen.getByRole("button", {
       name: "billing.addon.aiSmsName",
@@ -182,15 +429,15 @@ describe("SettingsBillingPage AI SMS add-on", () => {
       url: "https://example.com/checkout",
     });
 
-    renderBillingPage(
-      buildStatus({
+    renderBillingPage({
+      status: buildStatus({
         plan: "pro",
         subscriptionState: "active",
         monthlyChargeCents: 1_500,
         overagesBillable: true,
         canPurchaseAiSmsAddon: true,
       }),
-    );
+    });
 
     const enableButton = screen.getByRole("button", {
       name: "billing.addon.aiSmsName",
@@ -207,8 +454,8 @@ describe("SettingsBillingPage AI SMS add-on", () => {
   });
 
   it("renders the add-on as active once AI SMS is enabled", () => {
-    renderBillingPage(
-      buildStatus({
+    renderBillingPage({
+      status: buildStatus({
         plan: "pro",
         subscriptionState: "active",
         activeAddons: ["ai_sms"],
@@ -216,7 +463,17 @@ describe("SettingsBillingPage AI SMS add-on", () => {
         monthlyChargeCents: 2_000,
         overagesBillable: true,
       }),
-    );
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        alertsUseBusinessSender: true,
+        aiSmsReady: true,
+        senderMode: "business_messaging_service",
+        status: "approved",
+        approvedPhoneNumberE164: "+14165550166",
+        twilioMessagingServiceSid: "MG-approved",
+      }),
+    });
 
     expect(screen.getAllByText("billing.addon.aiSmsActiveBadge").length).toBeGreaterThan(0);
     expect(screen.getByText("$15")).toBeTruthy();
@@ -229,8 +486,8 @@ describe("SettingsBillingPage AI SMS add-on", () => {
   });
 
   it("opens invoice links safely in a new tab", () => {
-    renderBillingPage(
-      buildStatus({
+    renderBillingPage({
+      status: buildStatus({
         recentTransactions: [
           {
             amountCents: 2_000,
@@ -244,7 +501,7 @@ describe("SettingsBillingPage AI SMS add-on", () => {
           },
         ],
       }),
-    );
+    });
 
     const invoiceLink = screen.getByRole("link", {
       name: "billing.transactions.invoice",
@@ -256,8 +513,8 @@ describe("SettingsBillingPage AI SMS add-on", () => {
   });
 
   it("renders the redesigned plan card content for Pro", () => {
-    renderBillingPage(
-      buildStatus({
+    renderBillingPage({
+      status: buildStatus({
         plan: "pro",
         subscriptionState: "active",
         monthlyChargeCents: 1_500,
@@ -265,7 +522,7 @@ describe("SettingsBillingPage AI SMS add-on", () => {
         hasCustomerPortalAccess: true,
         billingContactEmail: "raphael@example.com",
       }),
-    );
+    });
 
     expect(screen.getByText("$15")).toBeTruthy();
     expect(screen.getByText("billing.currentPlan.paygMonthlySuffix")).toBeTruthy();
@@ -274,26 +531,164 @@ describe("SettingsBillingPage AI SMS add-on", () => {
   });
 
   it("keeps portal access visible for free workspaces with a billing customer", () => {
-    renderBillingPage(
-      buildStatus({
+    renderBillingPage({
+      status: buildStatus({
         hasCustomerPortalAccess: true,
       }),
-    );
+    });
 
     expect(screen.getByRole("button", { name: "billing.actions.manageSubscription" })).toBeTruthy();
   });
 
   it("keeps usage off the billing overview page", () => {
-    renderBillingPage(buildStatus());
+    renderBillingPage({ status: buildStatus() });
 
     expect(screen.queryByText("billing.usage.voiceTitle")).toBeNull();
   });
 
+  it("shows setup required after AI SMS is purchased but compliance is not approved", () => {
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        setupRequired: true,
+        status: "pending_review",
+      }),
+    });
+
+    expect(screen.getAllByText("billing.addon.aiSmsSetupRequiredBadge").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("renders the hosted AI SMS compliance section for eligible workspaces", () => {
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        setupRequired: true,
+        pendingAction: {
+          type: "manual_review",
+          message: "Twilio is reviewing your campaign.",
+        },
+      }),
+    });
+
+    expect(screen.getByText("billing.compliance.title")).toBeTruthy();
+    expect(screen.getByText("billing.compliance.cardTitle")).toBeTruthy();
+    expect(screen.getByText(/billing\.compliance\.routingSummary/)).toBeTruthy();
+    expect(screen.getByText("Twilio is reviewing your campaign.")).toBeTruthy();
+  });
+
+  it("saves the compliance draft before starting registration", async () => {
+    const user = userEvent.setup();
+    saveComplianceFormMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "collecting_info",
+    });
+    startRegistrationMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        setupRequired: true,
+        status: "not_started",
+      }),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.submit" }),
+    );
+
+    await waitFor(() => {
+      expect(saveComplianceFormMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessId,
+          trafficTier: "low_volume",
+          draft: expect.objectContaining({
+            businessName: "Acme Clinic LLC",
+            campaignDescription: "Appointment alerts and AI SMS replies.",
+          }),
+        }),
+      );
+      expect(startRegistrationMock).toHaveBeenCalledWith({ businessId });
+    });
+    expect(saveComplianceFormMock.mock.invocationCallOrder[0]).toBeLessThan(
+      startRegistrationMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("saves the compliance draft before refreshing an in-review registration", async () => {
+    const user = userEvent.setup();
+    saveComplianceFormMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+    refreshStatusMock.mockResolvedValue({
+      registrationId: "registration_123",
+      status: "pending_review",
+    });
+
+    renderBillingPage({
+      status: buildStatus({
+        plan: "pro",
+        subscriptionState: "active",
+        activeAddons: ["ai_sms"],
+        aiSmsEnabled: true,
+        monthlyChargeCents: 2_000,
+        overagesBillable: true,
+      }),
+      compliance: buildCompliance({
+        applicable: true,
+        aiSmsCommerciallyEnabled: true,
+        status: "pending_review",
+      }),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "billing.compliance.actions.refresh" }),
+    );
+
+    await waitFor(() => {
+      expect(saveComplianceFormMock).toHaveBeenCalledTimes(1);
+      expect(refreshStatusMock).toHaveBeenCalledWith({ businessId });
+    });
+    expect(saveComplianceFormMock.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshStatusMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
   it("renders usage on the dedicated usage page", () => {
-    rememberedQueryMock.mockReturnValue({
-      data: buildStatus(),
-      isInitialLoading: false,
-      isRefreshing: false,
+    mockQueries({
+      status: buildStatus(),
     });
 
     render(

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -1328,8 +1328,18 @@ function getCompliancePrimaryActionLabel(
   }
 }
 
-function canEditApprovedPhoneNumber(status: SmsComplianceStatus): boolean {
-  return canEditComplianceDraft(status) || status === "pending_brand_verification";
+function canEditApprovedPhoneNumber(compliance: SmsComplianceState): boolean {
+  const hasStaleApprovedPhoneNumber =
+    compliance.approvedPhoneNumberId !== undefined &&
+    !compliance.availablePhoneNumbers.some(
+      (phoneNumber) => phoneNumber.id === compliance.approvedPhoneNumberId,
+    );
+
+  return (
+    canEditComplianceDraft(compliance.status) ||
+    compliance.status === "pending_brand_verification" ||
+    (compliance.status === "approved" && hasStaleApprovedPhoneNumber)
+  );
 }
 
 function canEditComplianceDraft(status: SmsComplianceStatus): boolean {
@@ -1374,7 +1384,7 @@ function AiSmsComplianceSection({
   );
   const [loading, setLoading] = useState<null | "save" | "action">(null);
   const isDraftEditable = canEditComplianceDraft(compliance.status);
-  const canEditPhoneNumber = canEditApprovedPhoneNumber(compliance.status);
+  const canEditPhoneNumber = canEditApprovedPhoneNumber(compliance);
 
   useEffect(() => {
     setForm(buildSmsComplianceFormState(compliance));

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -1329,7 +1329,7 @@ function getCompliancePrimaryActionLabel(
 }
 
 function canEditApprovedPhoneNumber(status: SmsComplianceStatus): boolean {
-  return canEditComplianceDraft(status);
+  return canEditComplianceDraft(status) || status === "pending_brand_verification";
 }
 
 function canEditComplianceDraft(status: SmsComplianceStatus): boolean {
@@ -1374,6 +1374,7 @@ function AiSmsComplianceSection({
   );
   const [loading, setLoading] = useState<null | "save" | "action">(null);
   const isDraftEditable = canEditComplianceDraft(compliance.status);
+  const canEditPhoneNumber = canEditApprovedPhoneNumber(compliance.status);
 
   useEffect(() => {
     setForm(buildSmsComplianceFormState(compliance));
@@ -1406,7 +1407,7 @@ function AiSmsComplianceSection({
   }
 
   async function handleSave() {
-    if (!isDraftEditable) {
+    if (!isDraftEditable && !canEditPhoneNumber) {
       return;
     }
 
@@ -1424,7 +1425,7 @@ function AiSmsComplianceSection({
   async function handlePrimaryAction() {
     setLoading("action");
     try {
-      if (isDraftEditable) {
+      if (isDraftEditable || canEditPhoneNumber) {
         await persistDraft();
       }
 
@@ -1530,10 +1531,6 @@ function AiSmsComplianceSection({
           </div>
         )}
 
-        <fieldset
-          className="contents"
-          disabled={loading !== null || !isDraftEditable}
-        >
         <div className="grid gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-2">
             <Label>{t("billing.compliance.fields.approvedPhoneNumber")}</Label>
@@ -1547,7 +1544,7 @@ function AiSmsComplianceSection({
               }
               disabled={
                 loading !== null ||
-                !canEditApprovedPhoneNumber(compliance.status) ||
+                !canEditPhoneNumber ||
                 compliance.availablePhoneNumbers.length === 0
               }
             >
@@ -1565,6 +1562,13 @@ function AiSmsComplianceSection({
               </SelectContent>
             </Select>
           </div>
+        </div>
+
+        <fieldset
+          className="contents"
+          disabled={loading !== null || !isDraftEditable}
+        >
+        <div className="grid gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-2">
             <Label htmlFor="sms-compliance-business-name">
               {t("billing.compliance.fields.businessName")}

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -82,6 +82,8 @@ type SmsComplianceDraft = {
   websiteUrl?: string;
   businessRegionsOfOperation?: string[];
   companyType?: string;
+  stockExchange?: string;
+  stockTicker?: string;
   brandContactEmail?: string;
   campaignDescription?: string;
   messageFlow?: string;
@@ -160,6 +162,8 @@ type SmsComplianceFormState = {
   businessRegistrationNumber: string;
   websiteUrl: string;
   companyType: string;
+  stockExchange: string;
+  stockTicker: string;
   brandContactEmail: string;
   representativeFirstName: string;
   representativeLastName: string;
@@ -195,6 +199,8 @@ const DEFAULT_SMS_COMPLIANCE_FORM_STATE: SmsComplianceFormState = {
   businessRegistrationNumber: "",
   websiteUrl: "",
   companyType: "private",
+  stockExchange: "",
+  stockTicker: "",
   brandContactEmail: "",
   representativeFirstName: "",
   representativeLastName: "",
@@ -461,6 +467,8 @@ function buildSmsComplianceFormState(
     businessRegistrationNumber: draft?.businessRegistrationNumber ?? "",
     websiteUrl: draft?.websiteUrl ?? "",
     companyType: draft?.companyType ?? DEFAULT_SMS_COMPLIANCE_FORM_STATE.companyType,
+    stockExchange: draft?.stockExchange ?? "",
+    stockTicker: draft?.stockTicker ?? "",
     brandContactEmail: draft?.brandContactEmail ?? "",
     representativeFirstName: draft?.authorizedRepresentative?.firstName ?? "",
     representativeLastName: draft?.authorizedRepresentative?.lastName ?? "",
@@ -508,6 +516,12 @@ function buildSmsComplianceDraft(
     businessRegistrationNumber: form.businessRegistrationNumber.trim(),
     websiteUrl: form.websiteUrl.trim(),
     companyType: form.companyType.trim(),
+    ...(form.companyType === "public" && form.stockExchange.trim().length > 0
+      ? { stockExchange: form.stockExchange.trim() }
+      : {}),
+    ...(form.companyType === "public" && form.stockTicker.trim().length > 0
+      ? { stockTicker: form.stockTicker.trim() }
+      : {}),
     ...(form.brandContactEmail.trim().length > 0
       ? { brandContactEmail: form.brandContactEmail.trim() }
       : {}),
@@ -1385,6 +1399,7 @@ function AiSmsComplianceSection({
   const [loading, setLoading] = useState<null | "save" | "action">(null);
   const isDraftEditable = canEditComplianceDraft(compliance.status);
   const canEditPhoneNumber = canEditApprovedPhoneNumber(compliance);
+  const isPublicCompany = form.companyType === "public";
 
   useEffect(() => {
     setForm(buildSmsComplianceFormState(compliance));
@@ -1704,10 +1719,46 @@ function AiSmsComplianceSection({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="private">{t("billing.compliance.companyTypes.private")}</SelectItem>
+                <SelectItem value="non-profit">{t("billing.compliance.companyTypes.nonProfit")}</SelectItem>
+                <SelectItem value="government">{t("billing.compliance.companyTypes.government")}</SelectItem>
                 <SelectItem value="public">{t("billing.compliance.companyTypes.public")}</SelectItem>
               </SelectContent>
             </Select>
           </div>
+          {isPublicCompany && (
+            <>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="sms-compliance-stock-exchange">
+                  {t("billing.compliance.fields.stockExchange")}
+                </Label>
+                <Input
+                  id="sms-compliance-stock-exchange"
+                  value={form.stockExchange}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      stockExchange: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="sms-compliance-stock-ticker">
+                  {t("billing.compliance.fields.stockTicker")}
+                </Label>
+                <Input
+                  id="sms-compliance-stock-ticker"
+                  value={form.stockTicker}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      stockTicker: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </>
+          )}
           <div className="flex flex-col gap-2">
             <Label htmlFor="sms-compliance-brand-contact">
               {t("billing.compliance.fields.brandContactEmail")}

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -1,7 +1,14 @@
-import { useState } from "react";
-import { useAction } from "convex/react";
+import { useEffect, useState } from "react";
+import { useAction, useMutation } from "convex/react";
 import { Trans, useTranslation } from "react-i18next";
-import { ArrowUpRight, Check, Lock } from "lucide-react";
+import {
+  ArrowUpRight,
+  Check,
+  CircleAlert,
+  Loader2,
+  Lock,
+  RefreshCw,
+} from "lucide-react";
 
 import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
@@ -15,8 +22,17 @@ import type {
 } from "../../../../../packages/shared/src/billing";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { SectionBlock } from "@/components/section-block";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -26,6 +42,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -45,6 +62,156 @@ type SettingsBillingPageProps = {
 
 type BillingTranslation = ReturnType<typeof useTranslation<"settings">>["t"];
 type BillingLocale = string;
+
+type SmsComplianceStatus =
+  | "not_started"
+  | "collecting_info"
+  | "submitting"
+  | "pending_brand_verification"
+  | "pending_review"
+  | "approved"
+  | "failed"
+  | "suspended";
+
+type SmsComplianceDraft = {
+  businessName?: string;
+  businessType?: string;
+  businessIndustry?: string;
+  businessRegistrationIdentifier?: string;
+  businessRegistrationNumber?: string;
+  websiteUrl?: string;
+  businessRegionsOfOperation?: string[];
+  companyType?: string;
+  brandContactEmail?: string;
+  campaignDescription?: string;
+  messageFlow?: string;
+  sampleMessages?: string[];
+  hasEmbeddedLinks?: boolean;
+  hasEmbeddedPhone?: boolean;
+  optInMessage?: string;
+  optOutMessage?: string;
+  helpMessage?: string;
+  optInKeywords?: string[];
+  optOutKeywords?: string[];
+  helpKeywords?: string[];
+  address?: {
+    customerName?: string;
+    street?: string;
+    streetSecondary?: string;
+    city?: string;
+    region?: string;
+    postalCode?: string;
+    isoCountry?: string;
+  };
+  authorizedRepresentative?: {
+    firstName?: string;
+    lastName?: string;
+    businessTitle?: string;
+    jobPosition?: string;
+    phoneNumber?: string;
+    email?: string;
+  };
+};
+
+type SmsComplianceState = {
+  applicable: boolean;
+  aiSmsCommerciallyEnabled: boolean;
+  alertsUseBusinessSender: boolean;
+  aiSmsReady: boolean;
+  setupRequired: boolean;
+  senderMode: "platform_phone" | "business_phone" | "business_messaging_service";
+  status: SmsComplianceStatus;
+  trafficTier: "low_volume" | "mixed";
+  draft?: SmsComplianceDraft;
+  pendingAction?: {
+    type:
+      | "brand_contact_email_otp"
+      | "missing_information"
+      | "manual_review"
+      | "customer_profile_review"
+      | "campaign_review"
+      | "phone_number_association";
+    message: string;
+  };
+  failureCode?: string;
+  failureMessage?: string;
+  approvedPhoneNumberE164?: string;
+  twilioMessagingServiceSid?: string;
+};
+
+type SmsComplianceCampaignOption = {
+  value: "low_volume" | "mixed";
+  twilioUsecaseCode: string;
+  recommended: boolean;
+};
+
+type SmsComplianceFormState = {
+  trafficTier: "low_volume" | "mixed";
+  businessName: string;
+  businessType: string;
+  businessIndustry: string;
+  businessRegistrationIdentifier: string;
+  businessRegistrationNumber: string;
+  websiteUrl: string;
+  companyType: string;
+  brandContactEmail: string;
+  representativeFirstName: string;
+  representativeLastName: string;
+  representativeBusinessTitle: string;
+  representativeJobPosition: string;
+  representativePhoneNumber: string;
+  representativeEmail: string;
+  addressCustomerName: string;
+  addressStreet: string;
+  addressStreetSecondary: string;
+  addressCity: string;
+  addressRegion: string;
+  addressPostalCode: string;
+  addressIsoCountry: string;
+  campaignDescription: string;
+  messageFlow: string;
+  sampleMessageOne: string;
+  sampleMessageTwo: string;
+  optInMessage: string;
+  optOutMessage: string;
+  helpMessage: string;
+  hasEmbeddedLinks: boolean;
+  hasEmbeddedPhone: boolean;
+};
+
+const DEFAULT_SMS_COMPLIANCE_FORM_STATE: SmsComplianceFormState = {
+  trafficTier: "low_volume",
+  businessName: "",
+  businessType: "Corporation",
+  businessIndustry: "TECHNOLOGY",
+  businessRegistrationIdentifier: "EIN",
+  businessRegistrationNumber: "",
+  websiteUrl: "",
+  companyType: "private",
+  brandContactEmail: "",
+  representativeFirstName: "",
+  representativeLastName: "",
+  representativeBusinessTitle: "",
+  representativeJobPosition: "CEO",
+  representativePhoneNumber: "",
+  representativeEmail: "",
+  addressCustomerName: "",
+  addressStreet: "",
+  addressStreetSecondary: "",
+  addressCity: "",
+  addressRegion: "",
+  addressPostalCode: "",
+  addressIsoCountry: "US",
+  campaignDescription: "",
+  messageFlow: "",
+  sampleMessageOne: "",
+  sampleMessageTwo: "",
+  optInMessage: "",
+  optOutMessage: "",
+  helpMessage: "",
+  hasEmbeddedLinks: false,
+  hasEmbeddedPhone: false,
+};
 
 // ---------------------------------------------------------------------------
 // Formatters
@@ -158,6 +325,130 @@ function useBillingStatus(businessId: Id<"businesses">) {
   return useRememberedConvexQuery(api.billing.getStatus, {
     businessId,
   });
+}
+
+function useSmsComplianceStatus(businessId: Id<"businesses">) {
+  return useRememberedConvexQuery(api.smsCompliance.getStatus, {
+    businessId,
+  });
+}
+
+function useSmsComplianceCampaignOptions() {
+  return useRememberedConvexQuery(api.smsCompliance.getCampaignOptions, {});
+}
+
+function buildSmsComplianceFormState(
+  compliance: SmsComplianceState | undefined,
+): SmsComplianceFormState {
+  const draft = compliance?.draft;
+  const sampleMessages = draft?.sampleMessages ?? [];
+
+  return {
+    ...DEFAULT_SMS_COMPLIANCE_FORM_STATE,
+    trafficTier: compliance?.trafficTier ?? "low_volume",
+    businessName: draft?.businessName ?? "",
+    businessType: draft?.businessType ?? DEFAULT_SMS_COMPLIANCE_FORM_STATE.businessType,
+    businessIndustry:
+      draft?.businessIndustry ?? DEFAULT_SMS_COMPLIANCE_FORM_STATE.businessIndustry,
+    businessRegistrationIdentifier:
+      draft?.businessRegistrationIdentifier ??
+      DEFAULT_SMS_COMPLIANCE_FORM_STATE.businessRegistrationIdentifier,
+    businessRegistrationNumber: draft?.businessRegistrationNumber ?? "",
+    websiteUrl: draft?.websiteUrl ?? "",
+    companyType: draft?.companyType ?? DEFAULT_SMS_COMPLIANCE_FORM_STATE.companyType,
+    brandContactEmail: draft?.brandContactEmail ?? "",
+    representativeFirstName: draft?.authorizedRepresentative?.firstName ?? "",
+    representativeLastName: draft?.authorizedRepresentative?.lastName ?? "",
+    representativeBusinessTitle:
+      draft?.authorizedRepresentative?.businessTitle ?? "",
+    representativeJobPosition:
+      draft?.authorizedRepresentative?.jobPosition ??
+      DEFAULT_SMS_COMPLIANCE_FORM_STATE.representativeJobPosition,
+    representativePhoneNumber: draft?.authorizedRepresentative?.phoneNumber ?? "",
+    representativeEmail: draft?.authorizedRepresentative?.email ?? "",
+    addressCustomerName: draft?.address?.customerName ?? "",
+    addressStreet: draft?.address?.street ?? "",
+    addressStreetSecondary: draft?.address?.streetSecondary ?? "",
+    addressCity: draft?.address?.city ?? "",
+    addressRegion: draft?.address?.region ?? "",
+    addressPostalCode: draft?.address?.postalCode ?? "",
+    addressIsoCountry:
+      draft?.address?.isoCountry ?? DEFAULT_SMS_COMPLIANCE_FORM_STATE.addressIsoCountry,
+    campaignDescription: draft?.campaignDescription ?? "",
+    messageFlow: draft?.messageFlow ?? "",
+    sampleMessageOne: sampleMessages[0] ?? "",
+    sampleMessageTwo: sampleMessages[1] ?? "",
+    optInMessage: draft?.optInMessage ?? "",
+    optOutMessage: draft?.optOutMessage ?? "",
+    helpMessage: draft?.helpMessage ?? "",
+    hasEmbeddedLinks: draft?.hasEmbeddedLinks ?? false,
+    hasEmbeddedPhone: draft?.hasEmbeddedPhone ?? false,
+  };
+}
+
+function buildSmsComplianceDraft(
+  form: SmsComplianceFormState,
+): SmsComplianceDraft {
+  const businessName = form.businessName.trim();
+  const sampleMessages = [
+    form.sampleMessageOne.trim(),
+    form.sampleMessageTwo.trim(),
+  ].filter((message) => message.length > 0);
+
+  return {
+    businessName,
+    businessType: form.businessType.trim(),
+    businessIndustry: form.businessIndustry.trim(),
+    businessRegistrationIdentifier: form.businessRegistrationIdentifier.trim(),
+    businessRegistrationNumber: form.businessRegistrationNumber.trim(),
+    websiteUrl: form.websiteUrl.trim(),
+    companyType: form.companyType.trim(),
+    ...(form.brandContactEmail.trim().length > 0
+      ? { brandContactEmail: form.brandContactEmail.trim() }
+      : {}),
+    campaignDescription: form.campaignDescription.trim(),
+    messageFlow: form.messageFlow.trim(),
+    sampleMessages,
+    ...(form.optInMessage.trim().length > 0
+      ? { optInMessage: form.optInMessage.trim() }
+      : {}),
+    optOutMessage: form.optOutMessage.trim(),
+    helpMessage: form.helpMessage.trim(),
+    hasEmbeddedLinks: form.hasEmbeddedLinks,
+    hasEmbeddedPhone: form.hasEmbeddedPhone,
+    businessRegionsOfOperation: ["USA_AND_CANADA"],
+    optInKeywords: ["START"],
+    optOutKeywords: ["STOP"],
+    helpKeywords: ["HELP"],
+    address: {
+      customerName:
+        form.addressCustomerName.trim().length > 0
+          ? form.addressCustomerName.trim()
+          : businessName,
+      street: form.addressStreet.trim(),
+      ...(form.addressStreetSecondary.trim().length > 0
+        ? { streetSecondary: form.addressStreetSecondary.trim() }
+        : {}),
+      city: form.addressCity.trim(),
+      region: form.addressRegion.trim(),
+      postalCode: form.addressPostalCode.trim(),
+      isoCountry: form.addressIsoCountry.trim(),
+    },
+    authorizedRepresentative: {
+      firstName: form.representativeFirstName.trim(),
+      lastName: form.representativeLastName.trim(),
+      businessTitle: form.representativeBusinessTitle.trim(),
+      jobPosition: form.representativeJobPosition.trim(),
+      phoneNumber: form.representativePhoneNumber.trim(),
+      email: form.representativeEmail.trim(),
+    },
+  };
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.trim().length > 0
+    ? error.message
+    : fallback;
 }
 
 // ---------------------------------------------------------------------------
@@ -697,18 +988,26 @@ function UsageMeterRow({
 
 function AddonsSection({
   status,
+  compliance,
   businessId,
   locale,
   t,
 }: {
   status: BillingStatus;
+  compliance?: SmsComplianceState;
   businessId: Id<"businesses">;
   locale: BillingLocale;
   t: BillingTranslation;
 }) {
   const startCheckout = useAction(api.billing.startCheckout);
   const [loading, setLoading] = useState<"ai_sms" | "pro" | null>(null);
-  const isActive = status.aiSmsEnabled;
+  const isOperational =
+    status.aiSmsEnabled &&
+    (status.plan === "self_host" || compliance?.status === "approved");
+  const setupRequired =
+    status.aiSmsEnabled &&
+    status.plan !== "self_host" &&
+    compliance?.status !== "approved";
   const canPurchase = status.canPurchaseAiSmsAddon;
   const canUpgradeToPro =
     status.hasCheckoutAccess &&
@@ -719,7 +1018,7 @@ function AddonsSection({
   );
   const isFreePlanLocked =
     status.plan === "free_cloud" &&
-    !isActive &&
+    !isOperational &&
     canUpgradeToPro;
 
   async function handleAddAiSms() {
@@ -750,12 +1049,19 @@ function AddonsSection({
     }
   }
 
-  const enableControl = isActive ? (
+  const enableControl = isOperational ? (
     <Badge
       variant="outline"
       className="border-emerald-200 bg-emerald-50 text-[11px] tracking-wide text-emerald-700"
     >
       {t("billing.addon.aiSmsActiveBadge")}
+    </Badge>
+  ) : setupRequired ? (
+    <Badge
+      variant="outline"
+      className="border-amber-200 bg-amber-50 text-[11px] tracking-wide text-amber-700"
+    >
+      {t("billing.addon.aiSmsSetupRequiredBadge")}
     </Badge>
   ) : (
     <Button
@@ -783,7 +1089,7 @@ function AddonsSection({
               <span className="text-[15px] font-medium leading-6 text-foreground">
                 {t("billing.addon.aiSmsName")}
               </span>
-              {isActive && (
+              {isOperational && (
                 <Badge
                   variant="default"
                   className="bg-emerald-600 text-[10px] tracking-wide text-white dark:bg-emerald-500"
@@ -791,11 +1097,26 @@ function AddonsSection({
                   {t("billing.addon.aiSmsActiveBadge")}
                 </Badge>
               )}
+              {!isOperational && setupRequired && (
+                <Badge
+                  variant="outline"
+                  className="border-amber-200 bg-amber-50 text-[10px] tracking-wide text-amber-700"
+                >
+                  {t("billing.addon.aiSmsSetupRequiredBadge")}
+                </Badge>
+              )}
             </div>
             <span className="text-[15px] leading-6 text-muted-foreground">
-              {t("billing.addon.aiSmsDescription")}
+              {setupRequired
+                ? t("billing.addon.aiSmsSetupRequiredDescription")
+                : t("billing.addon.aiSmsDescription")}
             </span>
-            {isActive && (
+            {setupRequired && (
+              <span className="text-sm leading-6 text-muted-foreground">
+                {t("billing.addon.aiSmsSetupRequiredNotice")}
+              </span>
+            )}
+            {status.aiSmsEnabled && (
               <div className="mt-1 flex flex-wrap items-end gap-2">
                 <span className="text-2xl font-semibold tracking-tight text-foreground">
                   {addonMonthlyPrice}
@@ -844,6 +1165,702 @@ function AddonsSection({
             ) : (
               enableControl
             )}
+          </div>
+        </div>
+      </BorderedItem>
+    </BillingSection>
+  );
+}
+
+function getComplianceBadge(
+  status: SmsComplianceStatus,
+  t: BillingTranslation,
+): { label: string; className: string } {
+  switch (status) {
+    case "approved":
+      return {
+        label: t("billing.compliance.status.approved"),
+        className: "border-emerald-200 bg-emerald-50 text-emerald-700",
+      };
+    case "pending_brand_verification":
+      return {
+        label: t("billing.compliance.status.awaitingVerification"),
+        className: "border-amber-200 bg-amber-50 text-amber-700",
+      };
+    case "pending_review":
+    case "submitting":
+      return {
+        label: t("billing.compliance.status.underReview"),
+        className: "border-sky-200 bg-sky-50 text-sky-700",
+      };
+    case "failed":
+      return {
+        label: t("billing.compliance.status.failed"),
+        className: "border-destructive/20 bg-destructive/10 text-destructive",
+      };
+    case "suspended":
+      return {
+        label: t("billing.compliance.status.suspended"),
+        className: "border-destructive/20 bg-destructive/10 text-destructive",
+      };
+    case "not_started":
+    case "collecting_info":
+    default:
+      return {
+        label: t("billing.compliance.status.setupRequired"),
+        className: "border-amber-200 bg-amber-50 text-amber-700",
+      };
+  }
+}
+
+function getCompliancePrimaryActionLabel(
+  status: SmsComplianceStatus,
+  t: BillingTranslation,
+): string {
+  switch (status) {
+    case "pending_brand_verification":
+      return t("billing.compliance.actions.resume");
+    case "pending_review":
+    case "approved":
+    case "suspended":
+      return t("billing.compliance.actions.refresh");
+    default:
+      return t("billing.compliance.actions.submit");
+  }
+}
+
+function getComplianceSenderModeCopy(
+  senderMode: SmsComplianceState["senderMode"],
+  t: BillingTranslation,
+): string {
+  switch (senderMode) {
+    case "business_messaging_service":
+      return t("billing.compliance.senderMode.businessMessagingService");
+    case "business_phone":
+      return t("billing.compliance.senderMode.businessPhone");
+    case "platform_phone":
+    default:
+      return t("billing.compliance.senderMode.platformPhone");
+  }
+}
+
+function AiSmsComplianceSection({
+  businessId,
+  compliance,
+  t,
+}: {
+  businessId: Id<"businesses">;
+  compliance: SmsComplianceState;
+  t: BillingTranslation;
+}) {
+  const saveComplianceForm = useMutation(api.smsCompliance.saveComplianceForm);
+  const startRegistration = useAction(api.smsCompliance.startRegistration);
+  const resumeRegistration = useAction(api.smsCompliance.resumeRegistration);
+  const refreshRegistration = useAction(api.smsCompliance.refreshStatus);
+  const { data: campaignOptions } = useSmsComplianceCampaignOptions();
+  const [form, setForm] = useState<SmsComplianceFormState>(() =>
+    buildSmsComplianceFormState(compliance),
+  );
+  const [loading, setLoading] = useState<null | "save" | "action">(null);
+
+  useEffect(() => {
+    setForm(buildSmsComplianceFormState(compliance));
+  }, [compliance]);
+
+  const badge = getComplianceBadge(compliance.status, t);
+  const primaryActionLabel = getCompliancePrimaryActionLabel(compliance.status, t);
+  const availableCampaignOptions = campaignOptions ?? [
+    {
+      value: "low_volume" as const,
+      twilioUsecaseCode: "LOW_VOLUME",
+      recommended: true,
+    },
+    {
+      value: "mixed" as const,
+      twilioUsecaseCode: "MIXED",
+      recommended: false,
+    },
+  ];
+
+  async function persistDraft() {
+    await saveComplianceForm({
+      businessId,
+      trafficTier: form.trafficTier,
+      draft: buildSmsComplianceDraft(form),
+    });
+  }
+
+  async function handleSave() {
+    setLoading("save");
+    try {
+      await persistDraft();
+      toast.success(t("billing.compliance.toast.saved"));
+    } catch (error) {
+      toast.error(getErrorMessage(error, t("billing.compliance.toast.saveFailed")));
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function handlePrimaryAction() {
+    setLoading("action");
+    try {
+      await persistDraft();
+
+      if (compliance.status === "pending_brand_verification") {
+        await resumeRegistration({ businessId });
+      } else if (
+        compliance.status === "pending_review" ||
+        compliance.status === "approved" ||
+        compliance.status === "suspended"
+      ) {
+        await refreshRegistration({ businessId });
+      } else {
+        await startRegistration({ businessId });
+      }
+
+      toast.success(t("billing.compliance.toast.submitted"));
+    } catch (error) {
+      toast.error(getErrorMessage(error, t("billing.compliance.toast.submitFailed")));
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <BillingSection
+      title={t("billing.compliance.title")}
+      description={t("billing.compliance.description")}
+    >
+      <BorderedItem className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[15px] font-medium leading-6 text-foreground">
+                {t("billing.compliance.cardTitle")}
+              </span>
+              <Badge
+                variant="outline"
+                className={`text-[11px] tracking-wide ${badge.className}`}
+              >
+                {badge.label}
+              </Badge>
+            </div>
+            <p className="text-sm leading-6 text-muted-foreground">
+              {t("billing.compliance.routingSummary", {
+                senderMode: getComplianceSenderModeCopy(compliance.senderMode, t),
+              })}
+            </p>
+            {compliance.approvedPhoneNumberE164 && (
+              <p className="text-sm leading-6 text-muted-foreground">
+                {t("billing.compliance.approvedNumber", {
+                  phoneNumber: compliance.approvedPhoneNumberE164,
+                })}
+              </p>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => void handleSave()}
+              disabled={loading !== null}
+            >
+              {loading === "save" ? t("billing.compliance.actions.saving") : t("billing.compliance.actions.save")}
+            </Button>
+            <Button onClick={() => void handlePrimaryAction()} disabled={loading !== null}>
+              {loading === "action" ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  {t("billing.compliance.actions.working")}
+                </>
+              ) : compliance.status === "pending_review" ||
+                compliance.status === "approved" ||
+                compliance.status === "suspended" ? (
+                <>
+                  <RefreshCw className="size-4" />
+                  {primaryActionLabel}
+                </>
+              ) : (
+                primaryActionLabel
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {(compliance.pendingAction?.message || compliance.failureMessage) && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            <div className="flex items-start gap-2">
+              <CircleAlert className="mt-0.5 size-4 shrink-0" />
+              <span>
+                {compliance.pendingAction?.message ?? compliance.failureMessage}
+              </span>
+            </div>
+          </div>
+        )}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-business-name">
+              {t("billing.compliance.fields.businessName")}
+            </Label>
+            <Input
+              id="sms-compliance-business-name"
+              value={form.businessName}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, businessName: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-website">
+              {t("billing.compliance.fields.websiteUrl")}
+            </Label>
+            <Input
+              id="sms-compliance-website"
+              value={form.websiteUrl}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, websiteUrl: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-business-type">
+              {t("billing.compliance.fields.businessType")}
+            </Label>
+            <Input
+              id="sms-compliance-business-type"
+              value={form.businessType}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, businessType: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-business-industry">
+              {t("billing.compliance.fields.businessIndustry")}
+            </Label>
+            <Input
+              id="sms-compliance-business-industry"
+              value={form.businessIndustry}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, businessIndustry: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-tax-id-type">
+              {t("billing.compliance.fields.businessRegistrationIdentifier")}
+            </Label>
+            <Input
+              id="sms-compliance-tax-id-type"
+              value={form.businessRegistrationIdentifier}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  businessRegistrationIdentifier: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-tax-id-number">
+              {t("billing.compliance.fields.businessRegistrationNumber")}
+            </Label>
+            <Input
+              id="sms-compliance-tax-id-number"
+              value={form.businessRegistrationNumber}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  businessRegistrationNumber: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>{t("billing.compliance.fields.companyType")}</Label>
+            <Select
+              value={form.companyType}
+              onValueChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  companyType: value ?? current.companyType,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="private">{t("billing.compliance.companyTypes.private")}</SelectItem>
+                <SelectItem value="public">{t("billing.compliance.companyTypes.public")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-brand-contact">
+              {t("billing.compliance.fields.brandContactEmail")}
+            </Label>
+            <Input
+              id="sms-compliance-brand-contact"
+              value={form.brandContactEmail}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, brandContactEmail: event.target.value }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-rep-first-name">
+              {t("billing.compliance.fields.representativeFirstName")}
+            </Label>
+            <Input
+              id="sms-compliance-rep-first-name"
+              value={form.representativeFirstName}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  representativeFirstName: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-rep-last-name">
+              {t("billing.compliance.fields.representativeLastName")}
+            </Label>
+            <Input
+              id="sms-compliance-rep-last-name"
+              value={form.representativeLastName}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  representativeLastName: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-rep-title">
+              {t("billing.compliance.fields.representativeBusinessTitle")}
+            </Label>
+            <Input
+              id="sms-compliance-rep-title"
+              value={form.representativeBusinessTitle}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  representativeBusinessTitle: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>{t("billing.compliance.fields.representativeJobPosition")}</Label>
+            <Select
+              value={form.representativeJobPosition}
+              onValueChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  representativeJobPosition: value ?? current.representativeJobPosition,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {["Director", "GM", "VP", "CEO", "CFO", "General Counsel", "Other"].map(
+                  (value) => (
+                    <SelectItem key={value} value={value}>
+                      {value}
+                    </SelectItem>
+                  ),
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-rep-phone">
+              {t("billing.compliance.fields.representativePhoneNumber")}
+            </Label>
+            <Input
+              id="sms-compliance-rep-phone"
+              value={form.representativePhoneNumber}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  representativePhoneNumber: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-rep-email">
+              {t("billing.compliance.fields.representativeEmail")}
+            </Label>
+            <Input
+              id="sms-compliance-rep-email"
+              value={form.representativeEmail}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  representativeEmail: event.target.value,
+                }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-name">
+              {t("billing.compliance.fields.addressCustomerName")}
+            </Label>
+            <Input
+              id="sms-compliance-address-name"
+              value={form.addressCustomerName}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  addressCustomerName: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-street">
+              {t("billing.compliance.fields.addressStreet")}
+            </Label>
+            <Input
+              id="sms-compliance-address-street"
+              value={form.addressStreet}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, addressStreet: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-street-2">
+              {t("billing.compliance.fields.addressStreetSecondary")}
+            </Label>
+            <Input
+              id="sms-compliance-address-street-2"
+              value={form.addressStreetSecondary}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  addressStreetSecondary: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-city">
+              {t("billing.compliance.fields.addressCity")}
+            </Label>
+            <Input
+              id="sms-compliance-address-city"
+              value={form.addressCity}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, addressCity: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-region">
+              {t("billing.compliance.fields.addressRegion")}
+            </Label>
+            <Input
+              id="sms-compliance-address-region"
+              value={form.addressRegion}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, addressRegion: event.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-postal-code">
+              {t("billing.compliance.fields.addressPostalCode")}
+            </Label>
+            <Input
+              id="sms-compliance-address-postal-code"
+              value={form.addressPostalCode}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  addressPostalCode: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-address-country">
+              {t("billing.compliance.fields.addressIsoCountry")}
+            </Label>
+            <Input
+              id="sms-compliance-address-country"
+              value={form.addressIsoCountry}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  addressIsoCountry: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>{t("billing.compliance.fields.trafficTier")}</Label>
+            <Select
+              value={form.trafficTier}
+              onValueChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  trafficTier: value ?? current.trafficTier,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {availableCampaignOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.value === "low_volume"
+                      ? t("billing.compliance.trafficTier.lowVolume")
+                      : t("billing.compliance.trafficTier.mixed")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-campaign-description">
+              {t("billing.compliance.fields.campaignDescription")}
+            </Label>
+            <Textarea
+              id="sms-compliance-campaign-description"
+              value={form.campaignDescription}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  campaignDescription: event.target.value,
+                }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="sms-compliance-message-flow">
+              {t("billing.compliance.fields.messageFlow")}
+            </Label>
+            <Textarea
+              id="sms-compliance-message-flow"
+              value={form.messageFlow}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, messageFlow: event.target.value }))
+              }
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="sms-compliance-sample-message-one">
+                {t("billing.compliance.fields.sampleMessageOne")}
+              </Label>
+              <Textarea
+                id="sms-compliance-sample-message-one"
+                value={form.sampleMessageOne}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    sampleMessageOne: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="sms-compliance-sample-message-two">
+                {t("billing.compliance.fields.sampleMessageTwo")}
+              </Label>
+              <Textarea
+                id="sms-compliance-sample-message-two"
+                value={form.sampleMessageTwo}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    sampleMessageTwo: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="sms-compliance-opt-in-message">
+                {t("billing.compliance.fields.optInMessage")}
+              </Label>
+              <Textarea
+                id="sms-compliance-opt-in-message"
+                value={form.optInMessage}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, optInMessage: event.target.value }))
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="sms-compliance-opt-out-message">
+                {t("billing.compliance.fields.optOutMessage")}
+              </Label>
+              <Textarea
+                id="sms-compliance-opt-out-message"
+                value={form.optOutMessage}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, optOutMessage: event.target.value }))
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="sms-compliance-help-message">
+                {t("billing.compliance.fields.helpMessage")}
+              </Label>
+              <Textarea
+                id="sms-compliance-help-message"
+                value={form.helpMessage}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, helpMessage: event.target.value }))
+                }
+              />
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-6">
+            <Label className="flex items-center gap-3 text-sm font-medium">
+              <Checkbox
+                checked={form.hasEmbeddedLinks}
+                onCheckedChange={(checked) =>
+                  setForm((current) => ({
+                    ...current,
+                    hasEmbeddedLinks: Boolean(checked),
+                  }))
+                }
+              />
+              {t("billing.compliance.fields.hasEmbeddedLinks")}
+            </Label>
+            <Label className="flex items-center gap-3 text-sm font-medium">
+              <Checkbox
+                checked={form.hasEmbeddedPhone}
+                onCheckedChange={(checked) =>
+                  setForm((current) => ({
+                    ...current,
+                    hasEmbeddedPhone: Boolean(checked),
+                  }))
+                }
+              />
+              {t("billing.compliance.fields.hasEmbeddedPhone")}
+            </Label>
           </div>
         </div>
       </BorderedItem>
@@ -1077,6 +2094,31 @@ function AddonsSectionSkeleton({
   );
 }
 
+function AiSmsComplianceSectionSkeleton({
+  t,
+}: {
+  t: BillingTranslation;
+}) {
+  return (
+    <BillingSection
+      title={t("billing.compliance.title")}
+      description={t("billing.compliance.description")}
+    >
+      <BorderedItem className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-80" />
+          </div>
+          <Skeleton className="h-8 w-32 rounded-xl" />
+        </div>
+        <Skeleton className="h-28 w-full rounded-xl" />
+        <Skeleton className="h-48 w-full rounded-xl" />
+      </BorderedItem>
+    </BillingSection>
+  );
+}
+
 function SpendingCapSectionSkeleton({
   t,
 }: {
@@ -1164,6 +2206,7 @@ function BillingOverviewSkeleton({
     <div className="flex w-full flex-col gap-10">
       <PlanSectionSkeleton t={t} />
       <AddonsSectionSkeleton t={t} />
+      <AiSmsComplianceSectionSkeleton t={t} />
       <SpendingCapSectionSkeleton t={t} />
       <TransactionsSectionSkeleton t={t} />
     </div>
@@ -1190,6 +2233,7 @@ export function SettingsBillingPage(props: SettingsBillingPageProps) {
   const { i18n, t } = useTranslation("settings");
   const locale = resolveLocale(i18n.resolvedLanguage, i18n.language);
   const { data: status, isInitialLoading: isLoadingStatus } = useBillingStatus(props.businessId);
+  const { data: compliance } = useSmsComplianceStatus(props.businessId);
 
   if (isLoadingStatus || !status) {
     return <BillingOverviewSkeleton t={t} />;
@@ -1218,10 +2262,18 @@ export function SettingsBillingPage(props: SettingsBillingPageProps) {
       />
       <AddonsSection
         status={status}
+        {...(compliance ? { compliance } : {})}
         businessId={props.businessId}
         locale={locale}
         t={t}
       />
+      {status.aiSmsEnabled && compliance && (
+        <AiSmsComplianceSection
+          businessId={props.businessId}
+          compliance={compliance}
+          t={t}
+        />
+      )}
       <SpendingCapSection status={status} t={t} />
       <TransactionsSection status={status} locale={locale} t={t} />
     </div>

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -122,6 +122,10 @@ type SmsComplianceState = {
   senderMode: "platform_phone" | "business_phone" | "business_messaging_service";
   status: SmsComplianceStatus;
   trafficTier: "low_volume" | "mixed";
+  availablePhoneNumbers: Array<{
+    id: Id<"phone_numbers">;
+    e164: string;
+  }>;
   draft?: SmsComplianceDraft;
   pendingAction?: {
     type:
@@ -135,6 +139,7 @@ type SmsComplianceState = {
   };
   failureCode?: string;
   failureMessage?: string;
+  approvedPhoneNumberId?: Id<"phone_numbers">;
   approvedPhoneNumberE164?: string;
   twilioMessagingServiceSid?: string;
 };
@@ -147,6 +152,7 @@ type SmsComplianceCampaignOption = {
 
 type SmsComplianceFormState = {
   trafficTier: "low_volume" | "mixed";
+  approvedPhoneNumberId: string;
   businessName: string;
   businessType: string;
   businessIndustry: string;
@@ -181,6 +187,7 @@ type SmsComplianceFormState = {
 
 const DEFAULT_SMS_COMPLIANCE_FORM_STATE: SmsComplianceFormState = {
   trafficTier: "low_volume",
+  approvedPhoneNumberId: "",
   businessName: "",
   businessType: "Corporation",
   businessIndustry: "TECHNOLOGY",
@@ -212,6 +219,73 @@ const DEFAULT_SMS_COMPLIANCE_FORM_STATE: SmsComplianceFormState = {
   hasEmbeddedLinks: false,
   hasEmbeddedPhone: false,
 };
+
+const SMS_COMPLIANCE_BUSINESS_TYPE_OPTIONS = [
+  "Co-operative",
+  "Corporation",
+  "Limited Liability Corporation",
+  "Non-profit Corporation",
+  "Partnership",
+] as const;
+
+const SMS_COMPLIANCE_BUSINESS_INDUSTRY_OPTIONS = [
+  "AGRICULTURE",
+  "AUTOMOTIVE",
+  "BANKING",
+  "CONSTRUCTION",
+  "CONSUMER",
+  "EDUCATION",
+  "ELECTRONICS",
+  "ENGINEERING",
+  "ENERGY",
+  "FAST_MOVING_CONSUMER_GOODS",
+  "FINANCIAL",
+  "FINTECH",
+  "FOOD_AND_BEVERAGE",
+  "GOVERNMENT",
+  "HEALTHCARE",
+  "HOSPITALITY",
+  "INSURANCE",
+  "JEWELRY",
+  "LEGAL",
+  "MANUFACTURING",
+  "MEDIA",
+  "NOT_FOR_PROFIT",
+  "OIL_AND_GAS",
+  "ONLINE",
+  "PROFESSIONAL_SERVICES",
+  "RAW_MATERIALS",
+  "REAL_ESTATE",
+  "RELIGION",
+  "RETAIL",
+  "TECHNOLOGY",
+  "TELECOMMUNICATIONS",
+  "TRANSPORTATION",
+  "TRAVEL",
+] as const;
+
+const SMS_COMPLIANCE_REGISTRATION_IDENTIFIER_OPTIONS = [
+  "EIN",
+  "DUNS",
+  "CBN",
+  "CN",
+  "ACN",
+  "CIN",
+  "VAT",
+  "VATRN",
+  "RN",
+  "Other",
+] as const;
+
+const SMS_COMPLIANCE_JOB_POSITION_OPTIONS = [
+  "Director",
+  "GM",
+  "VP",
+  "CEO",
+  "CFO",
+  "General Counsel",
+  "Other",
+] as const;
 
 // ---------------------------------------------------------------------------
 // Formatters
@@ -327,14 +401,32 @@ function useBillingStatus(businessId: Id<"businesses">) {
   });
 }
 
-function useSmsComplianceStatus(businessId: Id<"businesses">) {
-  return useRememberedConvexQuery(api.smsCompliance.getStatus, {
-    businessId,
-  });
+function useSmsComplianceStatus(
+  businessId: Id<"businesses">,
+  enabled: boolean,
+) {
+  return useRememberedConvexQuery(
+    api.smsCompliance.getStatus,
+    enabled ? { businessId } : "skip",
+  );
 }
 
 function useSmsComplianceCampaignOptions() {
   return useRememberedConvexQuery(api.smsCompliance.getCampaignOptions, {});
+}
+
+function formatSmsComplianceOptionLabel(value: string): string {
+  if (/^[A-Z0-9]+$/.test(value)) {
+    return value;
+  }
+
+  return value
+    .toLowerCase()
+    .split(/[_ ]+/)
+    .map((part) =>
+      part.length > 0 ? `${part[0]!.toUpperCase()}${part.slice(1)}` : part,
+    )
+    .join(" ");
 }
 
 function buildSmsComplianceFormState(
@@ -342,10 +434,23 @@ function buildSmsComplianceFormState(
 ): SmsComplianceFormState {
   const draft = compliance?.draft;
   const sampleMessages = draft?.sampleMessages ?? [];
+  const approvedPhoneNumberId =
+    compliance?.approvedPhoneNumberId &&
+    compliance.availablePhoneNumbers.some(
+      (phoneNumber) => phoneNumber.id === compliance.approvedPhoneNumberId,
+    )
+      ? compliance.approvedPhoneNumberId
+      : undefined;
+  const defaultApprovedPhoneNumberId =
+    approvedPhoneNumberId ??
+    (compliance?.availablePhoneNumbers.length === 1
+      ? compliance.availablePhoneNumbers[0]?.id
+      : undefined);
 
   return {
     ...DEFAULT_SMS_COMPLIANCE_FORM_STATE,
     trafficTier: compliance?.trafficTier ?? "low_volume",
+    approvedPhoneNumberId: defaultApprovedPhoneNumberId ?? "",
     businessName: draft?.businessName ?? "",
     businessType: draft?.businessType ?? DEFAULT_SMS_COMPLIANCE_FORM_STATE.businessType,
     businessIndustry:
@@ -988,26 +1093,20 @@ function UsageMeterRow({
 
 function AddonsSection({
   status,
-  compliance,
   businessId,
   locale,
   t,
 }: {
   status: BillingStatus;
-  compliance?: SmsComplianceState;
   businessId: Id<"businesses">;
   locale: BillingLocale;
   t: BillingTranslation;
 }) {
   const startCheckout = useAction(api.billing.startCheckout);
   const [loading, setLoading] = useState<"ai_sms" | "pro" | null>(null);
-  const isOperational =
-    status.aiSmsEnabled &&
-    (status.plan === "self_host" || compliance?.status === "approved");
+  const isOperational = status.aiSmsReady;
   const setupRequired =
-    status.aiSmsEnabled &&
-    status.plan !== "self_host" &&
-    compliance?.status !== "approved";
+    status.aiSmsEnabled && !status.aiSmsReady && status.plan !== "self_host";
   const canPurchase = status.canPurchaseAiSmsAddon;
   const canUpgradeToPro =
     status.hasCheckoutAccess &&
@@ -1229,6 +1328,18 @@ function getCompliancePrimaryActionLabel(
   }
 }
 
+function canEditApprovedPhoneNumber(status: SmsComplianceStatus): boolean {
+  return canEditComplianceDraft(status);
+}
+
+function canEditComplianceDraft(status: SmsComplianceStatus): boolean {
+  return status === "not_started" || status === "collecting_info" || status === "failed";
+}
+
+function isSuccessfulComplianceActionStatus(status: SmsComplianceStatus): boolean {
+  return status !== "failed" && status !== "suspended";
+}
+
 function getComplianceSenderModeCopy(
   senderMode: SmsComplianceState["senderMode"],
   t: BillingTranslation,
@@ -1262,6 +1373,7 @@ function AiSmsComplianceSection({
     buildSmsComplianceFormState(compliance),
   );
   const [loading, setLoading] = useState<null | "save" | "action">(null);
+  const isDraftEditable = canEditComplianceDraft(compliance.status);
 
   useEffect(() => {
     setForm(buildSmsComplianceFormState(compliance));
@@ -1287,10 +1399,17 @@ function AiSmsComplianceSection({
       businessId,
       trafficTier: form.trafficTier,
       draft: buildSmsComplianceDraft(form),
+      ...(form.approvedPhoneNumberId
+        ? { approvedPhoneNumberId: form.approvedPhoneNumberId as Id<"phone_numbers"> }
+        : {}),
     });
   }
 
   async function handleSave() {
+    if (!isDraftEditable) {
+      return;
+    }
+
     setLoading("save");
     try {
       await persistDraft();
@@ -1305,21 +1424,34 @@ function AiSmsComplianceSection({
   async function handlePrimaryAction() {
     setLoading("action");
     try {
-      await persistDraft();
+      if (isDraftEditable) {
+        await persistDraft();
+      }
+
+      let result:
+        | {
+            registrationId: Id<"sms_compliance_registrations">;
+            status: SmsComplianceStatus;
+          }
+        | undefined;
 
       if (compliance.status === "pending_brand_verification") {
-        await resumeRegistration({ businessId });
+        result = await resumeRegistration({ businessId });
       } else if (
         compliance.status === "pending_review" ||
         compliance.status === "approved" ||
         compliance.status === "suspended"
       ) {
-        await refreshRegistration({ businessId });
+        result = await refreshRegistration({ businessId });
       } else {
-        await startRegistration({ businessId });
+        result = await startRegistration({ businessId });
       }
 
-      toast.success(t("billing.compliance.toast.submitted"));
+      if (result && isSuccessfulComplianceActionStatus(result.status)) {
+        toast.success(t("billing.compliance.toast.submitted"));
+      } else {
+        toast.error(t("billing.compliance.toast.submitFailed"));
+      }
     } catch (error) {
       toast.error(getErrorMessage(error, t("billing.compliance.toast.submitFailed")));
     } finally {
@@ -1363,7 +1495,7 @@ function AiSmsComplianceSection({
             <Button
               variant="outline"
               onClick={() => void handleSave()}
-              disabled={loading !== null}
+              disabled={loading !== null || !isDraftEditable}
             >
               {loading === "save" ? t("billing.compliance.actions.saving") : t("billing.compliance.actions.save")}
             </Button>
@@ -1398,7 +1530,41 @@ function AiSmsComplianceSection({
           </div>
         )}
 
+        <fieldset
+          className="contents"
+          disabled={loading !== null || !isDraftEditable}
+        >
         <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <Label>{t("billing.compliance.fields.approvedPhoneNumber")}</Label>
+            <Select
+              value={form.approvedPhoneNumberId}
+              onValueChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  approvedPhoneNumberId: value ?? current.approvedPhoneNumberId,
+                }))
+              }
+              disabled={
+                loading !== null ||
+                !canEditApprovedPhoneNumber(compliance.status) ||
+                compliance.availablePhoneNumbers.length === 0
+              }
+            >
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={t("billing.compliance.fields.approvedPhoneNumber")}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {compliance.availablePhoneNumbers.map((phoneNumber) => (
+                  <SelectItem key={phoneNumber.id} value={phoneNumber.id}>
+                    {phoneNumber.e164}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <div className="flex flex-col gap-2">
             <Label htmlFor="sms-compliance-business-name">
               {t("billing.compliance.fields.businessName")}
@@ -1424,43 +1590,74 @@ function AiSmsComplianceSection({
             />
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="sms-compliance-business-type">
-              {t("billing.compliance.fields.businessType")}
-            </Label>
-            <Input
-              id="sms-compliance-business-type"
+            <Label>{t("billing.compliance.fields.businessType")}</Label>
+            <Select
               value={form.businessType}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, businessType: event.target.value }))
-              }
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="sms-compliance-business-industry">
-              {t("billing.compliance.fields.businessIndustry")}
-            </Label>
-            <Input
-              id="sms-compliance-business-industry"
-              value={form.businessIndustry}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, businessIndustry: event.target.value }))
-              }
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="sms-compliance-tax-id-type">
-              {t("billing.compliance.fields.businessRegistrationIdentifier")}
-            </Label>
-            <Input
-              id="sms-compliance-tax-id-type"
-              value={form.businessRegistrationIdentifier}
-              onChange={(event) =>
+              onValueChange={(value) =>
                 setForm((current) => ({
                   ...current,
-                  businessRegistrationIdentifier: event.target.value,
+                  businessType: value ?? current.businessType,
                 }))
               }
-            />
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SMS_COMPLIANCE_BUSINESS_TYPE_OPTIONS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {formatSmsComplianceOptionLabel(value)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>{t("billing.compliance.fields.businessIndustry")}</Label>
+            <Select
+              value={form.businessIndustry}
+              onValueChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  businessIndustry: value ?? current.businessIndustry,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SMS_COMPLIANCE_BUSINESS_INDUSTRY_OPTIONS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {formatSmsComplianceOptionLabel(value)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>{t("billing.compliance.fields.businessRegistrationIdentifier")}</Label>
+            <Select
+              value={form.businessRegistrationIdentifier}
+              onValueChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  businessRegistrationIdentifier:
+                    value ?? current.businessRegistrationIdentifier,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SMS_COMPLIANCE_REGISTRATION_IDENTIFIER_OPTIONS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {formatSmsComplianceOptionLabel(value)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div className="flex flex-col gap-2">
             <Label htmlFor="sms-compliance-tax-id-number">
@@ -1572,13 +1769,11 @@ function AiSmsComplianceSection({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {["Director", "GM", "VP", "CEO", "CFO", "General Counsel", "Other"].map(
-                  (value) => (
-                    <SelectItem key={value} value={value}>
-                      {value}
-                    </SelectItem>
-                  ),
-                )}
+                {SMS_COMPLIANCE_JOB_POSITION_OPTIONS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {formatSmsComplianceOptionLabel(value)}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
@@ -1863,6 +2058,7 @@ function AiSmsComplianceSection({
             </Label>
           </div>
         </div>
+        </fieldset>
       </BorderedItem>
     </BillingSection>
   );
@@ -2233,7 +2429,16 @@ export function SettingsBillingPage(props: SettingsBillingPageProps) {
   const { i18n, t } = useTranslation("settings");
   const locale = resolveLocale(i18n.resolvedLanguage, i18n.language);
   const { data: status, isInitialLoading: isLoadingStatus } = useBillingStatus(props.businessId);
-  const { data: compliance } = useSmsComplianceStatus(props.businessId);
+  const shouldFetchCompliance = Boolean(
+    status &&
+      status.hasBillingManagementAccess &&
+      status.plan !== "self_host" &&
+      status.aiSmsEnabled,
+  );
+  const { data: compliance } = useSmsComplianceStatus(
+    props.businessId,
+    shouldFetchCompliance,
+  );
 
   if (isLoadingStatus || !status) {
     return <BillingOverviewSkeleton t={t} />;
@@ -2262,12 +2467,11 @@ export function SettingsBillingPage(props: SettingsBillingPageProps) {
       />
       <AddonsSection
         status={status}
-        {...(compliance ? { compliance } : {})}
         businessId={props.businessId}
         locale={locale}
         t={t}
       />
-      {status.aiSmsEnabled && compliance && (
+      {status.hasBillingManagementAccess && status.aiSmsEnabled && compliance && (
         <AiSmsComplianceSection
           businessId={props.businessId}
           compliance={compliance}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -39,6 +39,7 @@ import type * as lib_accountCredentials from "../lib/accountCredentials.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_availability from "../lib/availability.js";
 import type * as lib_billing from "../lib/billing.js";
+import type * as lib_billingAccess from "../lib/billingAccess.js";
 import type * as lib_components from "../lib/components.js";
 import type * as lib_contactBlocking from "../lib/contactBlocking.js";
 import type * as lib_defaultStaff from "../lib/defaultStaff.js";
@@ -125,6 +126,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/availability": typeof lib_availability;
   "lib/billing": typeof lib_billing;
+  "lib/billingAccess": typeof lib_billingAccess;
   "lib/components": typeof lib_components;
   "lib/contactBlocking": typeof lib_contactBlocking;
   "lib/defaultStaff": typeof lib_defaultStaff;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -30,6 +30,7 @@ import type * as http from "../http.js";
 import type * as integrations_calendar from "../integrations/calendar.js";
 import type * as integrations_googleCalendar from "../integrations/googleCalendar.js";
 import type * as integrations_messageMedia from "../integrations/messageMedia.js";
+import type * as integrations_twilioA2p from "../integrations/twilioA2p.js";
 import type * as integrations_twilioMessageStatus from "../integrations/twilioMessageStatus.js";
 import type * as integrations_twilioSms from "../integrations/twilioSms.js";
 import type * as integrations_twilioSmsDebug from "../integrations/twilioSmsDebug.js";
@@ -64,6 +65,7 @@ import type * as lib_receptionistProfileDefaults from "../lib/receptionistProfil
 import type * as lib_runtimeLocale from "../lib/runtimeLocale.js";
 import type * as lib_serviceNameGeneration from "../lib/serviceNameGeneration.js";
 import type * as lib_serviceNames from "../lib/serviceNames.js";
+import type * as lib_smsCompliance from "../lib/smsCompliance.js";
 import type * as lib_smsPhoneNumbers from "../lib/smsPhoneNumbers.js";
 import type * as lib_snapshot from "../lib/snapshot.js";
 import type * as lib_twilioMessageStatus from "../lib/twilioMessageStatus.js";
@@ -76,6 +78,7 @@ import type * as onboarding_phoneNumbers from "../onboarding/phoneNumbers.js";
 import type * as onboarding_phoneVerification from "../onboarding/phoneVerification.js";
 import type * as onboarding_phoneVerificationState from "../onboarding/phoneVerificationState.js";
 import type * as services_localizedNames from "../services/localizedNames.js";
+import type * as smsCompliance from "../smsCompliance.js";
 import type * as telemetry_ai from "../telemetry/ai.js";
 import type * as telemetry_posthog from "../telemetry/posthog.js";
 import type * as telemetry_shared from "../telemetry/shared.js";
@@ -113,6 +116,7 @@ declare const fullApi: ApiFromModules<{
   "integrations/calendar": typeof integrations_calendar;
   "integrations/googleCalendar": typeof integrations_googleCalendar;
   "integrations/messageMedia": typeof integrations_messageMedia;
+  "integrations/twilioA2p": typeof integrations_twilioA2p;
   "integrations/twilioMessageStatus": typeof integrations_twilioMessageStatus;
   "integrations/twilioSms": typeof integrations_twilioSms;
   "integrations/twilioSmsDebug": typeof integrations_twilioSmsDebug;
@@ -147,6 +151,7 @@ declare const fullApi: ApiFromModules<{
   "lib/runtimeLocale": typeof lib_runtimeLocale;
   "lib/serviceNameGeneration": typeof lib_serviceNameGeneration;
   "lib/serviceNames": typeof lib_serviceNames;
+  "lib/smsCompliance": typeof lib_smsCompliance;
   "lib/smsPhoneNumbers": typeof lib_smsPhoneNumbers;
   "lib/snapshot": typeof lib_snapshot;
   "lib/twilioMessageStatus": typeof lib_twilioMessageStatus;
@@ -159,6 +164,7 @@ declare const fullApi: ApiFromModules<{
   "onboarding/phoneVerification": typeof onboarding_phoneVerification;
   "onboarding/phoneVerificationState": typeof onboarding_phoneVerificationState;
   "services/localizedNames": typeof services_localizedNames;
+  smsCompliance: typeof smsCompliance;
   "telemetry/ai": typeof telemetry_ai;
   "telemetry/posthog": typeof telemetry_posthog;
   "telemetry/shared": typeof telemetry_shared;

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -59,6 +59,14 @@ import {
   getProProductId,
   isAiSmsEnabled,
 } from "./lib/billing";
+import { selectSmsSenderPhoneNumber } from "./lib/smsPhoneNumbers";
+import {
+  isSmsComplianceApproved,
+  smsComplianceStatusValidator,
+  smsSenderModeValidator,
+  type SmsComplianceStatus,
+  type SmsSenderMode,
+} from "./lib/smsCompliance";
 import { enqueuePostHogEventBestEffort } from "./telemetry/posthog";
 
 type BillingContact = {
@@ -114,6 +122,10 @@ type PricingSummary = {
 type SmsCapabilityPolicy = {
   allowed: boolean;
   senderRole: SmsSenderRole;
+  senderMode: SmsSenderMode;
+  fromPhoneNumber?: string;
+  twilioMessagingServiceSid?: string;
+  complianceStatus?: SmsComplianceStatus;
   errorCode: BillingErrorCode | null;
 };
 
@@ -597,6 +609,19 @@ function reserveVoiceSecondsForStart(args: {
 function getPlatformAlertSmsSenderFromEnv(): string | null {
   const e164 = process.env.TWILIO_ALERT_SMS_FROM?.trim();
   return e164 && e164.length > 0 ? e164 : null;
+}
+
+function resolveApprovedBusinessSmsSender(input: {
+  phoneNumbers: Array<Pick<Doc<"phone_numbers">, "_id" | "e164" | "smsEnabled" | "status">>;
+  approvedPhoneNumberId?: Id<"phone_numbers">;
+}): string | null {
+  const preferredPhoneNumberE164 =
+    input.approvedPhoneNumberId !== undefined
+      ? input.phoneNumbers.find((phoneNumber) => phoneNumber._id === input.approvedPhoneNumberId)
+          ?.e164
+      : undefined;
+
+  return selectSmsSenderPhoneNumber(input.phoneNumbers, preferredPhoneNumberE164);
 }
 
 function getTargetProductIds(target: CheckoutTarget): Array<string> {
@@ -1990,6 +2015,10 @@ export const getSmsCapabilityPolicy = internalQuery({
   returns: v.object({
     allowed: v.boolean(),
     senderRole: v.union(v.literal("platform_alert"), v.literal("business_ai")),
+    senderMode: smsSenderModeValidator,
+    fromPhoneNumber: v.optional(v.string()),
+    twilioMessagingServiceSid: v.optional(v.string()),
+    complianceStatus: v.optional(smsComplianceStatusValidator),
     errorCode: v.union(
       v.literal("voice_limit_reached"),
       v.literal("alert_sms_limit_reached"),
@@ -1999,32 +2028,129 @@ export const getSmsCapabilityPolicy = internalQuery({
     ),
   }),
   handler: async (ctx, args): Promise<SmsCapabilityPolicy> => {
-    const snapshot = await getBillingSnapshot(ctx, {
-      businessId: args.businessId,
-    });
+    const [snapshot, registration, phoneNumbers, platformSender] = await Promise.all([
+      getBillingSnapshot(ctx, {
+        businessId: args.businessId,
+      }),
+      ctx.db
+        .query("sms_compliance_registrations")
+        .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
+        .unique(),
+      ctx.db
+        .query("phone_numbers")
+        .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
+        .collect(),
+      ctx.db
+        .query("platform_sms_senders")
+        .withIndex("by_role", (q) => q.eq("role", "platform_alert"))
+        .unique(),
+    ]);
     const usage = getBillingUsageSnapshotData({
       plan: snapshot.plan,
       periodKey: snapshot.periodKey,
       usage: snapshot.usage,
     });
+    const aiSmsCommerciallyEnabled = isAiSmsEnabled({
+      plan: snapshot.plan,
+      activeAddons: snapshot.activeAddons,
+    });
+    const businessSenderPhoneNumber = resolveApprovedBusinessSmsSender({
+      phoneNumbers,
+      ...(registration?.approvedPhoneNumberId
+        ? { approvedPhoneNumberId: registration.approvedPhoneNumberId }
+        : {}),
+    });
+    const hostedApprovedMessagingRoute =
+      snapshot.plan !== "self_host" &&
+      aiSmsCommerciallyEnabled &&
+      registration &&
+      isSmsComplianceApproved(registration.status) &&
+      Boolean(registration.twilioMessagingServiceSid) &&
+      Boolean(businessSenderPhoneNumber);
+    const activePlatformSender =
+      platformSender && platformSender.status === "active" && platformSender.smsEnabled
+        ? platformSender.e164
+        : getPlatformAlertSmsSenderFromEnv();
 
     if (args.capability === "alert") {
+      if (snapshot.plan === "self_host") {
+        return {
+          allowed: !usage.alertSmsBlocked,
+          senderRole: "business_ai",
+          senderMode: "business_phone",
+          ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+          ...(registration?.status ? { complianceStatus: registration.status } : {}),
+          errorCode: usage.alertSmsBlocked ? billingErrorCodes.alertSmsLimitReached : null,
+        };
+      }
+
+      if (hostedApprovedMessagingRoute) {
+        return {
+          allowed: !usage.alertSmsBlocked,
+          senderRole: "platform_alert",
+          senderMode: "business_messaging_service",
+          ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+          ...(registration?.twilioMessagingServiceSid
+            ? { twilioMessagingServiceSid: registration.twilioMessagingServiceSid }
+            : {}),
+          ...(registration?.status ? { complianceStatus: registration.status } : {}),
+          errorCode: usage.alertSmsBlocked ? billingErrorCodes.alertSmsLimitReached : null,
+        };
+      }
+
       return {
         allowed: !usage.alertSmsBlocked,
         senderRole: "platform_alert",
+        senderMode: "platform_phone",
+        ...(activePlatformSender ? { fromPhoneNumber: activePlatformSender } : {}),
+        ...(registration?.status ? { complianceStatus: registration.status } : {}),
         errorCode: usage.alertSmsBlocked ? billingErrorCodes.alertSmsLimitReached : null,
       };
     }
 
-    const aiSmsAllowed = isAiSmsEnabled({
-      plan: snapshot.plan,
-      activeAddons: snapshot.activeAddons,
-    });
+    if (!aiSmsCommerciallyEnabled) {
+      return {
+        allowed: false,
+        senderRole: "business_ai",
+        senderMode: snapshot.plan === "self_host" ? "business_phone" : "platform_phone",
+        ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+        ...(registration?.status ? { complianceStatus: registration.status } : {}),
+        errorCode: billingErrorCodes.aiSmsNotEnabled,
+      };
+    }
+
+    if (snapshot.plan === "self_host") {
+      return {
+        allowed: true,
+        senderRole: "business_ai",
+        senderMode: "business_phone",
+        ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+        ...(registration?.status ? { complianceStatus: registration.status } : {}),
+        errorCode: null,
+      };
+    }
+
+    if (hostedApprovedMessagingRoute) {
+      return {
+        allowed: true,
+        senderRole: "business_ai",
+        senderMode: "business_messaging_service",
+        ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+        ...(registration?.twilioMessagingServiceSid
+          ? { twilioMessagingServiceSid: registration.twilioMessagingServiceSid }
+          : {}),
+        ...(registration?.status ? { complianceStatus: registration.status } : {}),
+        errorCode: null,
+      };
+    }
 
     return {
-      allowed: aiSmsAllowed,
+      allowed: false,
       senderRole: "business_ai",
-      errorCode: aiSmsAllowed ? null : billingErrorCodes.aiSmsNotEnabled,
+      senderMode: "platform_phone",
+      ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+      ...(registration?.status ? { complianceStatus: registration.status } : {}),
+      errorCode: null,
     };
   },
 });

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -59,6 +59,10 @@ import {
   getProProductId,
   isAiSmsEnabled,
 } from "./lib/billing";
+import {
+  hasBillingManagementAccess,
+  requireBillingManagementAccess,
+} from "./lib/billingAccess";
 import { selectSmsSenderPhoneNumber } from "./lib/smsPhoneNumbers";
 import {
   isSmsComplianceApproved,
@@ -132,12 +136,6 @@ type SmsCapabilityPolicy = {
 type UsageSyncTelemetryEventName =
   | "ops.billing.usage_sync_failed"
   | "ops.billing.usage_sync_recovered";
-
-const BILLING_ADMIN_ROLES = new Set([
-  "business_owner",
-  "business_admin",
-  "owner",
-]);
 
 const USAGE_SYNC_RETRY_DELAYS_MS = [
   30_000,
@@ -322,6 +320,7 @@ function buildBillingStatus(input: {
   billingKey: string;
   plan: BillingPlanSlug;
   activeAddons: Array<BillingAddonSlug>;
+  aiSmsReady: boolean;
   subscriptionState: string;
   contact: BillingContact;
   usage: Doc<"billing_usage_months"> | null;
@@ -355,6 +354,7 @@ function buildBillingStatus(input: {
       plan: input.plan,
       activeAddons: input.activeAddons,
     }),
+    aiSmsReady: input.aiSmsReady,
     overagesBillable: billingPlanCatalog[input.plan].overagesBillable,
     monthlyChargeCents: getBillingMonthlyChargeCents({
       plan: input.plan,
@@ -363,6 +363,7 @@ function buildBillingStatus(input: {
     billingContactEmail: input.hasBillingManagementAccess ? input.contact.email : null,
     billingContactName: input.hasBillingManagementAccess ? input.contact.name : null,
     includedBusinessNumbers: billingPlanCatalog[input.plan].includedBusinessNumbers,
+    hasBillingManagementAccess: input.hasBillingManagementAccess,
     hasCustomerPortalAccess:
       input.hasBillingManagementAccess && input.hasCustomerPortalAccess,
     hasCheckoutAccess:
@@ -383,16 +384,6 @@ function buildBillingStatus(input: {
     },
     recentTransactions: input.hasBillingManagementAccess ? input.recentTransactions : [],
   };
-}
-
-function hasBillingManagementAccess(role: string): boolean {
-  return BILLING_ADMIN_ROLES.has(role);
-}
-
-function requireBillingManagementAccess(role: string): void {
-  if (!hasBillingManagementAccess(role)) {
-    throw new Error("Billing management requires admin access.");
-  }
 }
 
 function shouldSyncUsageEvent(args: {
@@ -615,13 +606,20 @@ function resolveApprovedBusinessSmsSender(input: {
   phoneNumbers: Array<Pick<Doc<"phone_numbers">, "_id" | "e164" | "smsEnabled" | "status">>;
   approvedPhoneNumberId?: Id<"phone_numbers">;
 }): string | null {
-  const preferredPhoneNumberE164 =
-    input.approvedPhoneNumberId !== undefined
-      ? input.phoneNumbers.find((phoneNumber) => phoneNumber._id === input.approvedPhoneNumberId)
-          ?.e164
-      : undefined;
+  if (input.approvedPhoneNumberId === undefined) {
+    return null;
+  }
 
-  return selectSmsSenderPhoneNumber(input.phoneNumbers, preferredPhoneNumberE164);
+  const approvedPhoneNumber = input.phoneNumbers.find(
+    (phoneNumber) => phoneNumber._id === input.approvedPhoneNumberId,
+  );
+  if (!approvedPhoneNumber) {
+    return null;
+  }
+
+  return approvedPhoneNumber.status === "active" && approvedPhoneNumber.smsEnabled
+    ? approvedPhoneNumber.e164
+    : null;
 }
 
 function getTargetProductIds(target: CheckoutTarget): Array<string> {
@@ -1289,6 +1287,10 @@ export const getStatus = query({
     const snapshot = await getBillingSnapshot(ctx, {
       businessId: args.businessId,
     });
+    const aiSmsEnabled = isAiSmsEnabled({
+      plan: snapshot.plan,
+      activeAddons: snapshot.activeAddons,
+    });
     const contact = hasManagementAccess
       ? await resolveBillingContact(ctx, {
           businessId: args.businessId,
@@ -1312,6 +1314,32 @@ export const getStatus = query({
         businessId: args.businessId,
       },
     );
+    const [registration, phoneNumbers] = aiSmsEnabled && snapshot.plan !== "self_host"
+      ? await Promise.all([
+          ctx.db
+            .query("sms_compliance_registrations")
+            .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
+            .unique(),
+          ctx.db
+            .query("phone_numbers")
+            .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
+            .collect(),
+        ])
+      : [null, []];
+    const aiSmsReady =
+      snapshot.plan === "self_host" ||
+      (aiSmsEnabled &&
+        registration !== null &&
+        isSmsComplianceApproved(registration.status) &&
+        Boolean(registration.twilioMessagingServiceSid) &&
+        Boolean(
+          resolveApprovedBusinessSmsSender({
+            phoneNumbers,
+            ...(registration.approvedPhoneNumberId
+              ? { approvedPhoneNumberId: registration.approvedPhoneNumberId }
+              : {}),
+          }),
+        ));
     const siteUrlConfigured = Boolean(process.env.SITE_URL?.trim());
     const availableCheckoutPlans = siteUrlConfigured ? getConfiguredCheckoutPlans() : [];
 
@@ -1319,6 +1347,7 @@ export const getStatus = query({
       billingKey: getBillingKey(args.businessId),
       plan: snapshot.plan,
       activeAddons: snapshot.activeAddons,
+      aiSmsReady,
       subscriptionState: snapshot.account?.subscriptionState ?? "inactive",
       contact,
       usage: snapshot.usage,
@@ -2054,7 +2083,8 @@ export const getSmsCapabilityPolicy = internalQuery({
       plan: snapshot.plan,
       activeAddons: snapshot.activeAddons,
     });
-    const businessSenderPhoneNumber = resolveApprovedBusinessSmsSender({
+    const activeBusinessSenderPhoneNumber = selectSmsSenderPhoneNumber(phoneNumbers);
+    const approvedBusinessSenderPhoneNumber = resolveApprovedBusinessSmsSender({
       phoneNumbers,
       ...(registration?.approvedPhoneNumberId
         ? { approvedPhoneNumberId: registration.approvedPhoneNumberId }
@@ -2066,7 +2096,7 @@ export const getSmsCapabilityPolicy = internalQuery({
       registration &&
       isSmsComplianceApproved(registration.status) &&
       Boolean(registration.twilioMessagingServiceSid) &&
-      Boolean(businessSenderPhoneNumber);
+      Boolean(approvedBusinessSenderPhoneNumber);
     const activePlatformSender =
       platformSender && platformSender.status === "active" && platformSender.smsEnabled
         ? platformSender.e164
@@ -2078,7 +2108,9 @@ export const getSmsCapabilityPolicy = internalQuery({
           allowed: !usage.alertSmsBlocked,
           senderRole: "business_ai",
           senderMode: "business_phone",
-          ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+          ...(activeBusinessSenderPhoneNumber
+            ? { fromPhoneNumber: activeBusinessSenderPhoneNumber }
+            : {}),
           ...(registration?.status ? { complianceStatus: registration.status } : {}),
           errorCode: usage.alertSmsBlocked ? billingErrorCodes.alertSmsLimitReached : null,
         };
@@ -2089,7 +2121,9 @@ export const getSmsCapabilityPolicy = internalQuery({
           allowed: !usage.alertSmsBlocked,
           senderRole: "platform_alert",
           senderMode: "business_messaging_service",
-          ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+          ...(approvedBusinessSenderPhoneNumber
+            ? { fromPhoneNumber: approvedBusinessSenderPhoneNumber }
+            : {}),
           ...(registration?.twilioMessagingServiceSid
             ? { twilioMessagingServiceSid: registration.twilioMessagingServiceSid }
             : {}),
@@ -2113,7 +2147,9 @@ export const getSmsCapabilityPolicy = internalQuery({
         allowed: false,
         senderRole: "business_ai",
         senderMode: snapshot.plan === "self_host" ? "business_phone" : "platform_phone",
-        ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+        ...(activeBusinessSenderPhoneNumber
+          ? { fromPhoneNumber: activeBusinessSenderPhoneNumber }
+          : {}),
         ...(registration?.status ? { complianceStatus: registration.status } : {}),
         errorCode: billingErrorCodes.aiSmsNotEnabled,
       };
@@ -2124,7 +2160,9 @@ export const getSmsCapabilityPolicy = internalQuery({
         allowed: true,
         senderRole: "business_ai",
         senderMode: "business_phone",
-        ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+        ...(activeBusinessSenderPhoneNumber
+          ? { fromPhoneNumber: activeBusinessSenderPhoneNumber }
+          : {}),
         ...(registration?.status ? { complianceStatus: registration.status } : {}),
         errorCode: null,
       };
@@ -2135,7 +2173,9 @@ export const getSmsCapabilityPolicy = internalQuery({
         allowed: true,
         senderRole: "business_ai",
         senderMode: "business_messaging_service",
-        ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+        ...(approvedBusinessSenderPhoneNumber
+          ? { fromPhoneNumber: approvedBusinessSenderPhoneNumber }
+          : {}),
         ...(registration?.twilioMessagingServiceSid
           ? { twilioMessagingServiceSid: registration.twilioMessagingServiceSid }
           : {}),
@@ -2148,7 +2188,9 @@ export const getSmsCapabilityPolicy = internalQuery({
       allowed: false,
       senderRole: "business_ai",
       senderMode: "platform_phone",
-      ...(businessSenderPhoneNumber ? { fromPhoneNumber: businessSenderPhoneNumber } : {}),
+      ...(approvedBusinessSenderPhoneNumber
+        ? { fromPhoneNumber: approvedBusinessSenderPhoneNumber }
+        : {}),
       ...(registration?.status ? { complianceStatus: registration.status } : {}),
       errorCode: null,
     };

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -514,9 +514,13 @@ export const getOutboundMessageDeliveryContext = internalQuery({
       );
     }
 
+    const preferredSenderPhoneNumber =
+      smsPolicy.senderMode === "business_messaging_service"
+        ? smsPolicy.fromPhoneNumber ?? undefined
+        : message.fromPhoneNumber ?? smsPolicy.fromPhoneNumber ?? undefined;
     const senderPhoneNumber = selectSmsSenderPhoneNumber(
       phoneNumbers,
-      message.fromPhoneNumber ?? smsPolicy.fromPhoneNumber ?? undefined,
+      preferredSenderPhoneNumber,
     );
     if (!senderPhoneNumber) {
       throw new Error(
@@ -1221,13 +1225,17 @@ export const handleTwilioSmsInbound = internalAction({
       body: args.body,
       ...(normalizedMedia ? { media: normalizedMedia } : {}),
     });
+    const replyFromPhoneNumber =
+      smsPolicy.senderMode === "business_messaging_service"
+        ? smsPolicy.fromPhoneNumber ?? phoneNumber.e164
+        : phoneNumber.e164;
     const messageId: Id<"messages"> = await ctx.runMutation(
       internal.conversations.webhooks.reserveOutboundAiMessage,
       {
         businessId: phoneNumber.businessId,
         conversationId,
         channel: "sms",
-        fromPhoneNumber: phoneNumber.e164,
+        fromPhoneNumber: replyFromPhoneNumber,
         senderRole: "business_ai",
       },
     );

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -109,7 +109,8 @@ type OutboundMessageDeliveryContext = {
   conversationId: Id<"conversations">;
   messageId: Id<"messages">;
   body: string;
-  from: string;
+  from?: string;
+  twilioMessagingServiceSid?: string;
   to: string;
   providerMessageSid?: string;
   status: string;
@@ -506,12 +507,16 @@ export const getOutboundMessageDeliveryContext = internalQuery({
     }
 
     if (!smsPolicy.allowed) {
-      throw new Error("AI SMS is not enabled for this workspace.");
+      throw new Error(
+        smsPolicy.complianceStatus && smsPolicy.complianceStatus !== "approved"
+          ? "AI SMS is pending 10DLC approval for this workspace."
+          : "AI SMS is not enabled for this workspace.",
+      );
     }
 
     const senderPhoneNumber = selectSmsSenderPhoneNumber(
       phoneNumbers,
-      message.fromPhoneNumber,
+      message.fromPhoneNumber ?? smsPolicy.fromPhoneNumber ?? undefined,
     );
     if (!senderPhoneNumber) {
       throw new Error(
@@ -524,7 +529,10 @@ export const getOutboundMessageDeliveryContext = internalQuery({
       conversationId: message.conversationId,
       messageId: message._id,
       body: message.body,
-      from: senderPhoneNumber,
+      ...(senderPhoneNumber ? { from: senderPhoneNumber } : {}),
+      ...(smsPolicy.twilioMessagingServiceSid
+        ? { twilioMessagingServiceSid: smsPolicy.twilioMessagingServiceSid }
+        : {}),
       to: contact.phone,
       ...(message.providerMessageSid !== undefined
         ? { providerMessageSid: message.providerMessageSid }
@@ -1026,9 +1034,12 @@ export const sendStoredOutboundMessage = internalAction({
 
       const result = await ctx.runAction(internal.integrations.twilioSms.sendMessage, {
         to: context.to,
-        from: context.from,
         body: outboundBodyParts.join("\n\n"),
         statusCallbackUrl: buildTwilioSmsStatusCallbackUrl(),
+        ...(context.from ? { from: context.from } : {}),
+        ...(context.twilioMessagingServiceSid
+          ? { messagingServiceSid: context.twilioMessagingServiceSid }
+          : {}),
         ...(directMediaUrls.length > 0 ? { mediaUrls: directMediaUrls } : {}),
       });
 

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -515,13 +515,15 @@ export const getSmsReplyContext = internalQuery({
       );
     }
 
-    const preferredSenderPhoneNumber = await getPreferredConversationSmsSenderPhoneNumber(
-      ctx,
-      conversation._id,
-    );
+    const preferredSenderPhoneNumber =
+      smsPolicy.senderMode === "business_messaging_service"
+        ? smsPolicy.fromPhoneNumber ?? undefined
+        : (await getPreferredConversationSmsSenderPhoneNumber(ctx, conversation._id)) ??
+          smsPolicy.fromPhoneNumber ??
+          undefined;
     const fromPhoneNumber = selectSmsSenderPhoneNumber(
       phoneNumbers,
-      preferredSenderPhoneNumber ?? smsPolicy.fromPhoneNumber ?? undefined,
+      preferredSenderPhoneNumber,
     );
     if (!fromPhoneNumber) {
       throw new Error(

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -508,7 +508,11 @@ export const getSmsReplyContext = internalQuery({
       capability: "ai",
     });
     if (!smsPolicy.allowed) {
-      throw new Error("AI SMS add-on required before sending conversational SMS.");
+      throw new Error(
+        smsPolicy.complianceStatus && smsPolicy.complianceStatus !== "approved"
+          ? "Finish 10DLC setup and wait for approval before sending AI SMS."
+          : "AI SMS add-on required before sending conversational SMS.",
+      );
     }
 
     const preferredSenderPhoneNumber = await getPreferredConversationSmsSenderPhoneNumber(
@@ -517,7 +521,7 @@ export const getSmsReplyContext = internalQuery({
     );
     const fromPhoneNumber = selectSmsSenderPhoneNumber(
       phoneNumbers,
-      preferredSenderPhoneNumber ?? undefined,
+      preferredSenderPhoneNumber ?? smsPolicy.fromPhoneNumber ?? undefined,
     );
     if (!fromPhoneNumber) {
       throw new Error(

--- a/convex/integrations/twilioA2p.ts
+++ b/convex/integrations/twilioA2p.ts
@@ -1,0 +1,1011 @@
+"use node";
+
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import type { Doc } from "../_generated/dataModel";
+import { internalAction } from "../_generated/server";
+import { buildTwilioSmsInboundWebhookUrl } from "../lib/twilioUrls";
+import {
+  assertSmsComplianceDraftReady,
+  smsComplianceDraftValidator,
+  smsCompliancePendingActionValidator,
+  smsComplianceStatusValidator,
+  smsComplianceTrafficTierValidator,
+  type CompletedSmsComplianceDraft,
+  type SmsCompliancePendingAction,
+  type SmsComplianceStatus,
+} from "../lib/smsCompliance";
+import { getTwilioClient } from "../lib/node/twilioClient";
+
+const DEFAULT_TWILIO_A2P_TRUST_PRODUCT_POLICY_SID =
+  "RNc97f3d2a7ccf01b0e53a29ee4c54d31a";
+
+type TwilioClientLike = ReturnType<typeof getTwilioClient> & Record<string, unknown>;
+
+type TwilioRegistrationContext = {
+  business: Doc<"businesses">;
+  registration: Doc<"sms_compliance_registrations">;
+  phoneNumber: Doc<"phone_numbers">;
+  trafficTier: Doc<"sms_compliance_registrations">["trafficTier"];
+  twilioUsecaseCode: string;
+};
+
+type TwilioEvaluationSummary = {
+  status: string | null;
+  errors: string[];
+};
+
+type TwilioBrandSummary = {
+  sid?: string;
+  status?: string;
+  failureMessage?: string;
+  errors: string[];
+};
+
+type TwilioCampaignSummary = {
+  sid?: string;
+  campaignStatus?: string;
+  errors: string[];
+};
+
+function requirePrimaryCustomerProfileSid(): string {
+  const primaryCustomerProfileSid = process.env.TWILIO_PRIMARY_CUSTOMER_PROFILE_SID;
+  if (!primaryCustomerProfileSid) {
+    throw new Error(
+      "TWILIO_PRIMARY_CUSTOMER_PROFILE_SID is required for hosted 10DLC registration.",
+    );
+  }
+
+  return primaryCustomerProfileSid;
+}
+
+function getTwilioA2pTrustProductPolicySid(): string {
+  return (
+    process.env.TWILIO_A2P_TRUST_PRODUCT_POLICY_SID ??
+    DEFAULT_TWILIO_A2P_TRUST_PRODUCT_POLICY_SID
+  );
+}
+
+function requireTwilioA2pStatusEmail(): string {
+  const email = process.env.TWILIO_A2P_STATUS_EMAIL?.trim();
+  if (!email) {
+    throw new Error(
+      "TWILIO_A2P_STATUS_EMAIL is required for hosted 10DLC registration callbacks.",
+    );
+  }
+
+  return email;
+}
+
+function getTwilioA2pRequestDelayMs(): number {
+  const raw = process.env.TWILIO_A2P_REQUEST_DELAY_MS;
+  if (!raw) {
+    return 1_000;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1_000;
+}
+
+function getString(resource: unknown, ...keys: string[]): string | undefined {
+  if (!resource || typeof resource !== "object") {
+    return undefined;
+  }
+
+  const candidate = resource as Record<string, unknown>;
+  for (const key of keys) {
+    const value = candidate[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getStringArray(resource: unknown, key: string): string[] {
+  if (!resource || typeof resource !== "object") {
+    return [];
+  }
+
+  const value = (resource as Record<string, unknown>)[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return entry.trim();
+      }
+      if (entry && typeof entry === "object") {
+        return (
+          getString(entry, "message", "description", "error_code", "code") ?? JSON.stringify(entry)
+        );
+      }
+      return String(entry);
+    })
+    .filter((entry) => entry.length > 0);
+}
+
+function normalizeTwilioErrors(resource: unknown): string[] {
+  const errors = getStringArray(resource, "errors");
+  if (errors.length > 0) {
+    return errors;
+  }
+
+  const failureReason = getString(resource, "failureReason", "failure_reason");
+  return failureReason ? [failureReason] : [];
+}
+
+function normalizeBrand(resource: unknown): TwilioBrandSummary {
+  const sid = getString(resource, "sid");
+  const status = getString(resource, "status");
+  const failureMessage = getString(resource, "failureReason", "failure_reason");
+
+  return {
+    ...(sid ? { sid } : {}),
+    ...(status ? { status } : {}),
+    ...(failureMessage ? { failureMessage } : {}),
+    errors: normalizeTwilioErrors(resource),
+  };
+}
+
+function normalizeCampaign(resource: unknown): TwilioCampaignSummary {
+  const sid = getString(resource, "sid");
+  const campaignStatus = getString(resource, "campaignStatus", "campaign_status");
+
+  return {
+    ...(sid ? { sid } : {}),
+    ...(campaignStatus ? { campaignStatus } : {}),
+    errors: normalizeTwilioErrors(resource),
+  };
+}
+
+function normalizeEvaluation(resource: unknown): TwilioEvaluationSummary {
+  return {
+    status: getString(resource, "status") ?? null,
+    errors: getStringArray(resource, "results"),
+  };
+}
+
+function buildBusinessInformationAttributes(
+  draft: CompletedSmsComplianceDraft,
+): Record<string, string | string[]> {
+  return {
+    business_name: draft.businessName,
+    business_type: draft.businessType,
+    business_industry: draft.businessIndustry,
+    business_registration_identifier: draft.businessRegistrationIdentifier,
+    business_registration_number: draft.businessRegistrationNumber,
+    website_url: draft.websiteUrl,
+    business_identity: "direct_customer",
+    business_regions_of_operation: draft.businessRegionsOfOperation,
+    ...(draft.socialProfileUrls.length > 0
+      ? { social_media_profile_urls: draft.socialProfileUrls }
+      : {}),
+  };
+}
+
+function buildAuthorizedRepresentativeAttributes(
+  draft: CompletedSmsComplianceDraft,
+): Record<string, string> {
+  return {
+    first_name: draft.authorizedRepresentative.firstName,
+    last_name: draft.authorizedRepresentative.lastName,
+    business_title: draft.authorizedRepresentative.businessTitle,
+    job_position: draft.authorizedRepresentative.jobPosition,
+    phone_number: draft.authorizedRepresentative.phoneNumber,
+    email: draft.authorizedRepresentative.email,
+  };
+}
+
+function buildMessagingProfileAttributes(
+  draft: CompletedSmsComplianceDraft,
+): Record<string, string> {
+  return {
+    company_type: draft.companyType,
+    ...(draft.stockExchange ? { stock_exchange: draft.stockExchange } : {}),
+    ...(draft.stockTicker ? { stock_ticker: draft.stockTicker } : {}),
+    ...(draft.brandContactEmail ? { brand_contact_email: draft.brandContactEmail } : {}),
+  };
+}
+
+function buildTwilioErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "Twilio A2P registration failed.";
+}
+
+function isDuplicateTwilioError(error: unknown): boolean {
+  const message = buildTwilioErrorMessage(error).toLowerCase();
+  return (
+    message.includes("already exists") ||
+    message.includes("already assigned") ||
+    message.includes("duplicate")
+  );
+}
+
+function buildPendingActionFromErrors(
+  errors: string[],
+  fallbackType: SmsCompliancePendingAction["type"],
+): SmsCompliancePendingAction | undefined {
+  if (errors.length === 0) {
+    return undefined;
+  }
+
+  const message = errors.join(" ");
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("otp") ||
+    normalized.includes("one time passcode") ||
+    normalized.includes("verification")
+  ) {
+    return {
+      type: "brand_contact_email_otp",
+      message,
+      code: "brand_contact_email_otp",
+    };
+  }
+
+  if (normalized.includes("address") || normalized.includes("business") || normalized.includes("missing")) {
+    return {
+      type: "missing_information",
+      message,
+      code: "twilio_missing_information",
+    };
+  }
+
+  return {
+    type: fallbackType,
+    message,
+  };
+}
+
+function deriveRegistrationState(input: {
+  customerProfileEvaluation?: TwilioEvaluationSummary;
+  trustProductEvaluation?: TwilioEvaluationSummary;
+  brand?: TwilioBrandSummary;
+  campaign?: TwilioCampaignSummary;
+  phoneAttached: boolean;
+}): {
+  status: SmsComplianceStatus;
+  pendingAction?: SmsCompliancePendingAction;
+  failureCode?: string;
+  failureMessage?: string;
+} {
+  if (input.customerProfileEvaluation?.status === "noncompliant") {
+    const pendingAction = buildPendingActionFromErrors(
+      input.customerProfileEvaluation.errors,
+      "missing_information",
+    );
+    return {
+      status: "failed",
+      ...(pendingAction ? { pendingAction } : {}),
+      failureCode: "customer_profile_noncompliant",
+      failureMessage:
+        pendingAction?.message ?? "Twilio reported missing or invalid customer profile data.",
+    };
+  }
+
+  if (input.trustProductEvaluation?.status === "noncompliant") {
+    const pendingAction = buildPendingActionFromErrors(
+      input.trustProductEvaluation.errors,
+      "missing_information",
+    );
+    return {
+      status: "failed",
+      ...(pendingAction ? { pendingAction } : {}),
+      failureCode: "trust_product_noncompliant",
+      failureMessage:
+        pendingAction?.message ?? "Twilio reported missing or invalid messaging profile data.",
+    };
+  }
+
+  if (input.brand?.status === "FAILED") {
+    const pendingAction = buildPendingActionFromErrors(input.brand.errors, "manual_review");
+    return {
+      status: "failed",
+      ...(pendingAction ? { pendingAction } : {}),
+      failureCode: "brand_failed",
+      failureMessage:
+        input.brand.failureMessage ??
+        pendingAction?.message ??
+        "Twilio rejected the brand registration.",
+    };
+  }
+
+  if (input.brand?.status === "SUSPENDED") {
+    return {
+      status: "suspended",
+      pendingAction: {
+        type: "manual_review",
+        message: "Twilio suspended this 10DLC brand. Contact support before retrying.",
+      },
+      failureCode: "brand_suspended",
+      failureMessage: "Twilio suspended this 10DLC brand.",
+    };
+  }
+
+  if (input.campaign?.campaignStatus === "FAILED") {
+    const pendingAction = buildPendingActionFromErrors(input.campaign.errors, "campaign_review");
+    return {
+      status: "failed",
+      ...(pendingAction ? { pendingAction } : {}),
+      failureCode: "campaign_failed",
+      failureMessage:
+        pendingAction?.message ?? "Twilio rejected the A2P campaign submission.",
+    };
+  }
+
+  const otpPending = [...(input.brand?.errors ?? []), ...(input.campaign?.errors ?? [])].some(
+    (error) => {
+      const normalized = error.toLowerCase();
+      return normalized.includes("otp") || normalized.includes("verification");
+    },
+  );
+  if (otpPending) {
+    return {
+      status: "pending_brand_verification",
+      pendingAction: {
+        type: "brand_contact_email_otp",
+        message:
+          "Brand contact verification is still pending. Complete the Twilio verification email, then resume registration.",
+      },
+    };
+  }
+
+  if (input.campaign?.campaignStatus === "VERIFIED") {
+    if (input.phoneAttached) {
+      return {
+        status: "approved",
+      };
+    }
+
+    return {
+      status: "pending_review",
+      pendingAction: {
+        type: "phone_number_association",
+        message:
+          "The campaign is approved, but the business phone number is still being attached to the Messaging Service.",
+      },
+    };
+  }
+
+  if (
+    input.brand?.status === "PENDING" ||
+    input.brand?.status === "IN_REVIEW" ||
+    input.campaign?.campaignStatus === "IN_PROGRESS" ||
+    input.campaign?.campaignStatus === "PENDING"
+  ) {
+    return {
+      status: "pending_review",
+      pendingAction: {
+        type: "campaign_review",
+        message:
+          "Twilio is still reviewing this 10DLC registration. Keep alerts on the shared sender until approval completes.",
+      },
+    };
+  }
+
+  return {
+    status: "pending_review",
+    pendingAction: {
+      type: "manual_review",
+      message:
+        "Twilio accepted the registration request, but the review has not finished yet.",
+    },
+  };
+}
+
+async function maybePauseForTwilioRateLimit(): Promise<void> {
+  const delayMs = getTwilioA2pRequestDelayMs();
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function fetchPrimaryCustomerProfilePolicySid(
+  client: TwilioClientLike,
+): Promise<string> {
+  const primaryCustomerProfileSid = requirePrimaryCustomerProfileSid();
+  const resource = await (client as any).trusthub.v1
+    .customerProfiles(primaryCustomerProfileSid)
+    .fetch();
+
+  const policySid = getString(resource, "policySid", "policy_sid");
+  if (!policySid) {
+    throw new Error("Twilio primary customer profile is missing a policy SID.");
+  }
+
+  return policySid;
+}
+
+async function createSecondaryCustomerProfile(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+): Promise<string> {
+  const policySid = await fetchPrimaryCustomerProfilePolicySid(client);
+  const resource = await (client as any).trusthub.v1.customerProfiles.create({
+    friendlyName: `${context.business.name} Secondary Customer Profile`,
+    email: requireTwilioA2pStatusEmail(),
+    policySid,
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a customer profile SID.");
+  }
+
+  return sid;
+}
+
+async function createBusinessInformationEndUser(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  draft: CompletedSmsComplianceDraft,
+): Promise<string> {
+  const resource = await (client as any).trusthub.v1.endUsers.create({
+    friendlyName: `${context.business.name} Business Information`,
+    type: "customer_profile_business_information",
+    attributes: buildBusinessInformationAttributes(draft),
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a business information end user SID.");
+  }
+  return sid;
+}
+
+async function createAuthorizedRepresentativeEndUser(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  draft: CompletedSmsComplianceDraft,
+): Promise<string> {
+  const resource = await (client as any).trusthub.v1.endUsers.create({
+    friendlyName: `${context.business.name} Authorized Representative`,
+    type: "authorized_representative_1",
+    attributes: buildAuthorizedRepresentativeAttributes(draft),
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return an authorized representative SID.");
+  }
+  return sid;
+}
+
+async function createBusinessAddress(
+  client: TwilioClientLike,
+  draft: CompletedSmsComplianceDraft,
+): Promise<string> {
+  const resource = await (client as any).trusthub.v1.addresses.create({
+    friendlyName: `${draft.businessName} Mailing Address`,
+    customerName: draft.address.customerName,
+    street: draft.address.street,
+    ...(draft.address.streetSecondary
+      ? { streetSecondary: draft.address.streetSecondary }
+      : {}),
+    city: draft.address.city,
+    region: draft.address.region,
+    postalCode: draft.address.postalCode,
+    isoCountry: draft.address.isoCountry,
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a mailing address SID.");
+  }
+  return sid;
+}
+
+async function createCustomerProfileAddressDocument(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  addressSid: string,
+): Promise<string> {
+  const resource = await (client as any).trusthub.v1.supportingDocuments.create({
+    friendlyName: `${context.business.name} Customer Profile Address`,
+    type: "customer_profile_address",
+    attributes: {
+      address_sids: addressSid,
+    },
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a customer profile address document SID.");
+  }
+  return sid;
+}
+
+async function createMessagingProfileEndUser(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  draft: CompletedSmsComplianceDraft,
+): Promise<string> {
+  const resource = await (client as any).trusthub.v1.endUsers.create({
+    friendlyName: `${context.business.name} A2P Messaging Profile`,
+    type: "us_a2p_messaging_profile_information",
+    attributes: buildMessagingProfileAttributes(draft),
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a messaging profile SID.");
+  }
+  return sid;
+}
+
+async function createTrustProduct(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+): Promise<string> {
+  const resource = await (client as any).trusthub.v1.trustProducts.create({
+    friendlyName: `${context.business.name} A2P Messaging Profile`,
+    email: requireTwilioA2pStatusEmail(),
+    policySid: getTwilioA2pTrustProductPolicySid(),
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a TrustProduct SID.");
+  }
+  return sid;
+}
+
+async function assignObjectToCustomerProfile(
+  client: TwilioClientLike,
+  customerProfileSid: string,
+  objectSid: string,
+): Promise<void> {
+  try {
+    await (client as any).trusthub.v1
+      .customerProfiles(customerProfileSid)
+      .customerProfilesEntityAssignments.create({
+        objectSid,
+      });
+  } catch (error) {
+    if (isDuplicateTwilioError(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function assignObjectToTrustProduct(
+  client: TwilioClientLike,
+  trustProductSid: string,
+  objectSid: string,
+): Promise<void> {
+  try {
+    await (client as any).trusthub.v1
+      .trustProducts(trustProductSid)
+      .trustProductsEntityAssignments.create({
+        objectSid,
+      });
+  } catch (error) {
+    if (isDuplicateTwilioError(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function evaluateCustomerProfile(
+  client: TwilioClientLike,
+  customerProfileSid: string,
+): Promise<TwilioEvaluationSummary> {
+  const resource = await (client as any).trusthub.v1
+    .customerProfiles(customerProfileSid)
+    .evaluations.create({
+      policySid: await fetchPrimaryCustomerProfilePolicySid(client),
+    });
+
+  return normalizeEvaluation(resource);
+}
+
+async function submitCustomerProfileForReview(
+  client: TwilioClientLike,
+  customerProfileSid: string,
+): Promise<void> {
+  await (client as any).trusthub.v1.customerProfiles(customerProfileSid).update({
+    status: "pending-review",
+  });
+}
+
+async function evaluateTrustProduct(
+  client: TwilioClientLike,
+  trustProductSid: string,
+): Promise<TwilioEvaluationSummary> {
+  const resource = await (client as any).trusthub.v1
+    .trustProducts(trustProductSid)
+    .evaluations.create({
+      policySid: getTwilioA2pTrustProductPolicySid(),
+    });
+
+  return normalizeEvaluation(resource);
+}
+
+async function submitTrustProductForReview(
+  client: TwilioClientLike,
+  trustProductSid: string,
+): Promise<void> {
+  await (client as any).trusthub.v1.trustProducts(trustProductSid).update({
+    status: "pending-review",
+  });
+}
+
+async function createBrandRegistration(
+  client: TwilioClientLike,
+  input: {
+    customerProfileSid: string;
+    trustProductSid: string;
+    lowVolume: boolean;
+  },
+): Promise<TwilioBrandSummary> {
+  await maybePauseForTwilioRateLimit();
+
+  const resource = await (client as any).messaging.v1.brandRegistrations.create({
+    customerProfileBundleSid: input.customerProfileSid,
+    a2PProfileBundleSid: input.trustProductSid,
+    brandType: "STANDARD",
+    skipAutomaticSecVet: input.lowVolume,
+  });
+
+  return normalizeBrand(resource);
+}
+
+async function fetchBrandRegistration(
+  client: TwilioClientLike,
+  brandRegistrationSid: string,
+): Promise<TwilioBrandSummary> {
+  const resource = await (client as any).messaging.v1
+    .brandRegistrations(brandRegistrationSid)
+    .fetch();
+  return normalizeBrand(resource);
+}
+
+async function createMessagingService(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+): Promise<string> {
+  const resource = await (client as any).messaging.v1.services.create({
+    friendlyName: `${context.business.name} AI SMS`,
+    stickySender: true,
+    useInboundWebhookOnNumber: true,
+    inboundRequestUrl: buildTwilioSmsInboundWebhookUrl(),
+    inboundMethod: "POST",
+  });
+
+  const sid = getString(resource, "sid");
+  if (!sid) {
+    throw new Error("Twilio did not return a Messaging Service SID.");
+  }
+  return sid;
+}
+
+async function createCampaign(
+  client: TwilioClientLike,
+  input: {
+    messagingServiceSid: string;
+    brandRegistrationSid: string;
+    draft: CompletedSmsComplianceDraft;
+    usecaseCode: string;
+  },
+): Promise<TwilioCampaignSummary> {
+  await maybePauseForTwilioRateLimit();
+
+  const resource = await (client as any).messaging.v1
+    .services(input.messagingServiceSid)
+    .usAppToPerson.create({
+      brandRegistrationSid: input.brandRegistrationSid,
+      description: input.draft.campaignDescription,
+      messageFlow: input.draft.messageFlow,
+      messageSamples: input.draft.sampleMessages,
+      usAppToPersonUsecase: input.usecaseCode,
+      hasEmbeddedLinks: input.draft.hasEmbeddedLinks,
+      hasEmbeddedPhone: input.draft.hasEmbeddedPhone,
+      subscriberOptIn: true,
+      subscriberOptOut: true,
+      subscriberHelp: true,
+      ...(input.draft.optInMessage ? { optInMessage: input.draft.optInMessage } : {}),
+      optOutMessage: input.draft.optOutMessage,
+      helpMessage: input.draft.helpMessage,
+      ...(input.draft.optInKeywords.length > 0
+        ? { optInKeywords: input.draft.optInKeywords }
+        : {}),
+      ...(input.draft.optOutKeywords.length > 0
+        ? { optOutKeywords: input.draft.optOutKeywords }
+        : {}),
+      ...(input.draft.helpKeywords.length > 0
+        ? { helpKeywords: input.draft.helpKeywords }
+        : {}),
+    });
+
+  return normalizeCampaign(resource);
+}
+
+async function fetchCampaign(
+  client: TwilioClientLike,
+  messagingServiceSid: string,
+  campaignSid?: string,
+): Promise<TwilioCampaignSummary | undefined> {
+  if (campaignSid) {
+    const resource = await (client as any).messaging.v1
+      .services(messagingServiceSid)
+      .usAppToPerson(campaignSid)
+      .fetch();
+    return normalizeCampaign(resource);
+  }
+
+  const resources = await (client as any).messaging.v1
+    .services(messagingServiceSid)
+    .usAppToPerson.list({
+      limit: 1,
+    });
+
+  const resource = Array.isArray(resources) ? resources[0] : undefined;
+  return resource ? normalizeCampaign(resource) : undefined;
+}
+
+async function ensurePhoneNumberAttachedToMessagingService(
+  client: TwilioClientLike,
+  input: {
+    messagingServiceSid: string;
+    phoneNumberSid: string;
+  },
+): Promise<boolean> {
+  const phoneNumbers = await (client as any).messaging.v1
+    .services(input.messagingServiceSid)
+    .phoneNumbers.list({
+      limit: 100,
+    });
+  if (
+    Array.isArray(phoneNumbers) &&
+    phoneNumbers.some(
+      (phoneNumber) => getString(phoneNumber, "sid", "phoneNumberSid") === input.phoneNumberSid,
+    )
+  ) {
+    return true;
+  }
+
+  await (client as any).messaging.v1
+    .services(input.messagingServiceSid)
+    .phoneNumbers.create({
+      phoneNumberSid: input.phoneNumberSid,
+    });
+  return true;
+}
+
+export const syncRegistration = internalAction({
+  args: {
+    registrationId: v.id("sms_compliance_registrations"),
+    mode: v.union(v.literal("submit"), v.literal("refresh")),
+  },
+  returns: v.object({
+    status: smsComplianceStatusValidator,
+    trafficTier: v.optional(smsComplianceTrafficTierValidator),
+    draft: v.optional(smsComplianceDraftValidator),
+    twilioCustomerProfileSid: v.optional(v.string()),
+    twilioBusinessInfoSid: v.optional(v.string()),
+    twilioAuthorizedRepresentativeSid: v.optional(v.string()),
+    twilioAddressSid: v.optional(v.string()),
+    twilioAddressDocumentSid: v.optional(v.string()),
+    twilioTrustProductSid: v.optional(v.string()),
+    twilioMessagingProfileSid: v.optional(v.string()),
+    twilioBrandRegistrationSid: v.optional(v.string()),
+    twilioMessagingServiceSid: v.optional(v.string()),
+    twilioCampaignSid: v.optional(v.string()),
+    approvedPhoneNumberId: v.optional(v.id("phone_numbers")),
+    brandContactEmail: v.optional(v.string()),
+    lastSubmittedAt: v.optional(v.string()),
+    lastSyncedAt: v.string(),
+    failureCode: v.optional(v.string()),
+    failureMessage: v.optional(v.string()),
+    pendingAction: v.optional(smsCompliancePendingActionValidator),
+  }),
+  handler: async (ctx, args) => {
+    const client = getTwilioClient() as TwilioClientLike;
+    const context = (await ctx.runQuery(internal.smsCompliance.getTwilioRegistrationContext, {
+      registrationId: args.registrationId,
+    })) as unknown as TwilioRegistrationContext;
+    const draft = assertSmsComplianceDraftReady(context.registration.draft);
+    const now = new Date().toISOString();
+
+    let customerProfileSid = context.registration.twilioCustomerProfileSid;
+    let businessInfoSid = context.registration.twilioBusinessInfoSid;
+    let authorizedRepresentativeSid = context.registration.twilioAuthorizedRepresentativeSid;
+    let addressSid = context.registration.twilioAddressSid;
+    let addressDocumentSid = context.registration.twilioAddressDocumentSid;
+    let trustProductSid = context.registration.twilioTrustProductSid;
+    let messagingProfileSid = context.registration.twilioMessagingProfileSid;
+    let brandRegistrationSid = context.registration.twilioBrandRegistrationSid;
+    let messagingServiceSid = context.registration.twilioMessagingServiceSid;
+    let campaignSid = context.registration.twilioCampaignSid;
+
+    let customerProfileEvaluation: TwilioEvaluationSummary | undefined;
+    let trustProductEvaluation: TwilioEvaluationSummary | undefined;
+    let brand: TwilioBrandSummary | undefined;
+    let campaign: TwilioCampaignSummary | undefined;
+
+    try {
+      if (args.mode === "submit") {
+        if (!customerProfileSid) {
+          customerProfileSid = await createSecondaryCustomerProfile(client, context);
+        }
+        if (!businessInfoSid) {
+          businessInfoSid = await createBusinessInformationEndUser(client, context, draft);
+        }
+        await assignObjectToCustomerProfile(client, customerProfileSid, businessInfoSid);
+        if (!authorizedRepresentativeSid) {
+          authorizedRepresentativeSid = await createAuthorizedRepresentativeEndUser(
+            client,
+            context,
+            draft,
+          );
+        }
+        await assignObjectToCustomerProfile(
+          client,
+          customerProfileSid,
+          authorizedRepresentativeSid,
+        );
+        if (!addressSid) {
+          addressSid = await createBusinessAddress(client, draft);
+        }
+        if (!addressDocumentSid) {
+          addressDocumentSid = await createCustomerProfileAddressDocument(
+            client,
+            context,
+            addressSid,
+          );
+        }
+        await assignObjectToCustomerProfile(client, customerProfileSid, addressDocumentSid);
+
+        await assignObjectToCustomerProfile(
+          client,
+          customerProfileSid,
+          requirePrimaryCustomerProfileSid(),
+        );
+        customerProfileEvaluation = await evaluateCustomerProfile(client, customerProfileSid);
+        if (customerProfileEvaluation.status !== "noncompliant") {
+          await submitCustomerProfileForReview(client, customerProfileSid);
+        }
+
+        if (!trustProductSid) {
+          trustProductSid = await createTrustProduct(client, context);
+        }
+        if (!messagingProfileSid) {
+          messagingProfileSid = await createMessagingProfileEndUser(client, context, draft);
+        }
+        await assignObjectToTrustProduct(client, trustProductSid, messagingProfileSid);
+        await assignObjectToTrustProduct(client, trustProductSid, customerProfileSid);
+        trustProductEvaluation = await evaluateTrustProduct(client, trustProductSid);
+        if (trustProductEvaluation.status !== "noncompliant") {
+          await submitTrustProductForReview(client, trustProductSid);
+        }
+
+        if (!brandRegistrationSid && trustProductEvaluation.status !== "noncompliant") {
+          brand = await createBrandRegistration(client, {
+            customerProfileSid,
+            trustProductSid,
+            lowVolume: context.trafficTier === "low_volume",
+          });
+          brandRegistrationSid = brand.sid;
+        }
+
+        if (!messagingServiceSid) {
+          messagingServiceSid = await createMessagingService(client, context);
+        }
+
+        if (
+          brandRegistrationSid &&
+          messagingServiceSid &&
+          !campaignSid &&
+          trustProductEvaluation.status !== "noncompliant"
+        ) {
+          campaign = await createCampaign(client, {
+            messagingServiceSid,
+            brandRegistrationSid,
+            draft,
+            usecaseCode: context.twilioUsecaseCode,
+          });
+          campaignSid = campaign.sid;
+        }
+      }
+
+      if (brandRegistrationSid) {
+        brand = await fetchBrandRegistration(client, brandRegistrationSid);
+      }
+      if (messagingServiceSid) {
+        campaign = await fetchCampaign(client, messagingServiceSid, campaignSid);
+      }
+
+      let phoneAttached = false;
+      if (
+        messagingServiceSid &&
+        campaign?.campaignStatus === "VERIFIED" &&
+        context.phoneNumber.twilioPhoneSid
+      ) {
+        try {
+          phoneAttached = await ensurePhoneNumberAttachedToMessagingService(client, {
+            messagingServiceSid,
+            phoneNumberSid: context.phoneNumber.twilioPhoneSid,
+          });
+        } catch (error) {
+          phoneAttached = false;
+        }
+      }
+
+      const derivedState = deriveRegistrationState({
+        ...(customerProfileEvaluation ? { customerProfileEvaluation } : {}),
+        ...(trustProductEvaluation ? { trustProductEvaluation } : {}),
+        ...(brand ? { brand } : {}),
+        ...(campaign ? { campaign } : {}),
+        phoneAttached,
+      });
+
+      return {
+        status: derivedState.status,
+        trafficTier: context.registration.trafficTier,
+        ...(context.registration.draft ? { draft: context.registration.draft } : {}),
+        ...(customerProfileSid ? { twilioCustomerProfileSid: customerProfileSid } : {}),
+        ...(businessInfoSid ? { twilioBusinessInfoSid: businessInfoSid } : {}),
+        ...(authorizedRepresentativeSid
+          ? { twilioAuthorizedRepresentativeSid: authorizedRepresentativeSid }
+          : {}),
+        ...(addressSid ? { twilioAddressSid: addressSid } : {}),
+        ...(addressDocumentSid ? { twilioAddressDocumentSid: addressDocumentSid } : {}),
+        ...(trustProductSid ? { twilioTrustProductSid: trustProductSid } : {}),
+        ...(messagingProfileSid ? { twilioMessagingProfileSid: messagingProfileSid } : {}),
+        ...(brandRegistrationSid ? { twilioBrandRegistrationSid: brandRegistrationSid } : {}),
+        ...(messagingServiceSid ? { twilioMessagingServiceSid: messagingServiceSid } : {}),
+        ...(campaign?.sid ?? campaignSid ? { twilioCampaignSid: campaign?.sid ?? campaignSid } : {}),
+        approvedPhoneNumberId: context.phoneNumber._id,
+        ...(draft.brandContactEmail ? { brandContactEmail: draft.brandContactEmail } : {}),
+        ...(args.mode === "submit" ? { lastSubmittedAt: now } : {}),
+        lastSyncedAt: now,
+        ...(derivedState.failureCode ? { failureCode: derivedState.failureCode } : {}),
+        ...(derivedState.failureMessage ? { failureMessage: derivedState.failureMessage } : {}),
+        ...(derivedState.pendingAction ? { pendingAction: derivedState.pendingAction } : {}),
+      };
+    } catch (error) {
+      const message = buildTwilioErrorMessage(error);
+      const pendingAction = buildPendingActionFromErrors([message], "manual_review");
+      const failureStatus: SmsComplianceStatus =
+        pendingAction?.type === "brand_contact_email_otp"
+          ? "pending_brand_verification"
+          : "failed";
+      return {
+        status: failureStatus,
+        trafficTier: context.registration.trafficTier,
+        ...(context.registration.draft ? { draft: context.registration.draft } : {}),
+        ...(customerProfileSid ? { twilioCustomerProfileSid: customerProfileSid } : {}),
+        ...(businessInfoSid ? { twilioBusinessInfoSid: businessInfoSid } : {}),
+        ...(authorizedRepresentativeSid
+          ? { twilioAuthorizedRepresentativeSid: authorizedRepresentativeSid }
+          : {}),
+        ...(addressSid ? { twilioAddressSid: addressSid } : {}),
+        ...(addressDocumentSid ? { twilioAddressDocumentSid: addressDocumentSid } : {}),
+        ...(trustProductSid ? { twilioTrustProductSid: trustProductSid } : {}),
+        ...(messagingProfileSid ? { twilioMessagingProfileSid: messagingProfileSid } : {}),
+        ...(brandRegistrationSid ? { twilioBrandRegistrationSid: brandRegistrationSid } : {}),
+        ...(messagingServiceSid ? { twilioMessagingServiceSid: messagingServiceSid } : {}),
+        ...(campaignSid ? { twilioCampaignSid: campaignSid } : {}),
+        approvedPhoneNumberId: context.phoneNumber._id,
+        ...(draft.brandContactEmail ? { brandContactEmail: draft.brandContactEmail } : {}),
+        ...(args.mode === "submit" ? { lastSubmittedAt: now } : {}),
+        lastSyncedAt: now,
+        failureCode: "twilio_registration_error",
+        failureMessage: message,
+        ...(pendingAction ? { pendingAction } : {}),
+      };
+    }
+  },
+});

--- a/convex/integrations/twilioA2p.ts
+++ b/convex/integrations/twilioA2p.ts
@@ -29,6 +29,7 @@ type TwilioRegistrationContext = {
   phoneNumber: Doc<"phone_numbers">;
   trafficTier: Doc<"sms_compliance_registrations">["trafficTier"];
   twilioUsecaseCode: string;
+  previousCompletedSubmission?: Doc<"sms_compliance_submissions">;
 };
 
 type TwilioEvaluationSummary = {
@@ -129,6 +130,14 @@ function getStringArray(resource: unknown, key: string): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+function areStringArraysEqual(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((entry, index) => entry === right[index]);
+}
+
 function normalizeTwilioErrors(resource: unknown): string[] {
   const errors = getStringArray(resource, "errors");
   if (errors.length > 0) {
@@ -210,6 +219,103 @@ function buildMessagingProfileAttributes(
     ...(draft.stockTicker ? { stock_ticker: draft.stockTicker } : {}),
     ...(draft.brandContactEmail ? { brand_contact_email: draft.brandContactEmail } : {}),
   };
+}
+
+function buildBusinessAddressParams(
+  draft: CompletedSmsComplianceDraft,
+): Record<string, string> {
+  return {
+    friendlyName: `${draft.businessName} Mailing Address`,
+    customerName: draft.address.customerName,
+    street: draft.address.street,
+    ...(draft.address.streetSecondary
+      ? { streetSecondary: draft.address.streetSecondary }
+      : {}),
+    city: draft.address.city,
+    region: draft.address.region,
+    postalCode: draft.address.postalCode,
+  };
+}
+
+function buildMessagingServiceParams(
+  context: TwilioRegistrationContext,
+): Record<string, boolean | string> {
+  return {
+    friendlyName: `${context.business.name} AI SMS`,
+    stickySender: true,
+    useInboundWebhookOnNumber: true,
+    inboundRequestUrl: buildTwilioSmsInboundWebhookUrl(),
+    inboundMethod: "POST",
+  };
+}
+
+function buildCampaignUpdateParams(
+  draft: CompletedSmsComplianceDraft,
+): Record<string, boolean | string | string[]> {
+  return {
+    ageGated: false,
+    description: draft.campaignDescription,
+    directLending: false,
+    hasEmbeddedLinks: draft.hasEmbeddedLinks,
+    hasEmbeddedPhone: draft.hasEmbeddedPhone,
+    messageFlow: draft.messageFlow,
+    messageSamples: draft.sampleMessages,
+  };
+}
+
+function buildCampaignCreateParams(input: {
+  brandRegistrationSid: string;
+  draft: CompletedSmsComplianceDraft;
+  usecaseCode: string;
+}): Record<string, boolean | string | string[]> {
+  return {
+    brandRegistrationSid: input.brandRegistrationSid,
+    ...buildCampaignUpdateParams(input.draft),
+    usAppToPersonUsecase: input.usecaseCode,
+    subscriberOptIn: true,
+    subscriberOptOut: true,
+    subscriberHelp: true,
+    ...(input.draft.optInMessage ? { optInMessage: input.draft.optInMessage } : {}),
+    optOutMessage: input.draft.optOutMessage,
+    helpMessage: input.draft.helpMessage,
+    ...(input.draft.optInKeywords.length > 0
+      ? { optInKeywords: input.draft.optInKeywords }
+      : {}),
+    ...(input.draft.optOutKeywords.length > 0
+      ? { optOutKeywords: input.draft.optOutKeywords }
+      : {}),
+    ...(input.draft.helpKeywords.length > 0
+      ? { helpKeywords: input.draft.helpKeywords }
+      : {}),
+  };
+}
+
+function getPreviousCompletedDraft(
+  context: TwilioRegistrationContext,
+): CompletedSmsComplianceDraft | undefined {
+  const previousDraft = context.previousCompletedSubmission?.snapshot.draft;
+  if (!previousDraft) {
+    return undefined;
+  }
+
+  return assertSmsComplianceDraftReady(previousDraft);
+}
+
+function hasImmutableCampaignConfigChanges(input: {
+  currentDraft: CompletedSmsComplianceDraft;
+  currentTrafficTier: Doc<"sms_compliance_registrations">["trafficTier"];
+  previousDraft: CompletedSmsComplianceDraft;
+  previousTrafficTier: Doc<"sms_compliance_submissions">["trafficTier"];
+}): boolean {
+  return (
+    input.currentTrafficTier !== input.previousTrafficTier ||
+    (input.currentDraft.optInMessage ?? "") !== (input.previousDraft.optInMessage ?? "") ||
+    input.currentDraft.optOutMessage !== input.previousDraft.optOutMessage ||
+    input.currentDraft.helpMessage !== input.previousDraft.helpMessage ||
+    !areStringArraysEqual(input.currentDraft.optInKeywords, input.previousDraft.optInKeywords) ||
+    !areStringArraysEqual(input.currentDraft.optOutKeywords, input.previousDraft.optOutKeywords) ||
+    !areStringArraysEqual(input.currentDraft.helpKeywords, input.previousDraft.helpKeywords)
+  );
 }
 
 function buildTwilioErrorMessage(error: unknown): string {
@@ -463,6 +569,18 @@ async function createBusinessInformationEndUser(
   return sid;
 }
 
+async function updateBusinessInformationEndUser(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  businessInfoSid: string,
+  draft: CompletedSmsComplianceDraft,
+): Promise<void> {
+  await (client as any).trusthub.v1.endUsers(businessInfoSid).update({
+    friendlyName: `${context.business.name} Business Information`,
+    attributes: buildBusinessInformationAttributes(draft),
+  });
+}
+
 async function createAuthorizedRepresentativeEndUser(
   client: TwilioClientLike,
   context: TwilioRegistrationContext,
@@ -481,20 +599,24 @@ async function createAuthorizedRepresentativeEndUser(
   return sid;
 }
 
+async function updateAuthorizedRepresentativeEndUser(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  authorizedRepresentativeSid: string,
+  draft: CompletedSmsComplianceDraft,
+): Promise<void> {
+  await (client as any).trusthub.v1.endUsers(authorizedRepresentativeSid).update({
+    friendlyName: `${context.business.name} Authorized Representative`,
+    attributes: buildAuthorizedRepresentativeAttributes(draft),
+  });
+}
+
 async function createBusinessAddress(
   client: TwilioClientLike,
   draft: CompletedSmsComplianceDraft,
 ): Promise<string> {
   const resource = await (client as any).trusthub.v1.addresses.create({
-    friendlyName: `${draft.businessName} Mailing Address`,
-    customerName: draft.address.customerName,
-    street: draft.address.street,
-    ...(draft.address.streetSecondary
-      ? { streetSecondary: draft.address.streetSecondary }
-      : {}),
-    city: draft.address.city,
-    region: draft.address.region,
-    postalCode: draft.address.postalCode,
+    ...buildBusinessAddressParams(draft),
     isoCountry: draft.address.isoCountry,
   });
 
@@ -503,6 +625,16 @@ async function createBusinessAddress(
     throw new Error("Twilio did not return a mailing address SID.");
   }
   return sid;
+}
+
+async function updateBusinessAddress(
+  client: TwilioClientLike,
+  addressSid: string,
+  draft: CompletedSmsComplianceDraft,
+): Promise<void> {
+  await (client as any).trusthub.v1.addresses(addressSid).update(
+    buildBusinessAddressParams(draft),
+  );
 }
 
 async function createCustomerProfileAddressDocument(
@@ -525,6 +657,20 @@ async function createCustomerProfileAddressDocument(
   return sid;
 }
 
+async function updateCustomerProfileAddressDocument(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  addressDocumentSid: string,
+  addressSid: string,
+): Promise<void> {
+  await (client as any).trusthub.v1.supportingDocuments(addressDocumentSid).update({
+    friendlyName: `${context.business.name} Customer Profile Address`,
+    attributes: {
+      address_sids: addressSid,
+    },
+  });
+}
+
 async function createMessagingProfileEndUser(
   client: TwilioClientLike,
   context: TwilioRegistrationContext,
@@ -541,6 +687,18 @@ async function createMessagingProfileEndUser(
     throw new Error("Twilio did not return a messaging profile SID.");
   }
   return sid;
+}
+
+async function updateMessagingProfileEndUser(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  messagingProfileSid: string,
+  draft: CompletedSmsComplianceDraft,
+): Promise<void> {
+  await (client as any).trusthub.v1.endUsers(messagingProfileSid).update({
+    friendlyName: `${context.business.name} A2P Messaging Profile`,
+    attributes: buildMessagingProfileAttributes(draft),
+  });
 }
 
 async function createTrustProduct(
@@ -672,23 +830,41 @@ async function fetchBrandRegistration(
   return normalizeBrand(resource);
 }
 
+async function resubmitBrandRegistration(
+  client: TwilioClientLike,
+  brandRegistrationSid: string,
+): Promise<TwilioBrandSummary> {
+  await maybePauseForTwilioRateLimit();
+
+  const resource = await (client as any).messaging.v1
+    .brandRegistrations(brandRegistrationSid)
+    .update();
+  return normalizeBrand(resource);
+}
+
 async function createMessagingService(
   client: TwilioClientLike,
   context: TwilioRegistrationContext,
 ): Promise<string> {
-  const resource = await (client as any).messaging.v1.services.create({
-    friendlyName: `${context.business.name} AI SMS`,
-    stickySender: true,
-    useInboundWebhookOnNumber: true,
-    inboundRequestUrl: buildTwilioSmsInboundWebhookUrl(),
-    inboundMethod: "POST",
-  });
+  const resource = await (client as any).messaging.v1.services.create(
+    buildMessagingServiceParams(context),
+  );
 
   const sid = getString(resource, "sid");
   if (!sid) {
     throw new Error("Twilio did not return a Messaging Service SID.");
   }
   return sid;
+}
+
+async function updateMessagingService(
+  client: TwilioClientLike,
+  context: TwilioRegistrationContext,
+  messagingServiceSid: string,
+): Promise<void> {
+  await (client as any).messaging.v1
+    .services(messagingServiceSid)
+    .update(buildMessagingServiceParams(context));
 }
 
 async function createCampaign(
@@ -704,32 +880,47 @@ async function createCampaign(
 
   const resource = await (client as any).messaging.v1
     .services(input.messagingServiceSid)
-    .usAppToPerson.create({
-      brandRegistrationSid: input.brandRegistrationSid,
-      description: input.draft.campaignDescription,
-      messageFlow: input.draft.messageFlow,
-      messageSamples: input.draft.sampleMessages,
-      usAppToPersonUsecase: input.usecaseCode,
-      hasEmbeddedLinks: input.draft.hasEmbeddedLinks,
-      hasEmbeddedPhone: input.draft.hasEmbeddedPhone,
-      subscriberOptIn: true,
-      subscriberOptOut: true,
-      subscriberHelp: true,
-      ...(input.draft.optInMessage ? { optInMessage: input.draft.optInMessage } : {}),
-      optOutMessage: input.draft.optOutMessage,
-      helpMessage: input.draft.helpMessage,
-      ...(input.draft.optInKeywords.length > 0
-        ? { optInKeywords: input.draft.optInKeywords }
-        : {}),
-      ...(input.draft.optOutKeywords.length > 0
-        ? { optOutKeywords: input.draft.optOutKeywords }
-        : {}),
-      ...(input.draft.helpKeywords.length > 0
-        ? { helpKeywords: input.draft.helpKeywords }
-        : {}),
-    });
+    .usAppToPerson.create(
+      buildCampaignCreateParams({
+        brandRegistrationSid: input.brandRegistrationSid,
+        draft: input.draft,
+        usecaseCode: input.usecaseCode,
+      }),
+    );
 
   return normalizeCampaign(resource);
+}
+
+async function updateCampaign(
+  client: TwilioClientLike,
+  input: {
+    messagingServiceSid: string;
+    campaignSid: string;
+    draft: CompletedSmsComplianceDraft;
+  },
+): Promise<TwilioCampaignSummary> {
+  await maybePauseForTwilioRateLimit();
+
+  const resource = await (client as any).messaging.v1
+    .services(input.messagingServiceSid)
+    .usAppToPerson(input.campaignSid)
+    .update(buildCampaignUpdateParams(input.draft));
+  return normalizeCampaign(resource);
+}
+
+async function deleteCampaign(
+  client: TwilioClientLike,
+  input: {
+    messagingServiceSid: string;
+    campaignSid: string;
+  },
+): Promise<void> {
+  await maybePauseForTwilioRateLimit();
+
+  await (client as any).messaging.v1
+    .services(input.messagingServiceSid)
+    .usAppToPerson(input.campaignSid)
+    .remove();
 }
 
 async function fetchCampaign(
@@ -817,6 +1008,7 @@ export const syncRegistration = internalAction({
       registrationId: args.registrationId,
     })) as unknown as TwilioRegistrationContext;
     const draft = assertSmsComplianceDraftReady(context.registration.draft);
+    const previousCompletedDraft = getPreviousCompletedDraft(context);
     const now = new Date().toISOString();
 
     let customerProfileSid = context.registration.twilioCustomerProfileSid;
@@ -842,6 +1034,8 @@ export const syncRegistration = internalAction({
         }
         if (!businessInfoSid) {
           businessInfoSid = await createBusinessInformationEndUser(client, context, draft);
+        } else {
+          await updateBusinessInformationEndUser(client, context, businessInfoSid, draft);
         }
         await assignObjectToCustomerProfile(client, customerProfileSid, businessInfoSid);
         if (!authorizedRepresentativeSid) {
@@ -850,19 +1044,39 @@ export const syncRegistration = internalAction({
             context,
             draft,
           );
+        } else {
+          await updateAuthorizedRepresentativeEndUser(
+            client,
+            context,
+            authorizedRepresentativeSid,
+            draft,
+          );
         }
         await assignObjectToCustomerProfile(
           client,
           customerProfileSid,
           authorizedRepresentativeSid,
         );
-        if (!addressSid) {
+        const shouldRecreateAddress =
+          Boolean(addressSid) &&
+          Boolean(previousCompletedDraft) &&
+          previousCompletedDraft!.address.isoCountry !== draft.address.isoCountry;
+        if (!addressSid || shouldRecreateAddress) {
           addressSid = await createBusinessAddress(client, draft);
+        } else {
+          await updateBusinessAddress(client, addressSid, draft);
         }
         if (!addressDocumentSid) {
           addressDocumentSid = await createCustomerProfileAddressDocument(
             client,
             context,
+            addressSid,
+          );
+        } else {
+          await updateCustomerProfileAddressDocument(
+            client,
+            context,
+            addressDocumentSid,
             addressSid,
           );
         }
@@ -883,6 +1097,8 @@ export const syncRegistration = internalAction({
         }
         if (!messagingProfileSid) {
           messagingProfileSid = await createMessagingProfileEndUser(client, context, draft);
+        } else {
+          await updateMessagingProfileEndUser(client, context, messagingProfileSid, draft);
         }
         await assignObjectToTrustProduct(client, trustProductSid, messagingProfileSid);
         await assignObjectToTrustProduct(client, trustProductSid, customerProfileSid);
@@ -898,32 +1114,81 @@ export const syncRegistration = internalAction({
             lowVolume: context.trafficTier === "low_volume",
           });
           brandRegistrationSid = brand.sid;
+        } else if (brandRegistrationSid && trustProductEvaluation.status !== "noncompliant") {
+          brand = await fetchBrandRegistration(client, brandRegistrationSid);
+          if (brand.status === "FAILED") {
+            brand = await resubmitBrandRegistration(client, brandRegistrationSid);
+          }
         }
 
         if (!messagingServiceSid) {
           messagingServiceSid = await createMessagingService(client, context);
+        } else {
+          await updateMessagingService(client, context, messagingServiceSid);
         }
 
         if (
           brandRegistrationSid &&
           messagingServiceSid &&
-          !campaignSid &&
           trustProductEvaluation.status !== "noncompliant"
         ) {
-          campaign = await createCampaign(client, {
-            messagingServiceSid,
-            brandRegistrationSid,
-            draft,
-            usecaseCode: context.twilioUsecaseCode,
-          });
-          campaignSid = campaign.sid;
+          if (!campaignSid) {
+            campaign = await createCampaign(client, {
+              messagingServiceSid,
+              brandRegistrationSid,
+              draft,
+              usecaseCode: context.twilioUsecaseCode,
+            });
+            campaignSid = campaign.sid;
+          } else {
+            const existingCampaign = await fetchCampaign(client, messagingServiceSid, campaignSid);
+            const recreateFailedCampaign =
+              existingCampaign?.campaignStatus === "FAILED" &&
+              Boolean(previousCompletedDraft) &&
+              Boolean(context.previousCompletedSubmission) &&
+              hasImmutableCampaignConfigChanges({
+                currentDraft: draft,
+                currentTrafficTier: context.trafficTier,
+                previousDraft: previousCompletedDraft!,
+                previousTrafficTier: context.previousCompletedSubmission!.trafficTier,
+              });
+
+            if (recreateFailedCampaign) {
+              await deleteCampaign(client, {
+                messagingServiceSid,
+                campaignSid,
+              });
+              campaign = await createCampaign(client, {
+                messagingServiceSid,
+                brandRegistrationSid,
+                draft,
+                usecaseCode: context.twilioUsecaseCode,
+              });
+              campaignSid = campaign.sid;
+            } else if (existingCampaign) {
+              campaign = await updateCampaign(client, {
+                messagingServiceSid,
+                campaignSid,
+                draft,
+              });
+              campaignSid = campaign.sid ?? campaignSid;
+            } else {
+              campaign = await createCampaign(client, {
+                messagingServiceSid,
+                brandRegistrationSid,
+                draft,
+                usecaseCode: context.twilioUsecaseCode,
+              });
+              campaignSid = campaign.sid;
+            }
+          }
         }
       }
 
-      if (brandRegistrationSid) {
+      if (!brand && brandRegistrationSid) {
         brand = await fetchBrandRegistration(client, brandRegistrationSid);
       }
-      if (messagingServiceSid) {
+      if (!campaign && messagingServiceSid) {
         campaign = await fetchCampaign(client, messagingServiceSid, campaignSid);
       }
 
@@ -977,6 +1242,37 @@ export const syncRegistration = internalAction({
       };
     } catch (error) {
       const message = buildTwilioErrorMessage(error);
+      if (args.mode === "refresh") {
+        return {
+          status: context.registration.status,
+          trafficTier: context.registration.trafficTier,
+          ...(context.registration.draft ? { draft: context.registration.draft } : {}),
+          ...(customerProfileSid ? { twilioCustomerProfileSid: customerProfileSid } : {}),
+          ...(businessInfoSid ? { twilioBusinessInfoSid: businessInfoSid } : {}),
+          ...(authorizedRepresentativeSid
+            ? { twilioAuthorizedRepresentativeSid: authorizedRepresentativeSid }
+            : {}),
+          ...(addressSid ? { twilioAddressSid: addressSid } : {}),
+          ...(addressDocumentSid ? { twilioAddressDocumentSid: addressDocumentSid } : {}),
+          ...(trustProductSid ? { twilioTrustProductSid: trustProductSid } : {}),
+          ...(messagingProfileSid ? { twilioMessagingProfileSid: messagingProfileSid } : {}),
+          ...(brandRegistrationSid ? { twilioBrandRegistrationSid: brandRegistrationSid } : {}),
+          ...(messagingServiceSid ? { twilioMessagingServiceSid: messagingServiceSid } : {}),
+          ...(campaignSid ? { twilioCampaignSid: campaignSid } : {}),
+          approvedPhoneNumberId: context.phoneNumber._id,
+          ...(draft.brandContactEmail ? { brandContactEmail: draft.brandContactEmail } : {}),
+          lastSyncedAt: context.registration.lastSyncedAt ?? now,
+          ...(context.registration.failureCode
+            ? { failureCode: context.registration.failureCode }
+            : {}),
+          ...(context.registration.failureMessage
+            ? { failureMessage: context.registration.failureMessage }
+            : {}),
+          ...(context.registration.pendingAction
+            ? { pendingAction: context.registration.pendingAction }
+            : {}),
+        };
+      }
       const pendingAction = buildPendingActionFromErrors([message], "manual_review");
       const failureStatus: SmsComplianceStatus =
         pendingAction?.type === "brand_contact_email_otp"

--- a/convex/integrations/twilioA2p.ts
+++ b/convex/integrations/twilioA2p.ts
@@ -8,6 +8,7 @@ import { internalAction } from "../_generated/server";
 import { buildTwilioSmsInboundWebhookUrl } from "../lib/twilioUrls";
 import {
   assertSmsComplianceDraftReady,
+  isSmsComplianceApproved,
   smsComplianceDraftValidator,
   smsCompliancePendingActionValidator,
   smsComplianceStatusValidator,
@@ -1242,7 +1243,7 @@ export const syncRegistration = internalAction({
       };
     } catch (error) {
       const message = buildTwilioErrorMessage(error);
-      if (args.mode === "refresh") {
+      if (args.mode === "refresh" && isSmsComplianceApproved(context.registration.status)) {
         return {
           status: context.registration.status,
           trafficTier: context.registration.trafficTier,
@@ -1272,6 +1273,9 @@ export const syncRegistration = internalAction({
             ? { pendingAction: context.registration.pendingAction }
             : {}),
         };
+      }
+      if (args.mode === "refresh") {
+        throw error;
       }
       const pendingAction = buildPendingActionFromErrors([message], "manual_review");
       const failureStatus: SmsComplianceStatus =

--- a/convex/integrations/twilioA2p.ts
+++ b/convex/integrations/twilioA2p.ts
@@ -615,7 +615,7 @@ async function createBusinessAddress(
   client: TwilioClientLike,
   draft: CompletedSmsComplianceDraft,
 ): Promise<string> {
-  const resource = await (client as any).trusthub.v1.addresses.create({
+  const resource = await (client as any).api.v2010.account.addresses.create({
     ...buildBusinessAddressParams(draft),
     isoCountry: draft.address.isoCountry,
   });
@@ -632,7 +632,7 @@ async function updateBusinessAddress(
   addressSid: string,
   draft: CompletedSmsComplianceDraft,
 ): Promise<void> {
-  await (client as any).trusthub.v1.addresses(addressSid).update(
+  await (client as any).api.v2010.account.addresses(addressSid).update(
     buildBusinessAddressParams(draft),
   );
 }

--- a/convex/integrations/twilioSms.ts
+++ b/convex/integrations/twilioSms.ts
@@ -73,18 +73,26 @@ export const validateWebhookSignature = internalAction({
 export const sendMessage = internalAction({
   args: {
     to: v.string(),
-    from: v.string(),
+    from: v.optional(v.string()),
+    messagingServiceSid: v.optional(v.string()),
     body: v.string(),
     statusCallbackUrl: v.string(),
     mediaUrls: v.optional(v.array(v.string())),
   },
   handler: async (_ctx, args) => {
+    if (!args.from && !args.messagingServiceSid) {
+      throw new Error("Either a Twilio from number or Messaging Service SID is required.");
+    }
+
     const client = getTwilioClient();
     const message = await client.messages.create({
       to: args.to,
-      from: args.from,
       body: args.body,
       statusCallback: args.statusCallbackUrl,
+      ...(args.from ? { from: args.from } : {}),
+      ...(args.messagingServiceSid
+        ? { messagingServiceSid: args.messagingServiceSid }
+        : {}),
       ...(args.mediaUrls && args.mediaUrls.length > 0
         ? { mediaUrl: args.mediaUrls }
         : {}),

--- a/convex/lib/billingAccess.ts
+++ b/convex/lib/billingAccess.ts
@@ -1,0 +1,15 @@
+const BILLING_ADMIN_ROLES = new Set([
+  "business_owner",
+  "business_admin",
+  "owner",
+]);
+
+export function hasBillingManagementAccess(role: string): boolean {
+  return BILLING_ADMIN_ROLES.has(role);
+}
+
+export function requireBillingManagementAccess(role: string): void {
+  if (!hasBillingManagementAccess(role)) {
+    throw new Error("Billing management requires admin access.");
+  }
+}

--- a/convex/lib/smsCompliance.ts
+++ b/convex/lib/smsCompliance.ts
@@ -482,6 +482,15 @@ export function assertSmsComplianceDraftReady(
     email: requireText(authorizedRepresentative.email, "Authorized representative email"),
   };
 
+  const publicCompanyStockExchange =
+    companyType === "public"
+      ? requireText(draft.stockExchange, "Stock exchange")
+      : undefined;
+  const publicCompanyStockTicker =
+    companyType === "public"
+      ? requireText(draft.stockTicker, "Stock ticker")
+      : undefined;
+
   if (companyType === "public" && !brandContactEmail) {
     throw new Error("Brand contact email is required for public companies.");
   }
@@ -496,8 +505,8 @@ export function assertSmsComplianceDraftReady(
     socialProfileUrls: normalizeStringArray(draft.socialProfileUrls),
     businessRegionsOfOperation,
     companyType,
-    ...(hasText(draft.stockExchange) ? { stockExchange: draft.stockExchange.trim() } : {}),
-    ...(hasText(draft.stockTicker) ? { stockTicker: draft.stockTicker.trim() } : {}),
+    ...(publicCompanyStockExchange ? { stockExchange: publicCompanyStockExchange } : {}),
+    ...(publicCompanyStockTicker ? { stockTicker: publicCompanyStockTicker } : {}),
     ...(brandContactEmail ? { brandContactEmail } : {}),
     campaignDescription,
     messageFlow,

--- a/convex/lib/smsCompliance.ts
+++ b/convex/lib/smsCompliance.ts
@@ -1,0 +1,516 @@
+import { v } from "convex/values";
+
+export const smsComplianceStatuses = [
+  "not_started",
+  "collecting_info",
+  "submitting",
+  "pending_brand_verification",
+  "pending_review",
+  "approved",
+  "failed",
+  "suspended",
+] as const;
+export type SmsComplianceStatus = (typeof smsComplianceStatuses)[number];
+
+export const smsComplianceCustomerTypes = ["direct_customer"] as const;
+export type SmsComplianceCustomerType = (typeof smsComplianceCustomerTypes)[number];
+
+export const smsComplianceBrandKinds = ["standard_business"] as const;
+export type SmsComplianceBrandKind = (typeof smsComplianceBrandKinds)[number];
+
+export const smsComplianceTrafficTiers = ["low_volume", "mixed"] as const;
+export type SmsComplianceTrafficTier = (typeof smsComplianceTrafficTiers)[number];
+
+export const smsSenderModes = [
+  "platform_phone",
+  "business_phone",
+  "business_messaging_service",
+] as const;
+export type SmsSenderMode = (typeof smsSenderModes)[number];
+
+export const smsCompliancePendingActionTypes = [
+  "brand_contact_email_otp",
+  "missing_information",
+  "manual_review",
+  "customer_profile_review",
+  "campaign_review",
+  "phone_number_association",
+] as const;
+export type SmsCompliancePendingActionType =
+  (typeof smsCompliancePendingActionTypes)[number];
+
+export const smsComplianceStatusValidator = v.union(
+  v.literal("not_started"),
+  v.literal("collecting_info"),
+  v.literal("submitting"),
+  v.literal("pending_brand_verification"),
+  v.literal("pending_review"),
+  v.literal("approved"),
+  v.literal("failed"),
+  v.literal("suspended"),
+);
+
+export const smsComplianceCustomerTypeValidator = v.literal("direct_customer");
+export const smsComplianceBrandKindValidator = v.literal("standard_business");
+export const smsComplianceTrafficTierValidator = v.union(
+  v.literal("low_volume"),
+  v.literal("mixed"),
+);
+export const smsSenderModeValidator = v.union(
+  v.literal("platform_phone"),
+  v.literal("business_phone"),
+  v.literal("business_messaging_service"),
+);
+
+export const smsCompliancePendingActionValidator = v.object({
+  type: v.union(
+    v.literal("brand_contact_email_otp"),
+    v.literal("missing_information"),
+    v.literal("manual_review"),
+    v.literal("customer_profile_review"),
+    v.literal("campaign_review"),
+    v.literal("phone_number_association"),
+  ),
+  message: v.string(),
+  code: v.optional(v.string()),
+  submittedAt: v.optional(v.string()),
+  expiresAt: v.optional(v.string()),
+});
+
+export type SmsCompliancePendingAction = {
+  type: SmsCompliancePendingActionType;
+  message: string;
+  code?: string;
+  submittedAt?: string;
+  expiresAt?: string;
+};
+
+export const smsComplianceAddressDraftValidator = v.object({
+  customerName: v.optional(v.string()),
+  street: v.optional(v.string()),
+  streetSecondary: v.optional(v.string()),
+  city: v.optional(v.string()),
+  region: v.optional(v.string()),
+  postalCode: v.optional(v.string()),
+  isoCountry: v.optional(v.string()),
+});
+
+export type SmsComplianceAddressDraft = {
+  customerName?: string;
+  street?: string;
+  streetSecondary?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  isoCountry?: string;
+};
+
+export const smsComplianceAuthorizedRepresentativeDraftValidator = v.object({
+  firstName: v.optional(v.string()),
+  lastName: v.optional(v.string()),
+  businessTitle: v.optional(v.string()),
+  jobPosition: v.optional(v.string()),
+  phoneNumber: v.optional(v.string()),
+  email: v.optional(v.string()),
+});
+
+export type SmsComplianceAuthorizedRepresentativeDraft = {
+  firstName?: string;
+  lastName?: string;
+  businessTitle?: string;
+  jobPosition?: string;
+  phoneNumber?: string;
+  email?: string;
+};
+
+export const smsComplianceDraftValidator = v.object({
+  businessName: v.optional(v.string()),
+  businessType: v.optional(v.string()),
+  businessIndustry: v.optional(v.string()),
+  businessRegistrationIdentifier: v.optional(v.string()),
+  businessRegistrationNumber: v.optional(v.string()),
+  websiteUrl: v.optional(v.string()),
+  socialProfileUrls: v.optional(v.array(v.string())),
+  businessRegionsOfOperation: v.optional(v.array(v.string())),
+  companyType: v.optional(v.string()),
+  stockExchange: v.optional(v.string()),
+  stockTicker: v.optional(v.string()),
+  brandContactEmail: v.optional(v.string()),
+  campaignDescription: v.optional(v.string()),
+  messageFlow: v.optional(v.string()),
+  sampleMessages: v.optional(v.array(v.string())),
+  hasEmbeddedLinks: v.optional(v.boolean()),
+  hasEmbeddedPhone: v.optional(v.boolean()),
+  optInMessage: v.optional(v.string()),
+  optOutMessage: v.optional(v.string()),
+  helpMessage: v.optional(v.string()),
+  optInKeywords: v.optional(v.array(v.string())),
+  optOutKeywords: v.optional(v.array(v.string())),
+  helpKeywords: v.optional(v.array(v.string())),
+  address: v.optional(smsComplianceAddressDraftValidator),
+  authorizedRepresentative: v.optional(
+    smsComplianceAuthorizedRepresentativeDraftValidator,
+  ),
+});
+
+export type SmsComplianceDraft = {
+  businessName?: string;
+  businessType?: string;
+  businessIndustry?: string;
+  businessRegistrationIdentifier?: string;
+  businessRegistrationNumber?: string;
+  websiteUrl?: string;
+  socialProfileUrls?: string[];
+  businessRegionsOfOperation?: string[];
+  companyType?: string;
+  stockExchange?: string;
+  stockTicker?: string;
+  brandContactEmail?: string;
+  campaignDescription?: string;
+  messageFlow?: string;
+  sampleMessages?: string[];
+  hasEmbeddedLinks?: boolean;
+  hasEmbeddedPhone?: boolean;
+  optInMessage?: string;
+  optOutMessage?: string;
+  helpMessage?: string;
+  optInKeywords?: string[];
+  optOutKeywords?: string[];
+  helpKeywords?: string[];
+  address?: SmsComplianceAddressDraft;
+  authorizedRepresentative?: SmsComplianceAuthorizedRepresentativeDraft;
+};
+
+export type CompletedSmsComplianceDraft = {
+  businessName: string;
+  businessType: string;
+  businessIndustry: string;
+  businessRegistrationIdentifier: string;
+  businessRegistrationNumber: string;
+  websiteUrl: string;
+  socialProfileUrls: string[];
+  businessRegionsOfOperation: string[];
+  companyType: string;
+  stockExchange?: string;
+  stockTicker?: string;
+  brandContactEmail?: string;
+  campaignDescription: string;
+  messageFlow: string;
+  sampleMessages: string[];
+  hasEmbeddedLinks: boolean;
+  hasEmbeddedPhone: boolean;
+  optInMessage?: string;
+  optOutMessage: string;
+  helpMessage: string;
+  optInKeywords: string[];
+  optOutKeywords: string[];
+  helpKeywords: string[];
+  address: {
+    customerName: string;
+    street: string;
+    streetSecondary?: string;
+    city: string;
+    region: string;
+    postalCode: string;
+    isoCountry: string;
+  };
+  authorizedRepresentative: {
+    firstName: string;
+    lastName: string;
+    businessTitle: string;
+    jobPosition: string;
+    phoneNumber: string;
+    email: string;
+  };
+};
+
+export const smsComplianceSubmissionSnapshotValidator = v.object({
+  trafficTier: smsComplianceTrafficTierValidator,
+  draft: smsComplianceDraftValidator,
+});
+
+export type SmsComplianceSubmissionSnapshot = {
+  trafficTier: SmsComplianceTrafficTier;
+  draft: SmsComplianceDraft;
+};
+
+export const smsComplianceCampaignOptions = [
+  {
+    value: "low_volume" as const,
+    twilioUsecaseCode: "LOW_VOLUME",
+    recommended: true,
+  },
+  {
+    value: "mixed" as const,
+    twilioUsecaseCode: "MIXED",
+    recommended: false,
+  },
+];
+
+const BUSINESS_TYPES = new Set([
+  "Co-operative",
+  "Corporation",
+  "Limited Liability Corporation",
+  "Non-profit Corporation",
+  "Partnership",
+]);
+
+const BUSINESS_INDUSTRIES = new Set([
+  "AGRICULTURE",
+  "AUTOMOTIVE",
+  "BANKING",
+  "CONSTRUCTION",
+  "CONSUMER",
+  "EDUCATION",
+  "ELECTRONICS",
+  "ENGINEERING",
+  "ENERGY",
+  "FAST_MOVING_CONSUMER_GOODS",
+  "FINANCIAL",
+  "FINTECH",
+  "FOOD_AND_BEVERAGE",
+  "GOVERNMENT",
+  "HEALTHCARE",
+  "HOSPITALITY",
+  "INSURANCE",
+  "JEWELRY",
+  "LEGAL",
+  "MANUFACTURING",
+  "MEDIA",
+  "NOT_FOR_PROFIT",
+  "OIL_AND_GAS",
+  "ONLINE",
+  "PROFESSIONAL_SERVICES",
+  "RAW_MATERIALS",
+  "REAL_ESTATE",
+  "RELIGION",
+  "RETAIL",
+  "TECHNOLOGY",
+  "TELECOMMUNICATIONS",
+  "TRANSPORTATION",
+  "TRAVEL",
+]);
+
+const BUSINESS_REGISTRATION_IDENTIFIERS = new Set([
+  "EIN",
+  "DUNS",
+  "CBN",
+  "CN",
+  "ACN",
+  "CIN",
+  "VAT",
+  "VATRN",
+  "RN",
+  "Other",
+]);
+
+const BUSINESS_REGIONS_OF_OPERATION = new Set([
+  "AFRICA",
+  "ASIA",
+  "EUROPE",
+  "LATIN_AMERICA",
+  "USA_AND_CANADA",
+]);
+
+const COMPANY_TYPES = new Set(["government", "non-profit", "private", "public"]);
+
+const JOB_POSITIONS = new Set([
+  "Director",
+  "GM",
+  "VP",
+  "CEO",
+  "CFO",
+  "General Counsel",
+  "Other",
+]);
+
+function hasText(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeStringArray(values: string[] | undefined): string[] {
+  return (values ?? []).map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+function requireText(
+  value: string | undefined,
+  field: string,
+): string {
+  if (!hasText(value)) {
+    throw new Error(`${field} is required.`);
+  }
+
+  return value.trim();
+}
+
+function requireAllowedValue(
+  value: string | undefined,
+  field: string,
+  allowedValues: Set<string>,
+): string {
+  const normalized = requireText(value, field);
+  if (!allowedValues.has(normalized)) {
+    throw new Error(`${field} must be one of: ${Array.from(allowedValues).join(", ")}.`);
+  }
+  return normalized;
+}
+
+export function isSmsComplianceApproved(
+  status: SmsComplianceStatus | undefined | null,
+): status is "approved" {
+  return status === "approved";
+}
+
+export function getCampaignUsecaseForTrafficTier(
+  trafficTier: SmsComplianceTrafficTier,
+): "LOW_VOLUME" | "MIXED" {
+  return trafficTier === "mixed" ? "MIXED" : "LOW_VOLUME";
+}
+
+export function isTerminalSmsComplianceStatus(
+  status: SmsComplianceStatus,
+): boolean {
+  return status === "approved" || status === "failed" || status === "suspended";
+}
+
+export function assertSmsComplianceDraftReady(
+  draft: SmsComplianceDraft | undefined,
+): CompletedSmsComplianceDraft {
+  if (!draft) {
+    throw new Error("SMS compliance information is required before submission.");
+  }
+
+  const businessName = requireText(draft.businessName, "Business legal name");
+  const businessType = requireAllowedValue(
+    draft.businessType,
+    "Business type",
+    BUSINESS_TYPES,
+  );
+  const businessIndustry = requireAllowedValue(
+    draft.businessIndustry,
+    "Business industry",
+    BUSINESS_INDUSTRIES,
+  );
+  const businessRegistrationIdentifier = requireAllowedValue(
+    draft.businessRegistrationIdentifier,
+    "Business registration identifier",
+    BUSINESS_REGISTRATION_IDENTIFIERS,
+  );
+  const businessRegistrationNumber = requireText(
+    draft.businessRegistrationNumber,
+    "Business registration number",
+  );
+  const websiteUrl = requireText(draft.websiteUrl, "Website URL");
+  const businessRegionsOfOperation = normalizeStringArray(
+    draft.businessRegionsOfOperation,
+  );
+  if (businessRegionsOfOperation.length === 0) {
+    throw new Error("At least one business region of operation is required.");
+  }
+  for (const region of businessRegionsOfOperation) {
+    if (!BUSINESS_REGIONS_OF_OPERATION.has(region)) {
+      throw new Error(
+        `Business regions of operation must be one of: ${Array.from(BUSINESS_REGIONS_OF_OPERATION).join(", ")}.`,
+      );
+    }
+  }
+
+  const companyType = requireAllowedValue(draft.companyType, "Company type", COMPANY_TYPES);
+  const brandContactEmail = hasText(draft.brandContactEmail)
+    ? draft.brandContactEmail.trim()
+    : undefined;
+  const campaignDescription = requireText(
+    draft.campaignDescription,
+    "Campaign description",
+  );
+  const messageFlow = requireText(draft.messageFlow, "Message flow");
+  const sampleMessages = normalizeStringArray(draft.sampleMessages);
+  if (sampleMessages.length < 2) {
+    throw new Error("At least two sample messages are required.");
+  }
+
+  const optInKeywords = normalizeStringArray(draft.optInKeywords);
+  const optOutKeywords = normalizeStringArray(draft.optOutKeywords);
+  const helpKeywords = normalizeStringArray(draft.helpKeywords);
+  const optOutMessage = requireText(draft.optOutMessage, "Opt-out message");
+  const helpMessage = requireText(draft.helpMessage, "Help message");
+
+  const address = draft.address;
+  if (!address) {
+    throw new Error("Business mailing address is required.");
+  }
+
+  const authorizedRepresentative = draft.authorizedRepresentative;
+  if (!authorizedRepresentative) {
+    throw new Error("Authorized representative details are required.");
+  }
+
+  const normalizedAddress = {
+    customerName: requireText(address.customerName, "Business mailing name"),
+    street: requireText(address.street, "Street address"),
+    ...(hasText(address.streetSecondary)
+      ? { streetSecondary: address.streetSecondary.trim() }
+      : {}),
+    city: requireText(address.city, "City"),
+    region: requireText(address.region, "State or province"),
+    postalCode: requireText(address.postalCode, "Postal code"),
+    isoCountry: requireText(address.isoCountry, "Country code"),
+  };
+
+  const normalizedAuthorizedRepresentative = {
+    firstName: requireText(
+      authorizedRepresentative.firstName,
+      "Authorized representative first name",
+    ),
+    lastName: requireText(
+      authorizedRepresentative.lastName,
+      "Authorized representative last name",
+    ),
+    businessTitle: requireText(
+      authorizedRepresentative.businessTitle,
+      "Authorized representative business title",
+    ),
+    jobPosition: requireAllowedValue(
+      authorizedRepresentative.jobPosition,
+      "Authorized representative job position",
+      JOB_POSITIONS,
+    ),
+    phoneNumber: requireText(
+      authorizedRepresentative.phoneNumber,
+      "Authorized representative phone number",
+    ),
+    email: requireText(authorizedRepresentative.email, "Authorized representative email"),
+  };
+
+  if (companyType === "public" && !brandContactEmail) {
+    throw new Error("Brand contact email is required for public companies.");
+  }
+
+  return {
+    businessName,
+    businessType,
+    businessIndustry,
+    businessRegistrationIdentifier,
+    businessRegistrationNumber,
+    websiteUrl,
+    socialProfileUrls: normalizeStringArray(draft.socialProfileUrls),
+    businessRegionsOfOperation,
+    companyType,
+    ...(hasText(draft.stockExchange) ? { stockExchange: draft.stockExchange.trim() } : {}),
+    ...(hasText(draft.stockTicker) ? { stockTicker: draft.stockTicker.trim() } : {}),
+    ...(brandContactEmail ? { brandContactEmail } : {}),
+    campaignDescription,
+    messageFlow,
+    sampleMessages,
+    hasEmbeddedLinks: draft.hasEmbeddedLinks ?? false,
+    hasEmbeddedPhone: draft.hasEmbeddedPhone ?? false,
+    ...(hasText(draft.optInMessage) ? { optInMessage: draft.optInMessage.trim() } : {}),
+    optOutMessage,
+    helpMessage,
+    optInKeywords,
+    optOutKeywords,
+    helpKeywords,
+    address: normalizedAddress,
+    authorizedRepresentative: normalizedAuthorizedRepresentative,
+  };
+}

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -22,7 +22,6 @@ import {
   inferRuntimeLocaleFromBusinessContext,
   normalizeRuntimeLocale,
 } from "../lib/runtimeLocale";
-import { selectSmsSenderPhoneNumber } from "../lib/smsPhoneNumbers";
 
 type AppointmentNotificationKind = "appointment_reminder" | "booking_confirmation";
 
@@ -31,7 +30,8 @@ type NotificationDeliveryContext = {
   notificationId: Id<"notifications">;
   appointmentId: Id<"appointments">;
   to: string;
-  from: string;
+  from?: string;
+  twilioMessagingServiceSid?: string;
   kind: AppointmentNotificationKind;
   serviceId: Id<"services">;
   serviceName: string;
@@ -134,7 +134,7 @@ export const getNotificationDeliveryContext = internalQuery({
       throw new Error("Appointment not found for notification.");
     }
 
-    const [service, contact, business, profile, phoneNumbers, sender, smsPolicy, billingSnapshot] =
+    const [service, contact, business, profile, smsPolicy] =
       await Promise.all([
       ctx.db.get(appointment.serviceId),
       ctx.db.get(appointment.contactId),
@@ -143,17 +143,9 @@ export const getNotificationDeliveryContext = internalQuery({
         .query("receptionist_profiles")
         .withIndex("by_business_id", (q) => q.eq("businessId", notification.businessId))
         .unique(),
-      ctx.db
-        .query("phone_numbers")
-        .withIndex("by_business_id", (q) => q.eq("businessId", notification.businessId))
-        .collect(),
-      ctx.runQuery(internal.billing.getPlatformAlertSmsSender, {}),
       ctx.runQuery(internal.billing.getSmsCapabilityPolicy, {
         businessId: notification.businessId,
         capability: "alert",
-      }),
-      ctx.runQuery(internal.billing.getSnapshotForCheckout, {
-        businessId: notification.businessId,
       }),
     ]);
 
@@ -172,18 +164,13 @@ export const getNotificationDeliveryContext = internalQuery({
       throw new Error("Unsupported notification kind.");
     }
 
-    if (!smsPolicy.allowed && billingSnapshot.plan !== "self_host") {
+    if (!smsPolicy.allowed) {
       throw new Error("Alert SMS quota reached. Upgrade to continue sending notifications.");
     }
 
-    const senderPhoneNumber =
-      billingSnapshot.plan === "self_host"
-        ? selectSmsSenderPhoneNumber(phoneNumbers)
-        : sender?.e164 ?? null;
-
-    if (!senderPhoneNumber) {
+    if (!smsPolicy.fromPhoneNumber && !smsPolicy.twilioMessagingServiceSid) {
       throw new Error(
-        billingSnapshot.plan === "self_host"
+        smsPolicy.senderMode === "business_phone"
           ? "At least one active SMS-enabled phone number must be mapped to the business."
           : "Configure the shared alert SMS sender before delivering hosted notifications.",
       );
@@ -204,14 +191,17 @@ export const getNotificationDeliveryContext = internalQuery({
       notificationId: notification._id,
       appointmentId,
       to: contact.phone,
-      from: senderPhoneNumber,
+      ...(smsPolicy.fromPhoneNumber ? { from: smsPolicy.fromPhoneNumber } : {}),
+      ...(smsPolicy.twilioMessagingServiceSid
+        ? { twilioMessagingServiceSid: smsPolicy.twilioMessagingServiceSid }
+        : {}),
       kind: notification.kind,
       serviceId: service._id,
       serviceName: service.name,
       startsAt: appointment.startsAt,
       timezone: appointment.timezone,
       locale,
-      senderRole: billingSnapshot.plan === "self_host" ? "business_ai" : "platform_alert",
+      senderRole: smsPolicy.senderRole,
     };
   },
 });
@@ -459,10 +449,13 @@ export const deliverNotification = internalAction({
       const result: { providerMessageSid: string; providerStatus: string } = await ctx.runAction(
         internal.integrations.twilioSms.sendMessage,
         {
-        to: deliveryContext.to,
-        from: deliveryContext.from,
-        body,
-        statusCallbackUrl: buildTwilioSmsStatusCallbackUrl(),
+          to: deliveryContext.to,
+          body,
+          statusCallbackUrl: buildTwilioSmsStatusCallbackUrl(),
+          ...(deliveryContext.from ? { from: deliveryContext.from } : {}),
+          ...(deliveryContext.twilioMessagingServiceSid
+            ? { messagingServiceSid: deliveryContext.twilioMessagingServiceSid }
+            : {}),
         },
       );
       messageAcceptedByProvider = true;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,6 +5,15 @@ import {
   runtimeLocaleSourceValidator,
   runtimeLocaleValidator,
 } from "./lib/runtimeLocale";
+import {
+  smsComplianceBrandKindValidator,
+  smsComplianceCustomerTypeValidator,
+  smsComplianceDraftValidator,
+  smsCompliancePendingActionValidator,
+  smsComplianceStatusValidator,
+  smsComplianceSubmissionSnapshotValidator,
+  smsComplianceTrafficTierValidator,
+} from "./lib/smsCompliance";
 import { knowledgeSectionValidator } from "./lib/knowledgeSections";
 import { localizedServiceNamesValidator } from "./lib/serviceNames";
 
@@ -243,6 +252,58 @@ export default defineSchema({
   })
     .index("by_role", ["role"])
     .index("by_e164", ["e164"]),
+
+  sms_compliance_registrations: defineTable({
+    businessId: v.id("businesses"),
+    status: smsComplianceStatusValidator,
+    customerType: smsComplianceCustomerTypeValidator,
+    brandKind: smsComplianceBrandKindValidator,
+    trafficTier: smsComplianceTrafficTierValidator,
+    draft: v.optional(smsComplianceDraftValidator),
+    twilioCustomerProfileSid: v.optional(v.string()),
+    twilioBusinessInfoSid: v.optional(v.string()),
+    twilioAuthorizedRepresentativeSid: v.optional(v.string()),
+    twilioAddressSid: v.optional(v.string()),
+    twilioAddressDocumentSid: v.optional(v.string()),
+    twilioTrustProductSid: v.optional(v.string()),
+    twilioMessagingProfileSid: v.optional(v.string()),
+    twilioBrandRegistrationSid: v.optional(v.string()),
+    twilioMessagingServiceSid: v.optional(v.string()),
+    twilioCampaignSid: v.optional(v.string()),
+    approvedPhoneNumberId: v.optional(v.id("phone_numbers")),
+    brandContactEmail: v.optional(v.string()),
+    lastSubmittedAt: v.optional(v.string()),
+    lastSyncedAt: v.optional(v.string()),
+    failureCode: v.optional(v.string()),
+    failureMessage: v.optional(v.string()),
+    pendingAction: v.optional(smsCompliancePendingActionValidator),
+  })
+    .index("by_business_id", ["businessId"])
+    .index("by_status", ["status"]),
+
+  sms_compliance_submissions: defineTable({
+    registrationId: v.id("sms_compliance_registrations"),
+    businessId: v.id("businesses"),
+    attemptKey: v.string(),
+    status: smsComplianceStatusValidator,
+    trafficTier: smsComplianceTrafficTierValidator,
+    snapshot: smsComplianceSubmissionSnapshotValidator,
+    createdAt: v.string(),
+    submittedAt: v.optional(v.string()),
+    completedAt: v.optional(v.string()),
+    resultStatus: v.optional(smsComplianceStatusValidator),
+    twilioCustomerProfileSid: v.optional(v.string()),
+    twilioTrustProductSid: v.optional(v.string()),
+    twilioBrandRegistrationSid: v.optional(v.string()),
+    twilioMessagingServiceSid: v.optional(v.string()),
+    twilioCampaignSid: v.optional(v.string()),
+    failureCode: v.optional(v.string()),
+    failureMessage: v.optional(v.string()),
+    pendingAction: v.optional(smsCompliancePendingActionValidator),
+  })
+    .index("by_registration_id", ["registrationId"])
+    .index("by_business_id", ["businessId"])
+    .index("by_attempt_key", ["attemptKey"]),
 
   onboarding_phone_verifications: defineTable({
     businessId: v.id("businesses"),

--- a/convex/smsCompliance.ts
+++ b/convex/smsCompliance.ts
@@ -13,6 +13,7 @@ import {
   type QueryCtx,
 } from "./_generated/server";
 import { requireMembership } from "./lib/auth";
+import { requireBillingManagementAccess } from "./lib/billingAccess";
 import { getBillingSnapshot, isAiSmsEnabled } from "./lib/billing";
 import {
   assertSmsComplianceDraftReady,
@@ -48,6 +49,10 @@ type SmsComplianceStatusView = {
   customerType: "direct_customer";
   brandKind: "standard_business";
   trafficTier: SmsComplianceTrafficTier;
+  availablePhoneNumbers: Array<{
+    id: Id<"phone_numbers">;
+    e164: string;
+  }>;
   draft?: SmsComplianceDraft;
   pendingAction?: NonNullable<Doc<"sms_compliance_registrations">["pendingAction"]>;
   failureCode?: string;
@@ -102,13 +107,19 @@ async function getSmsComplianceRegistration(
     .unique();
 }
 
+function getEligibleSmsPhoneNumbers(
+  phoneNumbers: Array<SmsPhoneNumberDoc>,
+): Array<SmsPhoneNumberDoc> {
+  return phoneNumbers.filter(
+    (phoneNumber) => phoneNumber.status === "active" && phoneNumber.smsEnabled,
+  );
+}
+
 function selectActiveSmsPhoneNumber(
   phoneNumbers: Array<SmsPhoneNumberDoc>,
   preferredPhoneNumberId?: Id<"phone_numbers">,
 ): SmsPhoneNumberDoc | null {
-  const eligiblePhoneNumbers = phoneNumbers.filter(
-    (phoneNumber) => phoneNumber.status === "active" && phoneNumber.smsEnabled,
-  );
+  const eligiblePhoneNumbers = getEligibleSmsPhoneNumbers(phoneNumbers);
   if (eligiblePhoneNumbers.length === 0) {
     return null;
   }
@@ -120,9 +131,27 @@ function selectActiveSmsPhoneNumber(
     if (preferredPhoneNumber) {
       return preferredPhoneNumber;
     }
+
+    return null;
   }
 
-  return eligiblePhoneNumbers[0] ?? null;
+  return eligiblePhoneNumbers.length === 1 ? eligiblePhoneNumbers[0] ?? null : null;
+}
+
+function getPhoneNumberSelectionError(input: {
+  phoneNumbers: Array<SmsPhoneNumberDoc>;
+  preferredPhoneNumberId?: Id<"phone_numbers">;
+}): string {
+  const eligiblePhoneNumbers = getEligibleSmsPhoneNumbers(input.phoneNumbers);
+  if (eligiblePhoneNumbers.length === 0) {
+    return "At least one active SMS-enabled phone number must be mapped to the business.";
+  }
+
+  if (input.preferredPhoneNumberId) {
+    return "The selected business phone number must remain active and SMS-enabled before continuing 10DLC registration.";
+  }
+
+  return "Choose which active SMS-enabled business phone number should be registered for hosted AI SMS before continuing 10DLC registration.";
 }
 
 function deriveHostedSenderMode(input: {
@@ -168,6 +197,29 @@ function createDefaultRegistration(
   };
 }
 
+async function requireSmsComplianceManagementAccess(
+  ctx: Pick<QueryCtx, "auth" | "db"> | Pick<MutationCtx, "auth" | "db">,
+  businessId: Id<"businesses">,
+): Promise<void> {
+  const membership = await requireMembership(ctx, businessId);
+  requireBillingManagementAccess(membership.role);
+}
+
+function canEditComplianceDraft(status: SmsComplianceStatus): boolean {
+  return status === "not_started" || status === "collecting_info" || status === "failed";
+}
+
+export const assertManagementAccess = internalQuery({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await requireSmsComplianceManagementAccess(ctx, args.businessId);
+    return null;
+  },
+});
+
 export const getStatus = query({
   args: {
     businessId: v.id("businesses"),
@@ -183,6 +235,12 @@ export const getStatus = query({
     customerType: smsComplianceCustomerTypeValidator,
     brandKind: smsComplianceBrandKindValidator,
     trafficTier: smsComplianceTrafficTierValidator,
+    availablePhoneNumbers: v.array(
+      v.object({
+        id: v.id("phone_numbers"),
+        e164: v.string(),
+      }),
+    ),
     draft: v.optional(smsComplianceDraftValidator),
     pendingAction: v.optional(smsCompliancePendingActionValidator),
     failureCode: v.optional(v.string()),
@@ -192,7 +250,7 @@ export const getStatus = query({
     twilioMessagingServiceSid: v.optional(v.string()),
   }),
   handler: async (ctx, args): Promise<SmsComplianceStatusView> => {
-    await requireMembership(ctx, args.businessId);
+    await requireSmsComplianceManagementAccess(ctx, args.businessId);
 
     const [snapshot, registration, phoneNumbers] = await Promise.all([
       getBillingSnapshot(ctx, { businessId: args.businessId }),
@@ -220,6 +278,10 @@ export const getStatus = query({
         ? phoneNumbers.find((phoneNumber) => phoneNumber._id === registration.approvedPhoneNumberId) ??
           null
         : null;
+    const availablePhoneNumbers = getEligibleSmsPhoneNumbers(phoneNumbers).map((phoneNumber) => ({
+      id: phoneNumber._id,
+      e164: phoneNumber.e164,
+    }));
 
     return {
       applicable,
@@ -240,6 +302,7 @@ export const getStatus = query({
       customerType: registration?.customerType ?? "direct_customer",
       brandKind: registration?.brandKind ?? "standard_business",
       trafficTier: registration?.trafficTier ?? "low_volume",
+      availablePhoneNumbers,
       ...(registration?.draft ? { draft: registration.draft } : {}),
       ...(registration?.pendingAction ? { pendingAction: registration.pendingAction } : {}),
       ...(registration?.failureCode ? { failureCode: registration.failureCode } : {}),
@@ -272,28 +335,48 @@ export const saveComplianceForm = mutation({
     businessId: v.id("businesses"),
     trafficTier: smsComplianceTrafficTierValidator,
     draft: smsComplianceDraftValidator,
+    approvedPhoneNumberId: v.optional(v.id("phone_numbers")),
   },
   returns: v.object({
     registrationId: v.id("sms_compliance_registrations"),
     status: smsComplianceStatusValidator,
   }),
   handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
-    await requireMembership(ctx, args.businessId);
+    await requireSmsComplianceManagementAccess(ctx, args.businessId);
     const existingRegistration = await getSmsComplianceRegistration(ctx, args.businessId);
+    const approvedPhoneNumber =
+      args.approvedPhoneNumberId !== undefined
+        ? await ctx.db.get(args.approvedPhoneNumberId)
+        : null;
+    if (
+      args.approvedPhoneNumberId !== undefined &&
+      (!approvedPhoneNumber ||
+        approvedPhoneNumber.businessId !== args.businessId ||
+        approvedPhoneNumber.status !== "active" ||
+        !approvedPhoneNumber.smsEnabled)
+    ) {
+      throw new Error(
+        "Select an active SMS-enabled business phone number before saving 10DLC registration.",
+      );
+    }
 
     if (existingRegistration) {
-      const nextStatus: SmsComplianceStatus =
-        existingRegistration.status === "approved" ||
-        existingRegistration.status === "pending_review" ||
-        existingRegistration.status === "pending_brand_verification" ||
-        existingRegistration.status === "submitting"
-          ? existingRegistration.status
-          : "collecting_info";
+      if (!canEditComplianceDraft(existingRegistration.status)) {
+        throw new Error(
+          "10DLC registration can't be edited after submission starts. Refresh status instead.",
+        );
+      }
+      const nextApprovedPhoneNumberId =
+        args.approvedPhoneNumberId ?? existingRegistration.approvedPhoneNumberId;
 
       await ctx.db.patch(existingRegistration._id, {
         draft: args.draft,
         trafficTier: args.trafficTier,
-        status: nextStatus,
+        status: "collecting_info",
+        failureCode: undefined,
+        failureMessage: undefined,
+        pendingAction: undefined,
+        ...(nextApprovedPhoneNumberId ? { approvedPhoneNumberId: nextApprovedPhoneNumberId } : {}),
         ...(args.draft.brandContactEmail
           ? { brandContactEmail: args.draft.brandContactEmail.trim() }
           : {}),
@@ -301,7 +384,7 @@ export const saveComplianceForm = mutation({
 
       return {
         registrationId: existingRegistration._id,
-        status: nextStatus,
+        status: "collecting_info",
       };
     }
 
@@ -310,6 +393,9 @@ export const saveComplianceForm = mutation({
       status: "collecting_info",
       draft: args.draft,
       trafficTier: args.trafficTier,
+      ...(args.approvedPhoneNumberId
+        ? { approvedPhoneNumberId: args.approvedPhoneNumberId }
+        : {}),
       ...(args.draft.brandContactEmail
         ? { brandContactEmail: args.draft.brandContactEmail.trim() }
         : {}),
@@ -333,7 +419,7 @@ export const beginSubmissionAttempt = internalMutation({
     attemptKey: v.optional(v.string()),
   }),
   handler: async (ctx, args): Promise<BeginSubmissionAttemptResult> => {
-    await requireMembership(ctx, args.businessId);
+    await requireSmsComplianceManagementAccess(ctx, args.businessId);
 
     const [snapshot, existingRegistration, phoneNumbers] = await Promise.all([
       getBillingSnapshot(ctx, { businessId: args.businessId }),
@@ -362,7 +448,12 @@ export const beginSubmissionAttempt = internalMutation({
     );
     if (!activePhoneNumber) {
       throw new Error(
-        "At least one active SMS-enabled phone number must be mapped to the business.",
+        getPhoneNumberSelectionError({
+          phoneNumbers,
+          ...(existingRegistration?.approvedPhoneNumberId
+            ? { preferredPhoneNumberId: existingRegistration.approvedPhoneNumberId }
+            : {}),
+        }),
       );
     }
     if (!activePhoneNumber.twilioPhoneSid) {
@@ -546,11 +637,15 @@ export const getTwilioRegistrationContext = internalQuery({
       throw new Error("SMS compliance registration not found.");
     }
 
-    const [business, phoneNumbers] = await Promise.all([
+    const [business, phoneNumbers, submissions] = await Promise.all([
       ctx.db.get(registration.businessId),
       ctx.db
         .query("phone_numbers")
         .withIndex("by_business_id", (q) => q.eq("businessId", registration.businessId))
+        .collect(),
+      ctx.db
+        .query("sms_compliance_submissions")
+        .withIndex("by_registration_id", (q) => q.eq("registrationId", args.registrationId))
         .collect(),
     ]);
     if (!business) {
@@ -563,12 +658,21 @@ export const getTwilioRegistrationContext = internalQuery({
     );
     if (!activePhoneNumber) {
       throw new Error(
-        "At least one active SMS-enabled phone number must be mapped to the business.",
+        getPhoneNumberSelectionError({
+          phoneNumbers,
+          ...(registration.approvedPhoneNumberId
+            ? { preferredPhoneNumberId: registration.approvedPhoneNumberId }
+            : {}),
+        }),
       );
     }
     if (!activePhoneNumber.twilioPhoneSid) {
       throw new Error("The approved business phone number is missing a Twilio phone SID.");
     }
+
+    const previousCompletedSubmission = submissions
+      .filter((submission) => submission.resultStatus !== undefined)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
 
     return {
       business,
@@ -576,6 +680,7 @@ export const getTwilioRegistrationContext = internalQuery({
       phoneNumber: activePhoneNumber,
       trafficTier: registration.trafficTier,
       twilioUsecaseCode: getCampaignUsecaseForTrafficTier(registration.trafficTier),
+      ...(previousCompletedSubmission ? { previousCompletedSubmission } : {}),
     };
   },
 });
@@ -669,6 +774,9 @@ export const startRegistration = action({
     status: smsComplianceStatusValidator,
   }),
   handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    await ctx.runQuery(internal.smsCompliance.assertManagementAccess, {
+      businessId: args.businessId,
+    });
     const attempt: BeginSubmissionAttemptResult = await ctx.runMutation(
       internal.smsCompliance.beginSubmissionAttempt,
       {
@@ -715,6 +823,9 @@ export const resumeRegistration = action({
     status: smsComplianceStatusValidator,
   }),
   handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    await ctx.runQuery(internal.smsCompliance.assertManagementAccess, {
+      businessId: args.businessId,
+    });
     const attempt: BeginSubmissionAttemptResult = await ctx.runMutation(
       internal.smsCompliance.beginSubmissionAttempt,
       {
@@ -761,6 +872,9 @@ export const refreshStatus = action({
     status: smsComplianceStatusValidator,
   }),
   handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    await ctx.runQuery(internal.smsCompliance.assertManagementAccess, {
+      businessId: args.businessId,
+    });
     const currentRegistration: Id<"sms_compliance_registrations"> | null = await ctx.runQuery(
       internal.smsCompliance.getRegistrationIdForBusiness,
       {
@@ -778,6 +892,19 @@ export const refreshStatus = action({
         mode: "refresh",
       });
     } catch (error) {
+      const persistedStatus: SmsComplianceStatus = await ctx.runQuery(
+        internal.smsCompliance.getRegistrationStatusForBusiness,
+        {
+          businessId: args.businessId,
+        },
+      );
+      if (isSmsComplianceApproved(persistedStatus)) {
+        return {
+          registrationId: currentRegistration,
+          status: persistedStatus,
+        };
+      }
+
       return await handleA2pSyncFailure(ctx, {
         registrationId: currentRegistration,
         error,
@@ -792,6 +919,7 @@ export const getRegistrationIdForBusiness = internalQuery({
   },
   returns: v.union(v.id("sms_compliance_registrations"), v.null()),
   handler: async (ctx, args) => {
+    await requireSmsComplianceManagementAccess(ctx, args.businessId);
     const registration = await getSmsComplianceRegistration(ctx, args.businessId);
     return registration?._id ?? null;
   },
@@ -803,6 +931,7 @@ export const getRegistrationStatusForBusiness = internalQuery({
   },
   returns: smsComplianceStatusValidator,
   handler: async (ctx, args): Promise<SmsComplianceStatus> => {
+    await requireSmsComplianceManagementAccess(ctx, args.businessId);
     const registration = await getSmsComplianceRegistration(ctx, args.businessId);
     return registration?.status ?? "not_started";
   },

--- a/convex/smsCompliance.ts
+++ b/convex/smsCompliance.ts
@@ -1,0 +1,809 @@
+import { v } from "convex/values";
+
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type ActionCtx,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
+import { requireMembership } from "./lib/auth";
+import { getBillingSnapshot, isAiSmsEnabled } from "./lib/billing";
+import {
+  assertSmsComplianceDraftReady,
+  getCampaignUsecaseForTrafficTier,
+  isSmsComplianceApproved,
+  smsComplianceBrandKindValidator,
+  smsComplianceCampaignOptions,
+  smsComplianceCustomerTypeValidator,
+  smsComplianceDraftValidator,
+  smsCompliancePendingActionValidator,
+  smsComplianceStatusValidator,
+  smsComplianceTrafficTierValidator,
+  smsSenderModeValidator,
+  type SmsComplianceDraft,
+  type SmsComplianceStatus,
+  type SmsComplianceTrafficTier,
+  type SmsSenderMode,
+} from "./lib/smsCompliance";
+
+type SmsPhoneNumberDoc = Pick<
+  Doc<"phone_numbers">,
+  "_id" | "e164" | "smsEnabled" | "status" | "twilioPhoneSid"
+>;
+
+type SmsComplianceStatusView = {
+  applicable: boolean;
+  aiSmsCommerciallyEnabled: boolean;
+  alertsUseBusinessSender: boolean;
+  aiSmsReady: boolean;
+  setupRequired: boolean;
+  senderMode: SmsSenderMode;
+  status: SmsComplianceStatus;
+  customerType: "direct_customer";
+  brandKind: "standard_business";
+  trafficTier: SmsComplianceTrafficTier;
+  draft?: SmsComplianceDraft;
+  pendingAction?: NonNullable<Doc<"sms_compliance_registrations">["pendingAction"]>;
+  failureCode?: string;
+  failureMessage?: string;
+  approvedPhoneNumberId?: Id<"phone_numbers">;
+  approvedPhoneNumberE164?: string;
+  twilioMessagingServiceSid?: string;
+};
+
+type SmsComplianceActionResult = {
+  registrationId: Id<"sms_compliance_registrations">;
+  status: SmsComplianceStatus;
+};
+
+type BeginSubmissionAttemptResult = {
+  started: boolean;
+  registrationId: Id<"sms_compliance_registrations">;
+  submissionId?: Id<"sms_compliance_submissions">;
+  attemptKey?: string;
+};
+
+type TwilioSyncResult = {
+  status: SmsComplianceStatus;
+  trafficTier?: SmsComplianceTrafficTier;
+  draft?: SmsComplianceDraft;
+  twilioCustomerProfileSid?: string;
+  twilioBusinessInfoSid?: string;
+  twilioAuthorizedRepresentativeSid?: string;
+  twilioAddressSid?: string;
+  twilioAddressDocumentSid?: string;
+  twilioTrustProductSid?: string;
+  twilioMessagingProfileSid?: string;
+  twilioBrandRegistrationSid?: string;
+  twilioMessagingServiceSid?: string;
+  twilioCampaignSid?: string;
+  approvedPhoneNumberId?: Id<"phone_numbers">;
+  brandContactEmail?: string;
+  lastSubmittedAt?: string;
+  lastSyncedAt: string;
+  failureCode?: string;
+  failureMessage?: string;
+  pendingAction?: NonNullable<Doc<"sms_compliance_registrations">["pendingAction"]>;
+};
+
+async function getSmsComplianceRegistration(
+  ctx: Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">,
+  businessId: Id<"businesses">,
+): Promise<Doc<"sms_compliance_registrations"> | null> {
+  return await ctx.db
+    .query("sms_compliance_registrations")
+    .withIndex("by_business_id", (q) => q.eq("businessId", businessId))
+    .unique();
+}
+
+function selectActiveSmsPhoneNumber(
+  phoneNumbers: Array<SmsPhoneNumberDoc>,
+  preferredPhoneNumberId?: Id<"phone_numbers">,
+): SmsPhoneNumberDoc | null {
+  const eligiblePhoneNumbers = phoneNumbers.filter(
+    (phoneNumber) => phoneNumber.status === "active" && phoneNumber.smsEnabled,
+  );
+  if (eligiblePhoneNumbers.length === 0) {
+    return null;
+  }
+
+  if (preferredPhoneNumberId) {
+    const preferredPhoneNumber = eligiblePhoneNumbers.find(
+      (phoneNumber) => phoneNumber._id === preferredPhoneNumberId,
+    );
+    if (preferredPhoneNumber) {
+      return preferredPhoneNumber;
+    }
+  }
+
+  return eligiblePhoneNumbers[0] ?? null;
+}
+
+function deriveHostedSenderMode(input: {
+  aiSmsCommerciallyEnabled: boolean;
+  registration: Doc<"sms_compliance_registrations"> | null;
+}): "platform_phone" | "business_messaging_service" {
+  if (
+    input.aiSmsCommerciallyEnabled &&
+    input.registration &&
+    isSmsComplianceApproved(input.registration.status) &&
+    input.registration.twilioMessagingServiceSid &&
+    input.registration.approvedPhoneNumberId
+  ) {
+    return "business_messaging_service";
+  }
+
+  return "platform_phone";
+}
+
+function createDefaultDraft(): SmsComplianceDraft {
+  return {
+    businessRegionsOfOperation: ["USA_AND_CANADA"],
+    companyType: "private",
+    sampleMessages: [],
+    optInKeywords: ["START"],
+    optOutKeywords: ["STOP"],
+    helpKeywords: ["HELP"],
+    hasEmbeddedLinks: false,
+    hasEmbeddedPhone: false,
+  };
+}
+
+function createDefaultRegistration(
+  businessId: Id<"businesses">,
+): Omit<Doc<"sms_compliance_registrations">, "_id" | "_creationTime"> {
+  return {
+    businessId,
+    status: "not_started",
+    customerType: "direct_customer",
+    brandKind: "standard_business",
+    trafficTier: "low_volume",
+    draft: createDefaultDraft(),
+  };
+}
+
+export const getStatus = query({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.object({
+    applicable: v.boolean(),
+    aiSmsCommerciallyEnabled: v.boolean(),
+    alertsUseBusinessSender: v.boolean(),
+    aiSmsReady: v.boolean(),
+    setupRequired: v.boolean(),
+    senderMode: smsSenderModeValidator,
+    status: smsComplianceStatusValidator,
+    customerType: smsComplianceCustomerTypeValidator,
+    brandKind: smsComplianceBrandKindValidator,
+    trafficTier: smsComplianceTrafficTierValidator,
+    draft: v.optional(smsComplianceDraftValidator),
+    pendingAction: v.optional(smsCompliancePendingActionValidator),
+    failureCode: v.optional(v.string()),
+    failureMessage: v.optional(v.string()),
+    approvedPhoneNumberId: v.optional(v.id("phone_numbers")),
+    approvedPhoneNumberE164: v.optional(v.string()),
+    twilioMessagingServiceSid: v.optional(v.string()),
+  }),
+  handler: async (ctx, args): Promise<SmsComplianceStatusView> => {
+    await requireMembership(ctx, args.businessId);
+
+    const [snapshot, registration, phoneNumbers] = await Promise.all([
+      getBillingSnapshot(ctx, { businessId: args.businessId }),
+      getSmsComplianceRegistration(ctx, args.businessId),
+      ctx.db
+        .query("phone_numbers")
+        .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
+        .collect(),
+    ]);
+
+    const aiSmsCommerciallyEnabled = isAiSmsEnabled({
+      plan: snapshot.plan,
+      activeAddons: snapshot.activeAddons,
+    });
+    const applicable = snapshot.plan !== "self_host" && aiSmsCommerciallyEnabled;
+    const senderMode: SmsSenderMode =
+      snapshot.plan === "self_host"
+        ? "business_phone"
+        : deriveHostedSenderMode({
+            aiSmsCommerciallyEnabled,
+            registration,
+          });
+    const approvedPhoneNumber =
+      registration?.approvedPhoneNumberId !== undefined
+        ? phoneNumbers.find((phoneNumber) => phoneNumber._id === registration.approvedPhoneNumberId) ??
+          null
+        : null;
+
+    return {
+      applicable,
+      aiSmsCommerciallyEnabled,
+      alertsUseBusinessSender:
+        snapshot.plan === "self_host" || senderMode === "business_messaging_service",
+      aiSmsReady:
+        snapshot.plan === "self_host" ||
+        (applicable && senderMode === "business_messaging_service"),
+      setupRequired:
+        applicable &&
+        (!registration ||
+          registration.status === "not_started" ||
+          registration.status === "collecting_info" ||
+          registration.status === "failed"),
+      senderMode,
+      status: registration?.status ?? "not_started",
+      customerType: registration?.customerType ?? "direct_customer",
+      brandKind: registration?.brandKind ?? "standard_business",
+      trafficTier: registration?.trafficTier ?? "low_volume",
+      ...(registration?.draft ? { draft: registration.draft } : {}),
+      ...(registration?.pendingAction ? { pendingAction: registration.pendingAction } : {}),
+      ...(registration?.failureCode ? { failureCode: registration.failureCode } : {}),
+      ...(registration?.failureMessage ? { failureMessage: registration.failureMessage } : {}),
+      ...(registration?.approvedPhoneNumberId
+        ? { approvedPhoneNumberId: registration.approvedPhoneNumberId }
+        : {}),
+      ...(approvedPhoneNumber ? { approvedPhoneNumberE164: approvedPhoneNumber.e164 } : {}),
+      ...(registration?.twilioMessagingServiceSid
+        ? { twilioMessagingServiceSid: registration.twilioMessagingServiceSid }
+        : {}),
+    };
+  },
+});
+
+export const getCampaignOptions = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      value: smsComplianceTrafficTierValidator,
+      twilioUsecaseCode: v.string(),
+      recommended: v.boolean(),
+    }),
+  ),
+  handler: async () => smsComplianceCampaignOptions,
+});
+
+export const saveComplianceForm = mutation({
+  args: {
+    businessId: v.id("businesses"),
+    trafficTier: smsComplianceTrafficTierValidator,
+    draft: smsComplianceDraftValidator,
+  },
+  returns: v.object({
+    registrationId: v.id("sms_compliance_registrations"),
+    status: smsComplianceStatusValidator,
+  }),
+  handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    await requireMembership(ctx, args.businessId);
+    const existingRegistration = await getSmsComplianceRegistration(ctx, args.businessId);
+
+    if (existingRegistration) {
+      const nextStatus: SmsComplianceStatus =
+        existingRegistration.status === "approved" ||
+        existingRegistration.status === "pending_review" ||
+        existingRegistration.status === "pending_brand_verification" ||
+        existingRegistration.status === "submitting"
+          ? existingRegistration.status
+          : "collecting_info";
+
+      await ctx.db.patch(existingRegistration._id, {
+        draft: args.draft,
+        trafficTier: args.trafficTier,
+        status: nextStatus,
+        ...(args.draft.brandContactEmail
+          ? { brandContactEmail: args.draft.brandContactEmail.trim() }
+          : {}),
+      });
+
+      return {
+        registrationId: existingRegistration._id,
+        status: nextStatus,
+      };
+    }
+
+    const registrationId = await ctx.db.insert("sms_compliance_registrations", {
+      ...createDefaultRegistration(args.businessId),
+      status: "collecting_info",
+      draft: args.draft,
+      trafficTier: args.trafficTier,
+      ...(args.draft.brandContactEmail
+        ? { brandContactEmail: args.draft.brandContactEmail.trim() }
+        : {}),
+    });
+
+    return {
+      registrationId,
+      status: "collecting_info",
+    };
+  },
+});
+
+export const beginSubmissionAttempt = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.object({
+    started: v.boolean(),
+    registrationId: v.id("sms_compliance_registrations"),
+    submissionId: v.optional(v.id("sms_compliance_submissions")),
+    attemptKey: v.optional(v.string()),
+  }),
+  handler: async (ctx, args): Promise<BeginSubmissionAttemptResult> => {
+    await requireMembership(ctx, args.businessId);
+
+    const [snapshot, existingRegistration, phoneNumbers] = await Promise.all([
+      getBillingSnapshot(ctx, { businessId: args.businessId }),
+      getSmsComplianceRegistration(ctx, args.businessId),
+      ctx.db
+        .query("phone_numbers")
+        .withIndex("by_business_id", (q) => q.eq("businessId", args.businessId))
+        .collect(),
+    ]);
+
+    if (snapshot.plan === "self_host") {
+      throw new Error("Self-hosted workspaces do not use hosted 10DLC registration.");
+    }
+
+    const aiSmsCommerciallyEnabled = isAiSmsEnabled({
+      plan: snapshot.plan,
+      activeAddons: snapshot.activeAddons,
+    });
+    if (!aiSmsCommerciallyEnabled) {
+      throw new Error("Enable AI SMS before starting 10DLC registration.");
+    }
+
+    const activePhoneNumber = selectActiveSmsPhoneNumber(
+      phoneNumbers,
+      existingRegistration?.approvedPhoneNumberId,
+    );
+    if (!activePhoneNumber) {
+      throw new Error(
+        "At least one active SMS-enabled phone number must be mapped to the business.",
+      );
+    }
+    if (!activePhoneNumber.twilioPhoneSid) {
+      throw new Error(
+        "The business phone number must be synced with Twilio before starting 10DLC registration.",
+      );
+    }
+
+    const registrationId =
+      existingRegistration?._id ??
+      (await ctx.db.insert("sms_compliance_registrations", {
+        ...createDefaultRegistration(args.businessId),
+      }));
+    const registration =
+      existingRegistration ?? (await ctx.db.get(registrationId));
+    if (!registration) {
+      throw new Error("SMS compliance registration could not be initialized.");
+    }
+    if (registration.status === "approved") {
+      return {
+        started: false,
+        registrationId,
+      };
+    }
+    if (registration.status === "submitting") {
+      return {
+        started: false,
+        registrationId,
+      };
+    }
+
+    const completedDraft = assertSmsComplianceDraftReady(registration.draft);
+    const startedAt = new Date().toISOString();
+    const attemptKey = `sms-compliance:${String(args.businessId)}:${Date.now()}`;
+    const submissionId = await ctx.db.insert("sms_compliance_submissions", {
+      registrationId,
+      businessId: args.businessId,
+      attemptKey,
+      status: "submitting",
+      trafficTier: registration.trafficTier,
+      snapshot: {
+        trafficTier: registration.trafficTier,
+        draft: registration.draft ?? {},
+      },
+      createdAt: startedAt,
+      submittedAt: startedAt,
+    });
+
+    await ctx.db.patch(registrationId, {
+      status: "submitting",
+      lastSubmittedAt: startedAt,
+      lastSyncedAt: startedAt,
+      failureCode: undefined,
+      failureMessage: undefined,
+      pendingAction: undefined,
+      approvedPhoneNumberId: activePhoneNumber._id,
+      ...(completedDraft.brandContactEmail
+        ? { brandContactEmail: completedDraft.brandContactEmail }
+        : {}),
+    });
+
+    return {
+      started: true,
+      registrationId,
+      submissionId,
+      attemptKey,
+    };
+  },
+});
+
+export const applySubmissionResult = internalMutation({
+  args: {
+    registrationId: v.id("sms_compliance_registrations"),
+    submissionId: v.optional(v.id("sms_compliance_submissions")),
+    status: smsComplianceStatusValidator,
+    trafficTier: v.optional(smsComplianceTrafficTierValidator),
+    draft: v.optional(smsComplianceDraftValidator),
+    twilioCustomerProfileSid: v.optional(v.string()),
+    twilioBusinessInfoSid: v.optional(v.string()),
+    twilioAuthorizedRepresentativeSid: v.optional(v.string()),
+    twilioAddressSid: v.optional(v.string()),
+    twilioAddressDocumentSid: v.optional(v.string()),
+    twilioTrustProductSid: v.optional(v.string()),
+    twilioMessagingProfileSid: v.optional(v.string()),
+    twilioBrandRegistrationSid: v.optional(v.string()),
+    twilioMessagingServiceSid: v.optional(v.string()),
+    twilioCampaignSid: v.optional(v.string()),
+    approvedPhoneNumberId: v.optional(v.id("phone_numbers")),
+    brandContactEmail: v.optional(v.string()),
+    lastSubmittedAt: v.optional(v.string()),
+    lastSyncedAt: v.string(),
+    failureCode: v.optional(v.string()),
+    failureMessage: v.optional(v.string()),
+    pendingAction: v.optional(smsCompliancePendingActionValidator),
+  },
+  returns: v.object({
+    registrationId: v.id("sms_compliance_registrations"),
+    status: smsComplianceStatusValidator,
+  }),
+  handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    const registration = await ctx.db.get(args.registrationId);
+    if (!registration) {
+      throw new Error("SMS compliance registration not found.");
+    }
+
+    await ctx.db.patch(args.registrationId, {
+      status: args.status,
+      ...(args.trafficTier ? { trafficTier: args.trafficTier } : {}),
+      ...(args.draft ? { draft: args.draft } : {}),
+      ...(args.twilioCustomerProfileSid
+        ? { twilioCustomerProfileSid: args.twilioCustomerProfileSid }
+        : {}),
+      ...(args.twilioBusinessInfoSid ? { twilioBusinessInfoSid: args.twilioBusinessInfoSid } : {}),
+      ...(args.twilioAuthorizedRepresentativeSid
+        ? { twilioAuthorizedRepresentativeSid: args.twilioAuthorizedRepresentativeSid }
+        : {}),
+      ...(args.twilioAddressSid ? { twilioAddressSid: args.twilioAddressSid } : {}),
+      ...(args.twilioAddressDocumentSid
+        ? { twilioAddressDocumentSid: args.twilioAddressDocumentSid }
+        : {}),
+      ...(args.twilioTrustProductSid ? { twilioTrustProductSid: args.twilioTrustProductSid } : {}),
+      ...(args.twilioMessagingProfileSid
+        ? { twilioMessagingProfileSid: args.twilioMessagingProfileSid }
+        : {}),
+      ...(args.twilioBrandRegistrationSid
+        ? { twilioBrandRegistrationSid: args.twilioBrandRegistrationSid }
+        : {}),
+      ...(args.twilioMessagingServiceSid
+        ? { twilioMessagingServiceSid: args.twilioMessagingServiceSid }
+        : {}),
+      ...(args.twilioCampaignSid ? { twilioCampaignSid: args.twilioCampaignSid } : {}),
+      ...(args.approvedPhoneNumberId ? { approvedPhoneNumberId: args.approvedPhoneNumberId } : {}),
+      ...(args.brandContactEmail ? { brandContactEmail: args.brandContactEmail } : {}),
+      ...(args.lastSubmittedAt ? { lastSubmittedAt: args.lastSubmittedAt } : {}),
+      lastSyncedAt: args.lastSyncedAt,
+      ...(args.failureCode ? { failureCode: args.failureCode } : { failureCode: undefined }),
+      ...(args.failureMessage
+        ? { failureMessage: args.failureMessage }
+        : { failureMessage: undefined }),
+      ...(args.pendingAction
+        ? { pendingAction: args.pendingAction }
+        : { pendingAction: undefined }),
+    });
+
+    if (args.submissionId) {
+      await ctx.db.patch(args.submissionId, {
+        status: args.status,
+        completedAt: args.lastSyncedAt,
+        resultStatus: args.status,
+        ...(args.twilioCustomerProfileSid
+          ? { twilioCustomerProfileSid: args.twilioCustomerProfileSid }
+          : {}),
+        ...(args.twilioTrustProductSid ? { twilioTrustProductSid: args.twilioTrustProductSid } : {}),
+        ...(args.twilioBrandRegistrationSid
+          ? { twilioBrandRegistrationSid: args.twilioBrandRegistrationSid }
+          : {}),
+        ...(args.twilioMessagingServiceSid
+          ? { twilioMessagingServiceSid: args.twilioMessagingServiceSid }
+          : {}),
+        ...(args.twilioCampaignSid ? { twilioCampaignSid: args.twilioCampaignSid } : {}),
+        ...(args.failureCode ? { failureCode: args.failureCode } : {}),
+        ...(args.failureMessage ? { failureMessage: args.failureMessage } : {}),
+        ...(args.pendingAction ? { pendingAction: args.pendingAction } : {}),
+      });
+    }
+
+    return {
+      registrationId: args.registrationId,
+      status: args.status,
+    };
+  },
+});
+
+export const getTwilioRegistrationContext = internalQuery({
+  args: {
+    registrationId: v.id("sms_compliance_registrations"),
+  },
+  handler: async (ctx, args) => {
+    const registration = await ctx.db.get(args.registrationId);
+    if (!registration) {
+      throw new Error("SMS compliance registration not found.");
+    }
+
+    const [business, phoneNumbers] = await Promise.all([
+      ctx.db.get(registration.businessId),
+      ctx.db
+        .query("phone_numbers")
+        .withIndex("by_business_id", (q) => q.eq("businessId", registration.businessId))
+        .collect(),
+    ]);
+    if (!business) {
+      throw new Error("Business not found for SMS compliance registration.");
+    }
+
+    const activePhoneNumber = selectActiveSmsPhoneNumber(
+      phoneNumbers,
+      registration.approvedPhoneNumberId,
+    );
+    if (!activePhoneNumber) {
+      throw new Error(
+        "At least one active SMS-enabled phone number must be mapped to the business.",
+      );
+    }
+    if (!activePhoneNumber.twilioPhoneSid) {
+      throw new Error("The approved business phone number is missing a Twilio phone SID.");
+    }
+
+    return {
+      business,
+      registration,
+      phoneNumber: activePhoneNumber,
+      trafficTier: registration.trafficTier,
+      twilioUsecaseCode: getCampaignUsecaseForTrafficTier(registration.trafficTier),
+    };
+  },
+});
+
+async function runA2pSyncAction(
+  ctx: ActionCtx,
+  input: {
+    businessId: Id<"businesses">;
+    registrationId: Id<"sms_compliance_registrations">;
+    submissionId?: Id<"sms_compliance_submissions">;
+    mode: "submit" | "refresh";
+  },
+): Promise<SmsComplianceActionResult> {
+  const result: TwilioSyncResult = await ctx.runAction(
+    internal.integrations.twilioA2p.syncRegistration,
+    {
+    registrationId: input.registrationId,
+    mode: input.mode,
+    },
+  );
+
+  return await ctx.runMutation(internal.smsCompliance.applySubmissionResult, {
+    registrationId: input.registrationId,
+    ...(input.submissionId ? { submissionId: input.submissionId } : {}),
+    status: result.status,
+    ...(result.trafficTier ? { trafficTier: result.trafficTier } : {}),
+    ...(result.draft ? { draft: result.draft } : {}),
+    ...(result.twilioCustomerProfileSid
+      ? { twilioCustomerProfileSid: result.twilioCustomerProfileSid }
+      : {}),
+    ...(result.twilioBusinessInfoSid ? { twilioBusinessInfoSid: result.twilioBusinessInfoSid } : {}),
+    ...(result.twilioAuthorizedRepresentativeSid
+      ? { twilioAuthorizedRepresentativeSid: result.twilioAuthorizedRepresentativeSid }
+      : {}),
+    ...(result.twilioAddressSid ? { twilioAddressSid: result.twilioAddressSid } : {}),
+    ...(result.twilioAddressDocumentSid
+      ? { twilioAddressDocumentSid: result.twilioAddressDocumentSid }
+      : {}),
+    ...(result.twilioTrustProductSid ? { twilioTrustProductSid: result.twilioTrustProductSid } : {}),
+    ...(result.twilioMessagingProfileSid
+      ? { twilioMessagingProfileSid: result.twilioMessagingProfileSid }
+      : {}),
+    ...(result.twilioBrandRegistrationSid
+      ? { twilioBrandRegistrationSid: result.twilioBrandRegistrationSid }
+      : {}),
+    ...(result.twilioMessagingServiceSid
+      ? { twilioMessagingServiceSid: result.twilioMessagingServiceSid }
+      : {}),
+    ...(result.twilioCampaignSid ? { twilioCampaignSid: result.twilioCampaignSid } : {}),
+    ...(result.approvedPhoneNumberId ? { approvedPhoneNumberId: result.approvedPhoneNumberId } : {}),
+    ...(result.brandContactEmail ? { brandContactEmail: result.brandContactEmail } : {}),
+    ...(result.lastSubmittedAt ? { lastSubmittedAt: result.lastSubmittedAt } : {}),
+    lastSyncedAt: result.lastSyncedAt,
+    ...(result.failureCode ? { failureCode: result.failureCode } : {}),
+    ...(result.failureMessage ? { failureMessage: result.failureMessage } : {}),
+    ...(result.pendingAction ? { pendingAction: result.pendingAction } : {}),
+  });
+}
+
+async function handleA2pSyncFailure(
+  ctx: ActionCtx,
+  input: {
+    registrationId: Id<"sms_compliance_registrations">;
+    submissionId?: Id<"sms_compliance_submissions">;
+    error: unknown;
+  },
+): Promise<SmsComplianceActionResult> {
+  const message =
+    input.error instanceof Error ? input.error.message : "SMS compliance registration failed.";
+
+  return await ctx.runMutation(internal.smsCompliance.applySubmissionResult, {
+    registrationId: input.registrationId,
+    ...(input.submissionId ? { submissionId: input.submissionId } : {}),
+    status: "failed",
+    lastSyncedAt: new Date().toISOString(),
+    failureCode: "twilio_sync_failed",
+    failureMessage: message,
+    pendingAction: {
+      type: "manual_review",
+      message,
+    },
+  });
+}
+
+export const startRegistration = action({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.object({
+    registrationId: v.id("sms_compliance_registrations"),
+    status: smsComplianceStatusValidator,
+  }),
+  handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    const attempt: BeginSubmissionAttemptResult = await ctx.runMutation(
+      internal.smsCompliance.beginSubmissionAttempt,
+      {
+      businessId: args.businessId,
+      },
+    );
+
+    if (!attempt.started || !attempt.submissionId) {
+      const registrationStatus = await ctx.runQuery(
+        internal.smsCompliance.getRegistrationStatusForBusiness,
+        {
+          businessId: args.businessId,
+        },
+      );
+      return {
+        registrationId: attempt.registrationId,
+        status: registrationStatus,
+      };
+    }
+
+    try {
+      return await runA2pSyncAction(ctx, {
+        businessId: args.businessId,
+        registrationId: attempt.registrationId,
+        submissionId: attempt.submissionId,
+        mode: "submit",
+      });
+    } catch (error) {
+      return await handleA2pSyncFailure(ctx, {
+        registrationId: attempt.registrationId,
+        submissionId: attempt.submissionId,
+        error,
+      });
+    }
+  },
+});
+
+export const resumeRegistration = action({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.object({
+    registrationId: v.id("sms_compliance_registrations"),
+    status: smsComplianceStatusValidator,
+  }),
+  handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    const attempt: BeginSubmissionAttemptResult = await ctx.runMutation(
+      internal.smsCompliance.beginSubmissionAttempt,
+      {
+      businessId: args.businessId,
+      },
+    );
+
+    if (!attempt.started || !attempt.submissionId) {
+      const registrationStatus = await ctx.runQuery(
+        internal.smsCompliance.getRegistrationStatusForBusiness,
+        {
+          businessId: args.businessId,
+        },
+      );
+      return {
+        registrationId: attempt.registrationId,
+        status: registrationStatus,
+      };
+    }
+
+    try {
+      return await runA2pSyncAction(ctx, {
+        businessId: args.businessId,
+        registrationId: attempt.registrationId,
+        submissionId: attempt.submissionId,
+        mode: "submit",
+      });
+    } catch (error) {
+      return await handleA2pSyncFailure(ctx, {
+        registrationId: attempt.registrationId,
+        submissionId: attempt.submissionId,
+        error,
+      });
+    }
+  },
+});
+
+export const refreshStatus = action({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.object({
+    registrationId: v.id("sms_compliance_registrations"),
+    status: smsComplianceStatusValidator,
+  }),
+  handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
+    const currentRegistration: Id<"sms_compliance_registrations"> | null = await ctx.runQuery(
+      internal.smsCompliance.getRegistrationIdForBusiness,
+      {
+        businessId: args.businessId,
+      },
+    );
+    if (!currentRegistration) {
+      throw new Error("SMS compliance registration has not been started for this workspace.");
+    }
+
+    try {
+      return await runA2pSyncAction(ctx, {
+        businessId: args.businessId,
+        registrationId: currentRegistration,
+        mode: "refresh",
+      });
+    } catch (error) {
+      return await handleA2pSyncFailure(ctx, {
+        registrationId: currentRegistration,
+        error,
+      });
+    }
+  },
+});
+
+export const getRegistrationIdForBusiness = internalQuery({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: v.union(v.id("sms_compliance_registrations"), v.null()),
+  handler: async (ctx, args) => {
+    const registration = await getSmsComplianceRegistration(ctx, args.businessId);
+    return registration?._id ?? null;
+  },
+});
+
+export const getRegistrationStatusForBusiness = internalQuery({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  returns: smsComplianceStatusValidator,
+  handler: async (ctx, args): Promise<SmsComplianceStatus> => {
+    const registration = await getSmsComplianceRegistration(ctx, args.businessId);
+    return registration?.status ?? "not_started";
+  },
+});

--- a/convex/smsCompliance.ts
+++ b/convex/smsCompliance.ts
@@ -154,6 +154,12 @@ function getPhoneNumberSelectionError(input: {
   return "Choose which active SMS-enabled business phone number should be registered for hosted AI SMS before continuing 10DLC registration.";
 }
 
+function hasOperationalApprovedPhoneNumber(
+  phoneNumber: SmsPhoneNumberDoc | null | undefined,
+): boolean {
+  return Boolean(phoneNumber && phoneNumber.status === "active" && phoneNumber.smsEnabled);
+}
+
 function deriveHostedSenderMode(input: {
   aiSmsCommerciallyEnabled: boolean;
   registration: Doc<"sms_compliance_registrations"> | null;
@@ -212,8 +218,16 @@ function canEditComplianceDraft(status: SmsComplianceStatus): boolean {
   return status === "not_started" || status === "collecting_info" || status === "failed";
 }
 
-function canUpdateApprovedPhoneNumber(status: SmsComplianceStatus): boolean {
-  return canEditComplianceDraft(status) || status === "pending_brand_verification";
+function canUpdateApprovedPhoneNumber(input: {
+  status: SmsComplianceStatus;
+  currentApprovedPhoneNumber?: SmsPhoneNumberDoc | null;
+}): boolean {
+  return (
+    canEditComplianceDraft(input.status) ||
+    input.status === "pending_brand_verification" ||
+    (input.status === "approved" &&
+      !hasOperationalApprovedPhoneNumber(input.currentApprovedPhoneNumber))
+  );
 }
 
 export const assertManagementAccess = internalQuery({
@@ -352,6 +366,10 @@ export const saveComplianceForm = mutation({
   handler: async (ctx, args): Promise<SmsComplianceActionResult> => {
     await requireSmsComplianceManagementAccess(ctx, args.businessId);
     const existingRegistration = await getSmsComplianceRegistration(ctx, args.businessId);
+    const currentApprovedPhoneNumber =
+      existingRegistration?.approvedPhoneNumberId !== undefined
+        ? await ctx.db.get(existingRegistration.approvedPhoneNumberId)
+        : null;
     const approvedPhoneNumber =
       args.approvedPhoneNumberId !== undefined
         ? await ctx.db.get(args.approvedPhoneNumberId)
@@ -369,7 +387,12 @@ export const saveComplianceForm = mutation({
     }
 
     if (existingRegistration) {
-      if (!canUpdateApprovedPhoneNumber(existingRegistration.status)) {
+      if (
+        !canUpdateApprovedPhoneNumber({
+          status: existingRegistration.status,
+          currentApprovedPhoneNumber,
+        })
+      ) {
         throw new Error(
           "10DLC registration can't be edited after submission starts. Refresh status instead.",
         );
@@ -378,7 +401,25 @@ export const saveComplianceForm = mutation({
         args.approvedPhoneNumberId ?? existingRegistration.approvedPhoneNumberId;
 
       if (!canEditComplianceDraft(existingRegistration.status)) {
+        const isRecoveringApprovedSender =
+          existingRegistration.status === "approved" &&
+          !hasOperationalApprovedPhoneNumber(currentApprovedPhoneNumber) &&
+          nextApprovedPhoneNumberId !== undefined &&
+          nextApprovedPhoneNumberId !== existingRegistration.approvedPhoneNumberId;
+
         await ctx.db.patch(existingRegistration._id, {
+          ...(isRecoveringApprovedSender
+            ? {
+                status: "pending_review",
+                pendingAction: {
+                  type: "phone_number_association",
+                  message:
+                    "Refresh the 10DLC registration to attach the new business phone number to the Messaging Service.",
+                },
+                failureCode: undefined,
+                failureMessage: undefined,
+              }
+            : {}),
           ...(nextApprovedPhoneNumberId
             ? { approvedPhoneNumberId: nextApprovedPhoneNumberId }
             : {}),
@@ -386,7 +427,7 @@ export const saveComplianceForm = mutation({
 
         return {
           registrationId: existingRegistration._id,
-          status: existingRegistration.status,
+          status: isRecoveringApprovedSender ? "pending_review" : existingRegistration.status,
         };
       }
 

--- a/convex/smsCompliance.ts
+++ b/convex/smsCompliance.ts
@@ -157,13 +157,16 @@ function getPhoneNumberSelectionError(input: {
 function deriveHostedSenderMode(input: {
   aiSmsCommerciallyEnabled: boolean;
   registration: Doc<"sms_compliance_registrations"> | null;
+  approvedPhoneNumber: SmsPhoneNumberDoc | null;
 }): "platform_phone" | "business_messaging_service" {
   if (
     input.aiSmsCommerciallyEnabled &&
     input.registration &&
     isSmsComplianceApproved(input.registration.status) &&
     input.registration.twilioMessagingServiceSid &&
-    input.registration.approvedPhoneNumberId
+    input.approvedPhoneNumber &&
+    input.approvedPhoneNumber.status === "active" &&
+    input.approvedPhoneNumber.smsEnabled
   ) {
     return "business_messaging_service";
   }
@@ -207,6 +210,10 @@ async function requireSmsComplianceManagementAccess(
 
 function canEditComplianceDraft(status: SmsComplianceStatus): boolean {
   return status === "not_started" || status === "collecting_info" || status === "failed";
+}
+
+function canUpdateApprovedPhoneNumber(status: SmsComplianceStatus): boolean {
+  return canEditComplianceDraft(status) || status === "pending_brand_verification";
 }
 
 export const assertManagementAccess = internalQuery({
@@ -266,18 +273,19 @@ export const getStatus = query({
       activeAddons: snapshot.activeAddons,
     });
     const applicable = snapshot.plan !== "self_host" && aiSmsCommerciallyEnabled;
+    const approvedPhoneNumber =
+      registration?.approvedPhoneNumberId !== undefined
+        ? phoneNumbers.find((phoneNumber) => phoneNumber._id === registration.approvedPhoneNumberId) ??
+          null
+        : null;
     const senderMode: SmsSenderMode =
       snapshot.plan === "self_host"
         ? "business_phone"
         : deriveHostedSenderMode({
             aiSmsCommerciallyEnabled,
             registration,
+            approvedPhoneNumber,
           });
-    const approvedPhoneNumber =
-      registration?.approvedPhoneNumberId !== undefined
-        ? phoneNumbers.find((phoneNumber) => phoneNumber._id === registration.approvedPhoneNumberId) ??
-          null
-        : null;
     const availablePhoneNumbers = getEligibleSmsPhoneNumbers(phoneNumbers).map((phoneNumber) => ({
       id: phoneNumber._id,
       e164: phoneNumber.e164,
@@ -361,13 +369,26 @@ export const saveComplianceForm = mutation({
     }
 
     if (existingRegistration) {
-      if (!canEditComplianceDraft(existingRegistration.status)) {
+      if (!canUpdateApprovedPhoneNumber(existingRegistration.status)) {
         throw new Error(
           "10DLC registration can't be edited after submission starts. Refresh status instead.",
         );
       }
       const nextApprovedPhoneNumberId =
         args.approvedPhoneNumberId ?? existingRegistration.approvedPhoneNumberId;
+
+      if (!canEditComplianceDraft(existingRegistration.status)) {
+        await ctx.db.patch(existingRegistration._id, {
+          ...(nextApprovedPhoneNumberId
+            ? { approvedPhoneNumberId: nextApprovedPhoneNumberId }
+            : {}),
+        });
+
+        return {
+          registrationId: existingRegistration._id,
+          status: existingRegistration.status,
+        };
+      }
 
       await ctx.db.patch(existingRegistration._id, {
         draft: args.draft,

--- a/convex/smsCompliance.ts
+++ b/convex/smsCompliance.ts
@@ -960,7 +960,10 @@ export const refreshStatus = action({
           businessId: args.businessId,
         },
       );
-      if (isSmsComplianceApproved(persistedStatus)) {
+      if (
+        isSmsComplianceApproved(persistedStatus) ||
+        persistedStatus === "suspended"
+      ) {
         return {
           registrationId: currentRegistration,
           status: persistedStatus,

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -214,6 +214,56 @@ async function seedUsageAnchors(
   };
 }
 
+async function seedBusinessPhoneNumber(
+  ctx: TestContext,
+  input: {
+    businessId: Id<"businesses">;
+    e164?: string;
+    twilioPhoneSid?: string;
+  },
+): Promise<Id<"phone_numbers">> {
+  return await ctx.db.insert("phone_numbers", {
+    businessId: input.businessId,
+    e164: input.e164 ?? "+14165550111",
+    twilioPhoneSid: input.twilioPhoneSid ?? "PN-billing-phone",
+    voiceEnabled: true,
+    smsEnabled: true,
+    status: "active",
+  });
+}
+
+async function seedSmsComplianceRegistration(
+  ctx: TestContext,
+  input: {
+    businessId: Id<"businesses">;
+    status:
+      | "pending_brand_verification"
+      | "pending_review"
+      | "approved"
+      | "failed";
+    approvedPhoneNumberId?: Id<"phone_numbers">;
+    twilioMessagingServiceSid?: string;
+  },
+): Promise<Id<"sms_compliance_registrations">> {
+  return await ctx.db.insert("sms_compliance_registrations", {
+    businessId: input.businessId,
+    status: input.status,
+    customerType: "direct_customer",
+    brandKind: "standard_business",
+    trafficTier: "low_volume",
+    draft: {
+      businessName: "Billing Workspace LLC",
+      websiteUrl: "https://example.com",
+    },
+    ...(input.approvedPhoneNumberId
+      ? { approvedPhoneNumberId: input.approvedPhoneNumberId }
+      : {}),
+    ...(input.twilioMessagingServiceSid
+      ? { twilioMessagingServiceSid: input.twilioMessagingServiceSid }
+      : {}),
+  });
+}
+
 describe("billing", () => {
   it("returns Free Cloud entitlements with no AI SMS and no overages", async () => {
     process.env.POLAR_PRO_PRODUCT_ID = "prod_pro";
@@ -374,9 +424,10 @@ describe("billing", () => {
       monthlyChargeCents: 1_500,
       canPurchaseAiSmsAddon: true,
     });
-    expect(beforePolicy).toEqual({
+    expect(beforePolicy).toMatchObject({
       allowed: false,
       senderRole: "business_ai",
+      senderMode: "platform_phone",
       errorCode: "ai_sms_not_enabled",
     });
 
@@ -407,9 +458,115 @@ describe("billing", () => {
       monthlyChargeCents: 2_000,
       canPurchaseAiSmsAddon: false,
     });
-    expect(afterPolicy).toEqual({
+    expect(afterPolicy).toMatchObject({
+      allowed: false,
+      senderRole: "business_ai",
+      senderMode: "platform_phone",
+      errorCode: null,
+    });
+  });
+
+  it("keeps hosted alerts on the platform sender while AI SMS compliance is pending", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-hosted-pending-compliance",
+      deploymentMode: "cloud",
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+        activeAddons: ["ai_sms"],
+      });
+      const phoneNumberId = await seedBusinessPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550122",
+        twilioPhoneSid: "PN-pending-compliance",
+      });
+      await seedSmsComplianceRegistration(ctx, {
+        businessId,
+        status: "pending_review",
+        approvedPhoneNumberId: phoneNumberId,
+      });
+    });
+
+    const alertPolicy = await t.query(internal.billing.getSmsCapabilityPolicy, {
+      businessId,
+      capability: "alert",
+    });
+    const aiPolicy = await t.query(internal.billing.getSmsCapabilityPolicy, {
+      businessId,
+      capability: "ai",
+    });
+
+    expect(alertPolicy).toMatchObject({
+      allowed: true,
+      senderRole: "platform_alert",
+      senderMode: "platform_phone",
+      complianceStatus: "pending_review",
+      errorCode: null,
+    });
+    expect(aiPolicy).toMatchObject({
+      allowed: false,
+      senderRole: "business_ai",
+      senderMode: "platform_phone",
+      complianceStatus: "pending_review",
+      errorCode: null,
+    });
+  });
+
+  it("routes approved hosted AI SMS through the business messaging service", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-hosted-approved-compliance",
+      deploymentMode: "cloud",
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+        activeAddons: ["ai_sms"],
+      });
+      const phoneNumberId = await seedBusinessPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550133",
+        twilioPhoneSid: "PN-approved-compliance",
+      });
+      await seedSmsComplianceRegistration(ctx, {
+        businessId,
+        status: "approved",
+        approvedPhoneNumberId: phoneNumberId,
+        twilioMessagingServiceSid: "MG-approved-compliance",
+      });
+    });
+
+    const alertPolicy = await t.query(internal.billing.getSmsCapabilityPolicy, {
+      businessId,
+      capability: "alert",
+    });
+    const aiPolicy = await t.query(internal.billing.getSmsCapabilityPolicy, {
+      businessId,
+      capability: "ai",
+    });
+
+    expect(alertPolicy).toMatchObject({
+      allowed: true,
+      senderRole: "platform_alert",
+      senderMode: "business_messaging_service",
+      fromPhoneNumber: "+14165550133",
+      twilioMessagingServiceSid: "MG-approved-compliance",
+      complianceStatus: "approved",
+      errorCode: null,
+    });
+    expect(aiPolicy).toMatchObject({
       allowed: true,
       senderRole: "business_ai",
+      senderMode: "business_messaging_service",
+      fromPhoneNumber: "+14165550133",
+      twilioMessagingServiceSid: "MG-approved-compliance",
+      complianceStatus: "approved",
       errorCode: null,
     });
   });
@@ -527,9 +684,10 @@ describe("billing", () => {
       alertSmsBlocked: true,
       outboundCallAttemptsBlocked: true,
     });
-    expect(alertPolicy).toEqual({
+    expect(alertPolicy).toMatchObject({
       allowed: false,
       senderRole: "platform_alert",
+      senderMode: "platform_phone",
       errorCode: "alert_sms_limit_reached",
     });
     expect(voicePolicy).toEqual({
@@ -1267,6 +1425,17 @@ describe("billing", () => {
         currentPlan: "pro",
         activeAddons: ["ai_sms"],
       });
+      const phoneNumberId = await seedBusinessPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550144",
+        twilioPhoneSid: "PN-pro-overages",
+      });
+      await seedSmsComplianceRegistration(ctx, {
+        businessId,
+        status: "approved",
+        approvedPhoneNumberId: phoneNumberId,
+        twilioMessagingServiceSid: "MG-pro-overages",
+      });
     });
     const anchors = await t.run(async (ctx: TestContext) => {
       return await seedUsageAnchors(ctx, { businessId });
@@ -1340,14 +1509,18 @@ describe("billing", () => {
       alertSmsBlocked: false,
       outboundCallAttemptsBlocked: false,
     });
-    expect(alertPolicy).toEqual({
+    expect(alertPolicy).toMatchObject({
       allowed: true,
       senderRole: "platform_alert",
+      senderMode: "business_messaging_service",
+      twilioMessagingServiceSid: "MG-pro-overages",
       errorCode: null,
     });
-    expect(aiPolicy).toEqual({
+    expect(aiPolicy).toMatchObject({
       allowed: true,
       senderRole: "business_ai",
+      senderMode: "business_messaging_service",
+      twilioMessagingServiceSid: "MG-pro-overages",
       errorCode: null,
     });
     expect(voicePolicy).toEqual({

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -280,6 +280,7 @@ describe("billing", () => {
     expect(status).toMatchObject({
       plan: "free_cloud",
       aiSmsEnabled: false,
+      aiSmsReady: false,
       overagesBillable: false,
       monthlyChargeCents: 0,
       includedBusinessNumbers: 0,
@@ -312,6 +313,7 @@ describe("billing", () => {
     expect(status).toMatchObject({
       plan: "self_host",
       aiSmsEnabled: true,
+      aiSmsReady: true,
       overagesBillable: false,
       monthlyChargeCents: 0,
       hasCheckoutAccess: false,
@@ -420,6 +422,7 @@ describe("billing", () => {
     expect(beforeAddon).toMatchObject({
       plan: "pro",
       aiSmsEnabled: false,
+      aiSmsReady: false,
       overagesBillable: true,
       monthlyChargeCents: 1_500,
       canPurchaseAiSmsAddon: true,
@@ -455,6 +458,7 @@ describe("billing", () => {
     expect(afterAddon).toMatchObject({
       plan: "pro",
       aiSmsEnabled: true,
+      aiSmsReady: false,
       monthlyChargeCents: 2_000,
       canPurchaseAiSmsAddon: false,
     });
@@ -518,7 +522,7 @@ describe("billing", () => {
 
   it("routes approved hosted AI SMS through the business messaging service", async () => {
     const t = convexTest(schema, convexModules);
-    const { businessId } = await seedWorkspace(t, {
+    const { authed, businessId } = await seedWorkspace(t, {
       subject: "billing-hosted-approved-compliance",
       deploymentMode: "cloud",
     });
@@ -550,6 +554,7 @@ describe("billing", () => {
       businessId,
       capability: "ai",
     });
+    const status = await authed.query(api.billing.getStatus, { businessId });
 
     expect(alertPolicy).toMatchObject({
       allowed: true,
@@ -569,6 +574,72 @@ describe("billing", () => {
       complianceStatus: "approved",
       errorCode: null,
     });
+    expect(status).toMatchObject({
+      aiSmsEnabled: true,
+      aiSmsReady: true,
+    });
+  });
+
+  it("falls back to the platform route when the approved business sender is no longer active", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-hosted-inactive-approved-sender",
+      deploymentMode: "cloud",
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+        activeAddons: ["ai_sms"],
+      });
+      const approvedPhoneNumberId = await seedBusinessPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550134",
+        twilioPhoneSid: "PN-inactive-approved-sender",
+      });
+      await seedBusinessPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550135",
+        twilioPhoneSid: "PN-active-alternate-sender",
+      });
+      await seedSmsComplianceRegistration(ctx, {
+        businessId,
+        status: "approved",
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-inactive-approved-sender",
+      });
+      await ctx.db.patch(approvedPhoneNumberId, {
+        status: "inactive",
+      });
+    });
+
+    const alertPolicy = await t.query(internal.billing.getSmsCapabilityPolicy, {
+      businessId,
+      capability: "alert",
+    });
+    const aiPolicy = await t.query(internal.billing.getSmsCapabilityPolicy, {
+      businessId,
+      capability: "ai",
+    });
+
+    expect(alertPolicy).toMatchObject({
+      allowed: true,
+      senderRole: "platform_alert",
+      senderMode: "platform_phone",
+      complianceStatus: "approved",
+      errorCode: null,
+    });
+    expect(alertPolicy.twilioMessagingServiceSid).toBeUndefined();
+    expect(aiPolicy).toMatchObject({
+      allowed: false,
+      senderRole: "business_ai",
+      senderMode: "platform_phone",
+      complianceStatus: "approved",
+      errorCode: null,
+    });
+    expect(aiPolicy.fromPhoneNumber).toBeUndefined();
+    expect(aiPolicy.twilioMessagingServiceSid).toBeUndefined();
   });
 
   it("recomputes alert sms entitlement from the current plan after an upgrade", async () => {

--- a/convex/tests/dashboardSmsReply.test.ts
+++ b/convex/tests/dashboardSmsReply.test.ts
@@ -39,7 +39,12 @@ type TestContext = Parameters<TestRunFunction>[0];
 
 async function seedSmsConversation(
   t: ConvexHarness,
-  input: { subject: string; blocked?: boolean; optedOut?: boolean },
+  input: {
+    subject: string;
+    blocked?: boolean;
+    optedOut?: boolean;
+    deploymentMode?: "cloud" | "manual";
+  },
 ) {
   const seeded = await t.run(async (ctx) => {
     const businessId = await ctx.db.insert("businesses", {
@@ -48,7 +53,7 @@ async function seedSmsConversation(
       timezone: "America/Toronto",
       businessType: "clinic",
       defaultLocale: "en",
-      deploymentMode: "manual",
+      deploymentMode: input.deploymentMode ?? "manual",
       status: "active",
     });
     const userId = await ctx.db.insert("users", {
@@ -260,6 +265,78 @@ describe("Dashboard SMS replies", () => {
       from: "+14165550121",
       body: "Replying from the same number",
       statusCallback: "https://example.convex.site/twilio/sms/status",
+    });
+  });
+
+  it("uses the approved business sender for hosted replies after 10DLC approval", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId, conversationId } = await seedSmsConversation(t, {
+      subject: "dashboard-sms-reply-approved-sender",
+      deploymentMode: "cloud",
+    });
+
+    await t.run(async (ctx) => {
+      const approvedPhoneNumberId = await ctx.db.insert("phone_numbers", {
+        businessId,
+        e164: "+14165550121",
+        voiceEnabled: true,
+        smsEnabled: true,
+        status: "active",
+      });
+      await ctx.db.insert("billing_accounts", {
+        businessId,
+        billingKey: `business:${String(businessId)}`,
+        currentPlan: "pro",
+        activeAddons: ["ai_sms"],
+        subscriptionState: "active",
+        billingContactEmail: "owner@example.com",
+        billingContactName: "Dashboard Reply Owner",
+        lastSyncedAt: "2026-04-18T12:00:00.000Z",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "approved",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: {
+          businessName: "Dashboard SMS Reply Business",
+          websiteUrl: "https://example.com",
+        },
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-dashboard-approved",
+      });
+      await ctx.db.insert("messages", {
+        businessId,
+        conversationId,
+        direction: "outbound",
+        channel: "sms",
+        body: "Earlier reply from the old sender",
+        fromPhoneNumber: "+14165550120",
+        status: "sent",
+        aiGenerated: false,
+      });
+    });
+
+    const result = await authed.action(api.dashboard.messages.sendSmsReply, {
+      businessId,
+      conversationId,
+      body: "Use the approved sender",
+    });
+
+    expect(sendTwilioMessageMock).toHaveBeenCalledWith({
+      to: "+14165550198",
+      from: "+14165550121",
+      messagingServiceSid: "MG-dashboard-approved",
+      body: "Use the approved sender",
+      statusCallback: "https://example.convex.site/twilio/sms/status",
+    });
+
+    await t.run(async (ctx) => {
+      const outbound = await ctx.db.get("messages", result.messageId);
+      expect(outbound).toMatchObject({
+        fromPhoneNumber: "+14165550121",
+      });
     });
   });
 

--- a/convex/tests/smsCompliance.test.ts
+++ b/convex/tests/smsCompliance.test.ts
@@ -1,0 +1,402 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { syncRegistrationMock } = vi.hoisted(() => ({
+  syncRegistrationMock: vi.fn(),
+}));
+
+vi.mock("../integrations/twilioA2p.ts", async () => {
+  const actual = await vi.importActual<typeof import("../integrations/twilioA2p")>(
+    "../integrations/twilioA2p.ts",
+  );
+  const { internalAction } = await import("../_generated/server");
+  const { v } = await import("convex/values");
+
+  return {
+    ...actual,
+    syncRegistration: internalAction({
+      args: {
+        registrationId: v.id("sms_compliance_registrations"),
+        mode: v.union(v.literal("submit"), v.literal("refresh")),
+      },
+      handler: async (_ctx, args) => {
+        return await syncRegistrationMock(args);
+      },
+    }),
+  };
+});
+
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { getBillingKey } from "../lib/billing";
+import type { SmsComplianceDraft } from "../lib/smsCompliance";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+type ConvexHarness = TestConvex<typeof schema>;
+type TestRunFunction = Parameters<ConvexHarness["run"]>[0];
+type TestContext = Parameters<TestRunFunction>[0];
+
+const convexModules = modules;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function seedWorkspace(
+  t: ConvexHarness,
+  subject: string,
+): Promise<{
+  authed: ReturnType<ConvexHarness["withIdentity"]>;
+  businessId: Id<"businesses">;
+}> {
+  const seeded = await t.run(async (ctx: TestContext) => {
+    const businessId: Id<"businesses"> = await ctx.db.insert("businesses", {
+      slug: `sms-compliance-${subject}`,
+      name: "SMS Compliance Test Workspace",
+      timezone: "America/Toronto",
+      businessType: "clinic",
+      defaultLocale: "en",
+      deploymentMode: "cloud",
+      status: "active",
+    });
+    const userId: Id<"users"> = await ctx.db.insert("users", {
+      authSubject: subject,
+      email: `${subject}@example.com`,
+      displayName: "SMS Compliance Owner",
+    });
+    await ctx.db.insert("business_memberships", {
+      businessId,
+      userId,
+      role: "business_owner",
+      status: "active",
+    });
+
+    return { businessId };
+  });
+
+  return {
+    ...seeded,
+    authed: t.withIdentity({ subject }),
+  };
+}
+
+async function seedBillingAccount(
+  ctx: TestContext,
+  businessId: Id<"businesses">,
+): Promise<void> {
+  await ctx.db.insert("billing_accounts", {
+    businessId,
+    billingKey: getBillingKey(businessId),
+    currentPlan: "pro",
+    activeAddons: ["ai_sms"],
+    subscriptionState: "active",
+    billingContactEmail: "owner@example.com",
+    billingContactName: "SMS Compliance Owner",
+    lastSyncedAt: "2026-04-17T12:00:00.000Z",
+  });
+}
+
+async function seedSmsPhoneNumber(
+  ctx: TestContext,
+  input: {
+    businessId: Id<"businesses">;
+    e164: string;
+    twilioPhoneSid: string;
+  },
+): Promise<Id<"phone_numbers">> {
+  return await ctx.db.insert("phone_numbers", {
+    businessId: input.businessId,
+    e164: input.e164,
+    twilioPhoneSid: input.twilioPhoneSid,
+    voiceEnabled: true,
+    smsEnabled: true,
+    status: "active",
+  });
+}
+
+function buildValidDraft(): SmsComplianceDraft {
+  return {
+    businessName: "Acme Clinic LLC",
+    businessType: "Corporation",
+    businessIndustry: "HEALTHCARE",
+    businessRegistrationIdentifier: "EIN",
+    businessRegistrationNumber: "12-3456789",
+    websiteUrl: "https://example.com",
+    businessRegionsOfOperation: ["USA_AND_CANADA"],
+    companyType: "private",
+    brandContactEmail: "ops@example.com",
+    campaignDescription: "Appointment alerts and AI SMS replies.",
+    messageFlow: "Customers opt in via online booking forms and intake paperwork.",
+    sampleMessages: [
+      "Acme Clinic: your appointment is tomorrow at 2 PM.",
+      "Acme Clinic: reply YES to confirm or STOP to unsubscribe.",
+    ],
+    hasEmbeddedLinks: false,
+    hasEmbeddedPhone: true,
+    optInMessage: "Reply START to opt in.",
+    optOutMessage: "Reply STOP to unsubscribe.",
+    helpMessage: "Reply HELP for support.",
+    optInKeywords: ["START"],
+    optOutKeywords: ["STOP"],
+    helpKeywords: ["HELP"],
+    address: {
+      customerName: "Acme Clinic LLC",
+      street: "123 Main Street",
+      city: "Toronto",
+      region: "ON",
+      postalCode: "M5V 2T6",
+      isoCountry: "CA",
+    },
+    authorizedRepresentative: {
+      firstName: "Jordan",
+      lastName: "Lee",
+      businessTitle: "Operations Manager",
+      jobPosition: "Director",
+      phoneNumber: "+14165550188",
+      email: "jordan@example.com",
+    },
+  };
+}
+
+describe("smsCompliance", () => {
+  it("reports setup required for hosted AI SMS workspaces until approval", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-setup-required");
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550170",
+        twilioPhoneSid: "PN-sms-compliance-setup-required",
+      });
+    });
+
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+    const campaignOptions = await authed.query(api.smsCompliance.getCampaignOptions, {});
+
+    expect(status).toMatchObject({
+      applicable: true,
+      aiSmsCommerciallyEnabled: true,
+      alertsUseBusinessSender: false,
+      aiSmsReady: false,
+      setupRequired: true,
+      senderMode: "platform_phone",
+      status: "not_started",
+      trafficTier: "low_volume",
+    });
+    expect(campaignOptions).toEqual([
+      {
+        value: "low_volume",
+        twilioUsecaseCode: "LOW_VOLUME",
+        recommended: true,
+      },
+      {
+        value: "mixed",
+        twilioUsecaseCode: "MIXED",
+        recommended: false,
+      },
+    ]);
+  });
+
+  it("starts registration, stores a submission snapshot, and remains on the platform sender while pending review", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-start");
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550171",
+        twilioPhoneSid: "PN-sms-compliance-start",
+      });
+    });
+    await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "mixed",
+      draft: buildValidDraft(),
+    });
+    syncRegistrationMock.mockResolvedValue({
+      status: "pending_review",
+      trafficTier: "mixed",
+      twilioCustomerProfileSid: "BU-pending-review",
+      twilioTrustProductSid: "TP-pending-review",
+      twilioBrandRegistrationSid: "BN-pending-review",
+      twilioMessagingServiceSid: "MG-pending-review",
+      twilioCampaignSid: "QE-pending-review",
+      brandContactEmail: "ops@example.com",
+      lastSubmittedAt: "2026-04-17T15:00:00.000Z",
+      lastSyncedAt: "2026-04-17T15:00:00.000Z",
+    });
+
+    const result = await authed.action(api.smsCompliance.startRegistration, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+    const submission = await t.run(async (ctx: TestContext) => {
+      return await ctx.db
+        .query("sms_compliance_submissions")
+        .withIndex("by_business_id", (q) => q.eq("businessId", businessId))
+        .unique();
+    });
+
+    expect(result).toMatchObject({
+      status: "pending_review",
+    });
+    expect(syncRegistrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "submit",
+      }),
+    );
+    expect(status).toMatchObject({
+      status: "pending_review",
+      senderMode: "platform_phone",
+      trafficTier: "mixed",
+      setupRequired: false,
+      alertsUseBusinessSender: false,
+      aiSmsReady: false,
+      twilioMessagingServiceSid: "MG-pending-review",
+    });
+    expect(submission).toMatchObject({
+      status: "pending_review",
+      resultStatus: "pending_review",
+      trafficTier: "mixed",
+      twilioBrandRegistrationSid: "BN-pending-review",
+      twilioMessagingServiceSid: "MG-pending-review",
+      snapshot: {
+        trafficTier: "mixed",
+        draft: expect.objectContaining({
+          businessName: "Acme Clinic LLC",
+        }),
+      },
+    });
+  });
+
+  it("resumes OTP-gated registration and cuts over to the business messaging service after approval", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-resume");
+
+    const phoneNumberId = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      return await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550172",
+        twilioPhoneSid: "PN-sms-compliance-resume",
+      });
+    });
+    const saved = await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      draft: buildValidDraft(),
+    });
+    await t.run(async (ctx: TestContext) => {
+      await ctx.db.patch(saved.registrationId, {
+        status: "pending_brand_verification",
+        approvedPhoneNumberId: phoneNumberId,
+        pendingAction: {
+          type: "brand_contact_email_otp",
+          message: "Enter the verification code sent to ops@example.com.",
+        },
+      });
+    });
+    syncRegistrationMock.mockResolvedValue({
+      status: "approved",
+      trafficTier: "low_volume",
+      approvedPhoneNumberId: phoneNumberId,
+      twilioMessagingServiceSid: "MG-approved",
+      twilioCampaignSid: "QE-approved",
+      twilioBrandRegistrationSid: "BN-approved",
+      lastSubmittedAt: "2026-04-17T16:00:00.000Z",
+      lastSyncedAt: "2026-04-17T16:15:00.000Z",
+    });
+
+    const result = await authed.action(api.smsCompliance.resumeRegistration, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(result).toMatchObject({
+      status: "approved",
+    });
+    expect(syncRegistrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "submit",
+      }),
+    );
+    expect(status).toMatchObject({
+      status: "approved",
+      senderMode: "business_messaging_service",
+      alertsUseBusinessSender: true,
+      aiSmsReady: true,
+      approvedPhoneNumberE164: "+14165550172",
+      twilioMessagingServiceSid: "MG-approved",
+    });
+  });
+
+  it("refreshes registration state and surfaces campaign rejection without cutting over traffic", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh");
+
+    const phoneNumberId = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      return await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550173",
+        twilioPhoneSid: "PN-sms-compliance-refresh",
+      });
+    });
+    const saved = await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      draft: buildValidDraft(),
+    });
+    await t.run(async (ctx: TestContext) => {
+      await ctx.db.patch(saved.registrationId, {
+        status: "pending_review",
+        approvedPhoneNumberId: phoneNumberId,
+        twilioMessagingServiceSid: "MG-refresh",
+      });
+    });
+    syncRegistrationMock.mockResolvedValue({
+      status: "failed",
+      trafficTier: "low_volume",
+      approvedPhoneNumberId: phoneNumberId,
+      twilioMessagingServiceSid: "MG-refresh",
+      failureCode: "campaign_rejected",
+      failureMessage: "Campaign rejected by TCR.",
+      pendingAction: {
+        type: "campaign_review",
+        message: "Campaign rejected by TCR.",
+      },
+      lastSyncedAt: "2026-04-17T17:00:00.000Z",
+    });
+
+    const result = await authed.action(api.smsCompliance.refreshStatus, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(result).toMatchObject({
+      status: "failed",
+    });
+    expect(syncRegistrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "refresh",
+      }),
+    );
+    expect(status).toMatchObject({
+      status: "failed",
+      senderMode: "platform_phone",
+      alertsUseBusinessSender: false,
+      aiSmsReady: false,
+      failureCode: "campaign_rejected",
+      failureMessage: "Campaign rejected by TCR.",
+      pendingAction: {
+        type: "campaign_review",
+        message: "Campaign rejected by TCR.",
+      },
+      twilioMessagingServiceSid: "MG-refresh",
+    });
+  });
+});

--- a/convex/tests/smsCompliance.test.ts
+++ b/convex/tests/smsCompliance.test.ts
@@ -764,6 +764,67 @@ describe("smsCompliance", () => {
     expect(status.approvedPhoneNumberId).not.toBe(inactiveApprovedPhoneNumberId);
   });
 
+  it("allows replacing an approved sender after the current number becomes inactive", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-approved-number-recovery",
+    );
+
+    const { activeReplacementPhoneNumberId } = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      const inactiveApprovedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550187",
+        twilioPhoneSid: "PN-sms-compliance-approved-old",
+      });
+      const activeReplacementPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550188",
+        twilioPhoneSid: "PN-sms-compliance-approved-new",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "approved",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+        approvedPhoneNumberId: inactiveApprovedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-sms-compliance-approved-recovery",
+      });
+      await ctx.db.patch(inactiveApprovedPhoneNumberId, {
+        status: "inactive",
+      });
+
+      return { activeReplacementPhoneNumberId };
+    });
+
+    const saved = await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      approvedPhoneNumberId: activeReplacementPhoneNumberId,
+      draft: buildValidDraft(),
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(saved).toMatchObject({
+      status: "pending_review",
+    });
+    expect(status).toMatchObject({
+      status: "pending_review",
+      senderMode: "platform_phone",
+      approvedPhoneNumberId: activeReplacementPhoneNumberId,
+      approvedPhoneNumberE164: "+14165550188",
+      aiSmsReady: false,
+      pendingAction: {
+        type: "phone_number_association",
+        message:
+          "Refresh the 10DLC registration to attach the new business phone number to the Messaging Service.",
+      },
+    });
+  });
+
   it("keeps approved registrations approved when refresh throws before syncing", async () => {
     const t = convexTest(schema, convexModules);
     const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh-approved");
@@ -810,6 +871,51 @@ describe("smsCompliance", () => {
     expect(status.failureCode).toBeUndefined();
     expect(status.failureMessage).toBeUndefined();
     expect(status.pendingAction).toBeUndefined();
+  });
+
+  it("marks pending registrations as failed when refresh throws before syncing", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh-failure");
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      const approvedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550189",
+        twilioPhoneSid: "PN-sms-compliance-refresh-failure",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "pending_review",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+        approvedPhoneNumberId,
+        twilioBrandRegistrationSid: "BN-refresh-failure",
+        twilioMessagingServiceSid: "MG-refresh-failure",
+        twilioCampaignSid: "QE-refresh-failure",
+      });
+    });
+    syncRegistrationMock.mockRejectedValueOnce(new Error("Twilio timeout"));
+
+    const result = await authed.action(api.smsCompliance.refreshStatus, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(result).toMatchObject({
+      status: "failed",
+    });
+    expect(status).toMatchObject({
+      status: "failed",
+      failureCode: "twilio_sync_failed",
+      failureMessage: "Twilio timeout",
+      pendingAction: {
+        type: "manual_review",
+        message: "Twilio timeout",
+      },
+    });
   });
 
   it("rejects status refreshes from users outside the workspace", async () => {

--- a/convex/tests/smsCompliance.test.ts
+++ b/convex/tests/smsCompliance.test.ts
@@ -46,6 +46,7 @@ afterEach(() => {
 async function seedWorkspace(
   t: ConvexHarness,
   subject: string,
+  role: "business_owner" | "business_admin" | "scheduler" | "viewer" = "business_owner",
 ): Promise<{
   authed: ReturnType<ConvexHarness["withIdentity"]>;
   businessId: Id<"businesses">;
@@ -68,7 +69,7 @@ async function seedWorkspace(
     await ctx.db.insert("business_memberships", {
       businessId,
       userId,
-      role: "business_owner",
+      role,
       status: "active",
     });
 
@@ -198,6 +199,256 @@ describe("smsCompliance", () => {
         recommended: false,
       },
     ]);
+  });
+
+  it("requires an explicit approved phone number when multiple active SMS lines exist", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-multi-number");
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550175",
+        twilioPhoneSid: "PN-sms-compliance-multi-number-1",
+      });
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550176",
+        twilioPhoneSid: "PN-sms-compliance-multi-number-2",
+      });
+    });
+
+    await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      draft: buildValidDraft(),
+    });
+
+    await expect(
+      authed.action(api.smsCompliance.startRegistration, {
+        businessId,
+      }),
+    ).rejects.toThrow(
+      "Choose which active SMS-enabled business phone number should be registered for hosted AI SMS before continuing 10DLC registration.",
+    );
+    expect(syncRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  it("requires admin access to read SMS compliance status", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-viewer-read",
+      "viewer",
+    );
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550179",
+        twilioPhoneSid: "PN-sms-compliance-viewer-read",
+      });
+    });
+
+    await expect(
+      authed.query(api.smsCompliance.getStatus, {
+        businessId,
+      }),
+    ).rejects.toThrow("Billing management requires admin access.");
+  });
+
+  it("requires admin access to save or submit SMS compliance registration", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-viewer-write",
+      "viewer",
+    );
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550180",
+        twilioPhoneSid: "PN-sms-compliance-viewer-write",
+      });
+    });
+
+    await expect(
+      authed.mutation(api.smsCompliance.saveComplianceForm, {
+        businessId,
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+      }),
+    ).rejects.toThrow("Billing management requires admin access.");
+
+    await expect(
+      authed.action(api.smsCompliance.startRegistration, {
+        businessId,
+      }),
+    ).rejects.toThrow("Billing management requires admin access.");
+    expect(syncRegistrationMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the selected approved phone number when multiple active SMS lines exist", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-selected-number",
+    );
+
+    const selectedPhoneNumberId = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550177",
+        twilioPhoneSid: "PN-sms-compliance-selected-number-1",
+      });
+      return await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550178",
+        twilioPhoneSid: "PN-sms-compliance-selected-number-2",
+      });
+    });
+
+    await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "mixed",
+      approvedPhoneNumberId: selectedPhoneNumberId,
+      draft: buildValidDraft(),
+    });
+    syncRegistrationMock.mockResolvedValue({
+      status: "pending_review",
+      trafficTier: "mixed",
+      twilioCustomerProfileSid: "BU-selected-number",
+      twilioTrustProductSid: "TP-selected-number",
+      twilioBrandRegistrationSid: "BN-selected-number",
+      twilioMessagingServiceSid: "MG-selected-number",
+      twilioCampaignSid: "QE-selected-number",
+      lastSubmittedAt: "2026-04-17T14:00:00.000Z",
+      lastSyncedAt: "2026-04-17T14:00:00.000Z",
+    });
+
+    await authed.action(api.smsCompliance.startRegistration, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(status).toMatchObject({
+      status: "pending_review",
+      approvedPhoneNumberId: selectedPhoneNumberId,
+      approvedPhoneNumberE164: "+14165550178",
+      twilioMessagingServiceSid: "MG-selected-number",
+    });
+  });
+
+  it("rejects draft edits after submission has started", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-read-only-after-submit");
+
+    const phoneNumberId = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      return await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550181",
+        twilioPhoneSid: "PN-sms-compliance-read-only-after-submit",
+      });
+    });
+
+    const saved = await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      approvedPhoneNumberId: phoneNumberId,
+      draft: buildValidDraft(),
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await ctx.db.patch(saved.registrationId, {
+        status: "pending_review",
+      });
+    });
+
+    await expect(
+      authed.mutation(api.smsCompliance.saveComplianceForm, {
+        businessId,
+        trafficTier: "mixed",
+        approvedPhoneNumberId: phoneNumberId,
+        draft: {
+          ...buildValidDraft(),
+          businessName: "Updated After Submission",
+        },
+      }),
+    ).rejects.toThrow(
+      "10DLC registration can't be edited after submission starts. Refresh status instead.",
+    );
+
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(status).toMatchObject({
+      status: "pending_review",
+      trafficTier: "low_volume",
+      draft: expect.objectContaining({
+        businessName: "Acme Clinic LLC",
+      }),
+    });
+  });
+
+  it("clears stale failure details when a failed draft is edited", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-clear-failure");
+
+    const phoneNumberId = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      return await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550182",
+        twilioPhoneSid: "PN-sms-compliance-clear-failure",
+      });
+    });
+
+    const saved = await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      approvedPhoneNumberId: phoneNumberId,
+      draft: buildValidDraft(),
+    });
+
+    await t.run(async (ctx: TestContext) => {
+      await ctx.db.patch(saved.registrationId, {
+        status: "failed",
+        failureCode: "campaign_rejected",
+        failureMessage: "Campaign rejected by TCR.",
+        pendingAction: {
+          type: "campaign_review",
+          message: "Campaign rejected by TCR.",
+        },
+      });
+    });
+
+    await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "mixed",
+      approvedPhoneNumberId: phoneNumberId,
+      draft: {
+        ...buildValidDraft(),
+        campaignDescription: "Updated compliance copy after the rejection.",
+      },
+    });
+
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(status).toMatchObject({
+      status: "collecting_info",
+      trafficTier: "mixed",
+      draft: expect.objectContaining({
+        campaignDescription: "Updated compliance copy after the rejection.",
+      }),
+    });
+    expect(status.failureCode).toBeUndefined();
+    expect(status.failureMessage).toBeUndefined();
+    expect(status.pendingAction).toBeUndefined();
   });
 
   it("starts registration, stores a submission snapshot, and remains on the platform sender while pending review", async () => {
@@ -398,5 +649,88 @@ describe("smsCompliance", () => {
       },
       twilioMessagingServiceSid: "MG-refresh",
     });
+  });
+
+  it("keeps approved registrations approved when refresh throws before syncing", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh-approved");
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      const approvedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550183",
+        twilioPhoneSid: "PN-sms-compliance-refresh-approved",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "approved",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-refresh-approved",
+      });
+    });
+    syncRegistrationMock.mockRejectedValueOnce(
+      new Error("The approved business phone number is no longer active."),
+    );
+
+    const result = await authed.action(api.smsCompliance.refreshStatus, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(result).toMatchObject({
+      status: "approved",
+    });
+    expect(syncRegistrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "refresh",
+      }),
+    );
+    expect(status).toMatchObject({
+      status: "approved",
+      twilioMessagingServiceSid: "MG-refresh-approved",
+    });
+    expect(status.failureCode).toBeUndefined();
+    expect(status.failureMessage).toBeUndefined();
+    expect(status.pendingAction).toBeUndefined();
+  });
+
+  it("rejects status refreshes from users outside the workspace", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, "sms-compliance-refresh-target");
+    const { authed: outsider } = await seedWorkspace(
+      t,
+      "sms-compliance-refresh-outsider",
+    );
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      const approvedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550174",
+        twilioPhoneSid: "PN-sms-compliance-refresh-target",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "approved",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-refresh-target",
+      });
+    });
+
+    await expect(
+      outsider.action(api.smsCompliance.refreshStatus, {
+        businessId,
+      }),
+    ).rejects.toThrow("You do not have access to this business.");
+    expect(syncRegistrationMock).not.toHaveBeenCalled();
   });
 });

--- a/convex/tests/smsCompliance.test.ts
+++ b/convex/tests/smsCompliance.test.ts
@@ -651,6 +651,119 @@ describe("smsCompliance", () => {
     });
   });
 
+  it("reports platform routing when the approved sender is no longer active", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-inactive-approved-sender",
+    );
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      const approvedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550184",
+        twilioPhoneSid: "PN-sms-compliance-inactive-approved-sender",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "approved",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-sms-compliance-inactive-approved-sender",
+      });
+      await ctx.db.patch(approvedPhoneNumberId, {
+        status: "inactive",
+      });
+    });
+
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(status).toMatchObject({
+      status: "approved",
+      senderMode: "platform_phone",
+      alertsUseBusinessSender: false,
+      aiSmsReady: false,
+      twilioMessagingServiceSid: "MG-sms-compliance-inactive-approved-sender",
+    });
+  });
+
+  it("allows replacing the approved phone number while OTP verification is pending", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-pending-brand-number-change",
+    );
+
+    const { activeReplacementPhoneNumberId, inactiveApprovedPhoneNumberId } = await t.run(
+      async (ctx: TestContext) => {
+        await seedBillingAccount(ctx, businessId);
+        const inactiveApprovedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+          businessId,
+          e164: "+14165550185",
+          twilioPhoneSid: "PN-sms-compliance-pending-brand-old",
+        });
+        const activeReplacementPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+          businessId,
+          e164: "+14165550186",
+          twilioPhoneSid: "PN-sms-compliance-pending-brand-new",
+        });
+
+        const registrationId = await ctx.db.insert("sms_compliance_registrations", {
+          businessId,
+          status: "pending_brand_verification",
+          customerType: "direct_customer",
+          brandKind: "standard_business",
+          trafficTier: "low_volume",
+          draft: buildValidDraft(),
+          approvedPhoneNumberId: inactiveApprovedPhoneNumberId,
+          pendingAction: {
+            type: "brand_contact_email_otp",
+            message: "Complete the brand contact email verification code.",
+          },
+        });
+
+        await ctx.db.patch(inactiveApprovedPhoneNumberId, {
+          status: "inactive",
+        });
+
+        return {
+          registrationId,
+          activeReplacementPhoneNumberId,
+          inactiveApprovedPhoneNumberId,
+        };
+      },
+    );
+
+    const saved = await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "mixed",
+      approvedPhoneNumberId: activeReplacementPhoneNumberId,
+      draft: {
+        ...buildValidDraft(),
+        businessName: "Ignored Draft Change While OTP Pending",
+      },
+    });
+
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(saved).toMatchObject({
+      status: "pending_brand_verification",
+    });
+    expect(status).toMatchObject({
+      status: "pending_brand_verification",
+      approvedPhoneNumberId: activeReplacementPhoneNumberId,
+      approvedPhoneNumberE164: "+14165550186",
+      draft: expect.objectContaining({
+        businessName: "Acme Clinic LLC",
+      }),
+    });
+    expect(status.approvedPhoneNumberId).not.toBe(inactiveApprovedPhoneNumberId);
+  });
+
   it("keeps approved registrations approved when refresh throws before syncing", async () => {
     const t = convexTest(schema, convexModules);
     const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh-approved");

--- a/convex/tests/smsCompliance.test.ts
+++ b/convex/tests/smsCompliance.test.ts
@@ -908,6 +908,61 @@ describe("smsCompliance", () => {
     expect(status.pendingAction).toBeUndefined();
   });
 
+  it("keeps suspended registrations suspended when refresh throws before syncing", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh-suspended");
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      const approvedPhoneNumberId = await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550184",
+        twilioPhoneSid: "PN-sms-compliance-refresh-suspended",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "suspended",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: buildValidDraft(),
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-refresh-suspended",
+        failureCode: "brand_suspended",
+        failureMessage: "Twilio suspended this 10DLC brand.",
+        pendingAction: {
+          type: "manual_review",
+          message: "Twilio suspended this 10DLC brand. Contact support before retrying.",
+        },
+      });
+    });
+    syncRegistrationMock.mockRejectedValueOnce(new Error("Twilio timeout"));
+
+    const result = await authed.action(api.smsCompliance.refreshStatus, {
+      businessId,
+    });
+    const status = await authed.query(api.smsCompliance.getStatus, { businessId });
+
+    expect(result).toMatchObject({
+      status: "suspended",
+    });
+    expect(syncRegistrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "refresh",
+      }),
+    );
+    expect(status).toMatchObject({
+      status: "suspended",
+      twilioMessagingServiceSid: "MG-refresh-suspended",
+      failureCode: "brand_suspended",
+      failureMessage: "Twilio suspended this 10DLC brand.",
+      pendingAction: {
+        type: "manual_review",
+        message: "Twilio suspended this 10DLC brand. Contact support before retrying.",
+      },
+    });
+  });
+
   it("marks pending registrations as failed when refresh throws before syncing", async () => {
     const t = convexTest(schema, convexModules);
     const { authed, businessId } = await seedWorkspace(t, "sms-compliance-refresh-failure");

--- a/convex/tests/smsCompliance.test.ts
+++ b/convex/tests/smsCompliance.test.ts
@@ -344,6 +344,41 @@ describe("smsCompliance", () => {
     });
   });
 
+  it("rejects public-company submissions that omit stock metadata", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(
+      t,
+      "sms-compliance-public-company-stock-required",
+    );
+
+    const phoneNumberId = await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, businessId);
+      return await seedSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550182",
+        twilioPhoneSid: "PN-sms-compliance-public-company-stock-required",
+      });
+    });
+
+    await authed.mutation(api.smsCompliance.saveComplianceForm, {
+      businessId,
+      trafficTier: "low_volume",
+      approvedPhoneNumberId: phoneNumberId,
+      draft: {
+        ...buildValidDraft(),
+        companyType: "public",
+        brandContactEmail: "investor.relations@example.com",
+      },
+    });
+
+    await expect(
+      authed.action(api.smsCompliance.startRegistration, {
+        businessId,
+      }),
+    ).rejects.toThrow("Stock exchange is required.");
+    expect(syncRegistrationMock).not.toHaveBeenCalled();
+  });
+
   it("rejects draft edits after submission has started", async () => {
     const t = convexTest(schema, convexModules);
     const { authed, businessId } = await seedWorkspace(t, "sms-compliance-read-only-after-submit");

--- a/convex/tests/twilioA2p.test.ts
+++ b/convex/tests/twilioA2p.test.ts
@@ -1,0 +1,531 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getTwilioClientMock } = vi.hoisted(() => ({
+  getTwilioClientMock: vi.fn(),
+}));
+
+vi.mock("../lib/node/twilioClient", async () => {
+  const actual = await vi.importActual<typeof import("../lib/node/twilioClient")>(
+    "../lib/node/twilioClient",
+  );
+
+  return {
+    ...actual,
+    getTwilioClient: () => getTwilioClientMock(),
+  };
+});
+
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { SmsComplianceDraft } from "../lib/smsCompliance";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+type ConvexHarness = TestConvex<typeof schema>;
+type TestRunFunction = Parameters<ConvexHarness["run"]>[0];
+type TestContext = Parameters<TestRunFunction>[0];
+
+const convexModules = modules;
+const originalConvexSiteUrl = process.env.CONVEX_SITE_URL;
+const originalPrimaryCustomerProfileSid = process.env.TWILIO_PRIMARY_CUSTOMER_PROFILE_SID;
+const originalA2pStatusEmail = process.env.TWILIO_A2P_STATUS_EMAIL;
+const originalTwilioRequestDelayMs = process.env.TWILIO_A2P_REQUEST_DELAY_MS;
+
+function buildValidDraft(): SmsComplianceDraft {
+  return {
+    businessName: "Acme Clinic LLC",
+    businessType: "Corporation",
+    businessIndustry: "HEALTHCARE",
+    businessRegistrationIdentifier: "EIN",
+    businessRegistrationNumber: "12-3456789",
+    websiteUrl: "https://example.com",
+    businessRegionsOfOperation: ["USA_AND_CANADA"],
+    companyType: "private",
+    brandContactEmail: "ops@example.com",
+    campaignDescription: "Appointment alerts and AI SMS replies for registered patients.",
+    messageFlow:
+      "Customers opt in through intake paperwork and online booking forms that clearly disclose SMS consent.",
+    sampleMessages: [
+      "Acme Clinic: your appointment is tomorrow at 2 PM. Reply STOP to unsubscribe.",
+      "Acme Clinic: reply YES to confirm your visit or STOP to unsubscribe from future texts.",
+    ],
+    hasEmbeddedLinks: false,
+    hasEmbeddedPhone: true,
+    optInMessage: "Acme Clinic: you are subscribed. Reply HELP for help or STOP to unsubscribe.",
+    optOutMessage: "Acme Clinic: you are unsubscribed and will receive no more SMS messages.",
+    helpMessage: "Acme Clinic: reply STOP to unsubscribe or call 416-555-0100 for support.",
+    optInKeywords: ["START"],
+    optOutKeywords: ["STOP"],
+    helpKeywords: ["HELP"],
+    address: {
+      customerName: "Acme Clinic LLC",
+      street: "123 Main Street",
+      city: "Toronto",
+      region: "ON",
+      postalCode: "M5V 2T6",
+      isoCountry: "CA",
+    },
+    authorizedRepresentative: {
+      firstName: "Jordan",
+      lastName: "Lee",
+      businessTitle: "Operations Manager",
+      jobPosition: "Director",
+      phoneNumber: "+14165550188",
+      email: "jordan@example.com",
+    },
+  };
+}
+
+async function seedRegistrationContext(
+  t: ConvexHarness,
+  input: {
+    registrationStatus: "approved" | "failed" | "pending_review";
+    trafficTier: "low_volume" | "mixed";
+    draft: SmsComplianceDraft;
+    twilioSids?: Partial<{
+      customerProfileSid: string;
+      businessInfoSid: string;
+      authorizedRepresentativeSid: string;
+      addressSid: string;
+      addressDocumentSid: string;
+      trustProductSid: string;
+      messagingProfileSid: string;
+      brandRegistrationSid: string;
+      messagingServiceSid: string;
+      campaignSid: string;
+    }>;
+    previousSubmission?: {
+      trafficTier: "low_volume" | "mixed";
+      draft: SmsComplianceDraft;
+      resultStatus: "failed" | "pending_review" | "approved";
+      twilioCampaignSid?: string;
+    };
+  },
+): Promise<{
+  registrationId: Id<"sms_compliance_registrations">;
+  phoneNumberId: Id<"phone_numbers">;
+}> {
+  return await t.run(async (ctx: TestContext) => {
+    const businessId: Id<"businesses"> = await ctx.db.insert("businesses", {
+      slug: `twilio-a2p-${Date.now()}`,
+      name: "Acme Clinic",
+      timezone: "America/Toronto",
+      businessType: "clinic",
+      defaultLocale: "en",
+      deploymentMode: "cloud",
+      status: "active",
+    });
+
+    const phoneNumberId: Id<"phone_numbers"> = await ctx.db.insert("phone_numbers", {
+      businessId,
+      e164: "+14165550170",
+      twilioPhoneSid: "PN-twilio-a2p-test",
+      voiceEnabled: true,
+      smsEnabled: true,
+      status: "active",
+    });
+
+    const registrationId: Id<"sms_compliance_registrations"> = await ctx.db.insert(
+      "sms_compliance_registrations",
+      {
+        businessId,
+        status: input.registrationStatus,
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: input.trafficTier,
+        draft: input.draft,
+        approvedPhoneNumberId: phoneNumberId,
+        ...(input.twilioSids?.customerProfileSid
+          ? { twilioCustomerProfileSid: input.twilioSids.customerProfileSid }
+          : {}),
+        ...(input.twilioSids?.businessInfoSid
+          ? { twilioBusinessInfoSid: input.twilioSids.businessInfoSid }
+          : {}),
+        ...(input.twilioSids?.authorizedRepresentativeSid
+          ? { twilioAuthorizedRepresentativeSid: input.twilioSids.authorizedRepresentativeSid }
+          : {}),
+        ...(input.twilioSids?.addressSid ? { twilioAddressSid: input.twilioSids.addressSid } : {}),
+        ...(input.twilioSids?.addressDocumentSid
+          ? { twilioAddressDocumentSid: input.twilioSids.addressDocumentSid }
+          : {}),
+        ...(input.twilioSids?.trustProductSid
+          ? { twilioTrustProductSid: input.twilioSids.trustProductSid }
+          : {}),
+        ...(input.twilioSids?.messagingProfileSid
+          ? { twilioMessagingProfileSid: input.twilioSids.messagingProfileSid }
+          : {}),
+        ...(input.twilioSids?.brandRegistrationSid
+          ? { twilioBrandRegistrationSid: input.twilioSids.brandRegistrationSid }
+          : {}),
+        ...(input.twilioSids?.messagingServiceSid
+          ? { twilioMessagingServiceSid: input.twilioSids.messagingServiceSid }
+          : {}),
+        ...(input.twilioSids?.campaignSid
+          ? { twilioCampaignSid: input.twilioSids.campaignSid }
+          : {}),
+      },
+    );
+
+    if (input.previousSubmission) {
+      await ctx.db.insert("sms_compliance_submissions", {
+        registrationId,
+        businessId,
+        attemptKey: "attempt-1",
+        status: input.previousSubmission.resultStatus,
+        trafficTier: input.previousSubmission.trafficTier,
+        snapshot: {
+          trafficTier: input.previousSubmission.trafficTier,
+          draft: input.previousSubmission.draft,
+        },
+        createdAt: "2026-04-17T12:00:00.000Z",
+        submittedAt: "2026-04-17T12:00:00.000Z",
+        completedAt: "2026-04-17T12:10:00.000Z",
+        resultStatus: input.previousSubmission.resultStatus,
+        ...(input.previousSubmission.twilioCampaignSid
+          ? { twilioCampaignSid: input.previousSubmission.twilioCampaignSid }
+          : {}),
+      });
+    }
+
+    return { registrationId, phoneNumberId };
+  });
+}
+
+function createTwilioClientFixture() {
+  const customerProfileAssignmentCreateMock = vi.fn(async (_sid: string, _params?: unknown) => null);
+  const customerProfileEvaluationCreateMock = vi.fn(async (_sid: string, _params?: unknown) => ({
+    status: "compliant",
+    results: [],
+  }));
+  const customerProfileUpdateMock = vi.fn(async (_sid: string, _params?: unknown) => ({}));
+  const customerProfileFetchMock = vi.fn(async (sid: string) => ({
+    sid,
+    ...(sid === process.env.TWILIO_PRIMARY_CUSTOMER_PROFILE_SID ? { policySid: "RN-primary" } : {}),
+  }));
+  const customerProfileCreateMock = vi.fn(async () => ({ sid: "BU-created" }));
+
+  const endUserUpdateMock = vi.fn(async (_sid: string, _params?: unknown) => ({}));
+  const endUserCreateMock = vi.fn(async () => ({ sid: "IT-created" }));
+
+  const addressUpdateMock = vi.fn(async (_sid: string, _params?: unknown) => ({}));
+  const addressCreateMock = vi.fn(async () => ({ sid: "AD-created" }));
+
+  const supportingDocumentUpdateMock = vi.fn(async (_sid: string, _params?: unknown) => ({}));
+  const supportingDocumentCreateMock = vi.fn(async () => ({ sid: "RD-created" }));
+
+  const trustProductAssignmentCreateMock = vi.fn(async (_sid: string, _params?: unknown) => null);
+  const trustProductEvaluationCreateMock = vi.fn(async (_sid: string, _params?: unknown) => ({
+    status: "compliant",
+    results: [],
+  }));
+  const trustProductUpdateMock = vi.fn(async (_sid: string, _params?: unknown) => ({}));
+  const trustProductCreateMock = vi.fn(async () => ({ sid: "BU-trust-created" }));
+
+  const brandCreateMock = vi.fn(async () => ({
+    sid: "BN-created",
+    status: "PENDING",
+    errors: [],
+  }));
+  const brandFetchMock = vi.fn(async (sid: string) => ({
+    sid,
+    status: "APPROVED",
+    errors: [],
+  }));
+  const brandUpdateMock = vi.fn(async (sid: string) => ({
+    sid,
+    status: "PENDING",
+    errors: [],
+  }));
+
+  const serviceUpdateMock = vi.fn(async (_sid: string, _params?: unknown) => ({}));
+  const serviceCreateMock = vi.fn(async () => ({ sid: "MG-created" }));
+
+  const campaignFetchMock = vi.fn(async (_serviceSid: string, campaignSid: string) => ({
+    sid: campaignSid,
+    campaignStatus: "FAILED",
+    errors: [],
+  }));
+  const campaignUpdateMock = vi.fn(
+    async (_serviceSid: string, campaignSid: string, _params?: unknown) => ({
+      sid: campaignSid,
+      campaignStatus: "PENDING",
+      errors: [],
+    }),
+  );
+  const campaignRemoveMock = vi.fn(async (_serviceSid: string, _campaignSid: string) => true);
+  const campaignCreateMock = vi.fn(async (_serviceSid: string, _params?: unknown) => ({
+    sid: "QE-created",
+    campaignStatus: "PENDING",
+    errors: [],
+  }));
+  const campaignListMock = vi.fn(async (_serviceSid: string, _params?: unknown) => []);
+
+  const phoneNumbersListMock = vi.fn(async (_serviceSid: string, _params?: unknown) => []);
+  const phoneNumbersCreateMock = vi.fn(async (_serviceSid: string, _params?: unknown) => ({}));
+
+  const client = {
+    trusthub: {
+      v1: {
+        customerProfiles: Object.assign(
+          (sid: string) => ({
+            fetch: () => customerProfileFetchMock(sid),
+            update: (params?: unknown) => customerProfileUpdateMock(sid, params),
+            evaluations: {
+              create: (params: unknown) => customerProfileEvaluationCreateMock(sid, params),
+            },
+            customerProfilesEntityAssignments: {
+              create: (params: unknown) => customerProfileAssignmentCreateMock(sid, params),
+            },
+          }),
+          {
+            create: customerProfileCreateMock,
+          },
+        ),
+        endUsers: Object.assign(
+          (sid: string) => ({
+            update: (params: unknown) => endUserUpdateMock(sid, params),
+          }),
+          {
+            create: endUserCreateMock,
+          },
+        ),
+        addresses: Object.assign(
+          (sid: string) => ({
+            update: (params: unknown) => addressUpdateMock(sid, params),
+          }),
+          {
+            create: addressCreateMock,
+          },
+        ),
+        supportingDocuments: Object.assign(
+          (sid: string) => ({
+            update: (params: unknown) => supportingDocumentUpdateMock(sid, params),
+          }),
+          {
+            create: supportingDocumentCreateMock,
+          },
+        ),
+        trustProducts: Object.assign(
+          (sid: string) => ({
+            update: (params?: unknown) => trustProductUpdateMock(sid, params),
+            evaluations: {
+              create: (params: unknown) => trustProductEvaluationCreateMock(sid, params),
+            },
+            trustProductsEntityAssignments: {
+              create: (params: unknown) => trustProductAssignmentCreateMock(sid, params),
+            },
+          }),
+          {
+            create: trustProductCreateMock,
+          },
+        ),
+      },
+    },
+    messaging: {
+      v1: {
+        brandRegistrations: Object.assign(
+          (sid: string) => ({
+            fetch: () => brandFetchMock(sid),
+            update: () => brandUpdateMock(sid),
+          }),
+          {
+            create: brandCreateMock,
+          },
+        ),
+        services: Object.assign(
+          (sid: string) => ({
+            update: (params: unknown) => serviceUpdateMock(sid, params),
+            usAppToPerson: Object.assign(
+              (campaignSid: string) => ({
+                fetch: () => campaignFetchMock(sid, campaignSid),
+                update: (params: unknown) => campaignUpdateMock(sid, campaignSid, params),
+                remove: () => campaignRemoveMock(sid, campaignSid),
+              }),
+              {
+                create: (params: unknown) => campaignCreateMock(sid, params),
+                list: (params: unknown) => campaignListMock(sid, params),
+              },
+            ),
+            phoneNumbers: {
+              list: (params: unknown) => phoneNumbersListMock(sid, params),
+              create: (params: unknown) => phoneNumbersCreateMock(sid, params),
+            },
+          }),
+          {
+            create: serviceCreateMock,
+          },
+        ),
+      },
+    },
+  };
+
+  return {
+    client,
+    mocks: {
+      addressCreateMock,
+      addressUpdateMock,
+      brandFetchMock,
+      campaignCreateMock,
+      campaignFetchMock,
+      campaignRemoveMock,
+      campaignUpdateMock,
+      customerProfileFetchMock,
+      endUserUpdateMock,
+      phoneNumbersCreateMock,
+      phoneNumbersListMock,
+      serviceUpdateMock,
+      supportingDocumentUpdateMock,
+    },
+  };
+}
+
+beforeEach(() => {
+  process.env.CONVEX_SITE_URL = "https://example.convex.site";
+  process.env.TWILIO_PRIMARY_CUSTOMER_PROFILE_SID = "BU-primary-profile";
+  process.env.TWILIO_A2P_STATUS_EMAIL = "a2p-status@example.com";
+  process.env.TWILIO_A2P_REQUEST_DELAY_MS = "0";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  process.env.CONVEX_SITE_URL = originalConvexSiteUrl;
+  process.env.TWILIO_PRIMARY_CUSTOMER_PROFILE_SID = originalPrimaryCustomerProfileSid;
+  process.env.TWILIO_A2P_STATUS_EMAIL = originalA2pStatusEmail;
+  process.env.TWILIO_A2P_REQUEST_DELAY_MS = originalTwilioRequestDelayMs;
+});
+
+describe("twilioA2p syncRegistration", () => {
+  it("updates existing Twilio resources and recreates failed campaigns for immutable changes", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentDraft = buildValidDraft();
+    const previousDraft = {
+      ...buildValidDraft(),
+      optOutMessage: "Acme Clinic: reply STOP to stop receiving messages.",
+    };
+
+    const { registrationId } = await seedRegistrationContext(t, {
+      registrationStatus: "failed",
+      trafficTier: "low_volume",
+      draft: currentDraft,
+      twilioSids: {
+        customerProfileSid: "BU-customer",
+        businessInfoSid: "IT-business",
+        authorizedRepresentativeSid: "IT-authorized",
+        addressSid: "AD-address",
+        addressDocumentSid: "RD-address-doc",
+        trustProductSid: "BU-trust",
+        messagingProfileSid: "IT-messaging",
+        brandRegistrationSid: "BN-brand",
+        messagingServiceSid: "MG-service",
+        campaignSid: "QE-failed",
+      },
+      previousSubmission: {
+        trafficTier: "low_volume",
+        draft: previousDraft,
+        resultStatus: "failed",
+        twilioCampaignSid: "QE-failed",
+      },
+    });
+
+    const fixture = createTwilioClientFixture();
+    getTwilioClientMock.mockReturnValue(fixture.client);
+
+    const context = await t.query(internal.smsCompliance.getTwilioRegistrationContext, {
+      registrationId,
+    });
+    expect(context.previousCompletedSubmission?.snapshot.draft.optOutMessage).toBe(
+      previousDraft.optOutMessage,
+    );
+
+    const result = await t.action(internal.integrations.twilioA2p.syncRegistration, {
+      registrationId,
+      mode: "submit",
+    });
+
+    expect(fixture.mocks.endUserUpdateMock).toHaveBeenCalledWith(
+      "IT-business",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          business_name: "Acme Clinic LLC",
+        }),
+      }),
+    );
+    expect(fixture.mocks.endUserUpdateMock).toHaveBeenCalledWith(
+      "IT-authorized",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          first_name: "Jordan",
+        }),
+      }),
+    );
+    expect(fixture.mocks.endUserUpdateMock).toHaveBeenCalledWith(
+      "IT-messaging",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          company_type: "private",
+        }),
+      }),
+    );
+    expect(fixture.mocks.addressUpdateMock).toHaveBeenCalledWith(
+      "AD-address",
+      expect.objectContaining({
+        customerName: "Acme Clinic LLC",
+      }),
+    );
+    expect(fixture.mocks.supportingDocumentUpdateMock).toHaveBeenCalledWith(
+      "RD-address-doc",
+      expect.objectContaining({
+        attributes: {
+          address_sids: "AD-address",
+        },
+      }),
+    );
+    expect(fixture.mocks.campaignRemoveMock).toHaveBeenCalledWith("MG-service", "QE-failed");
+    expect(fixture.mocks.campaignCreateMock).toHaveBeenCalledWith(
+      "MG-service",
+      expect.objectContaining({
+        optOutMessage: currentDraft.optOutMessage,
+        usAppToPersonUsecase: "LOW_VOLUME",
+      }),
+    );
+    expect(fixture.mocks.campaignUpdateMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "pending_review",
+      twilioCampaignSid: "QE-created",
+    });
+  });
+
+  it("keeps approved registrations approved when refresh hits a transient Twilio error", async () => {
+    const t = convexTest(schema, convexModules);
+    const { registrationId } = await seedRegistrationContext(t, {
+      registrationStatus: "approved",
+      trafficTier: "low_volume",
+      draft: buildValidDraft(),
+      twilioSids: {
+        customerProfileSid: "BU-customer",
+        brandRegistrationSid: "BN-approved",
+        messagingServiceSid: "MG-approved",
+        campaignSid: "QE-approved",
+      },
+    });
+
+    const fixture = createTwilioClientFixture();
+    fixture.mocks.brandFetchMock.mockRejectedValueOnce(new Error("Twilio timeout"));
+    getTwilioClientMock.mockReturnValue(fixture.client);
+
+    const result = await t.action(internal.integrations.twilioA2p.syncRegistration, {
+      registrationId,
+      mode: "refresh",
+    });
+
+    expect(result).toMatchObject({
+      status: "approved",
+      twilioMessagingServiceSid: "MG-approved",
+      twilioCampaignSid: "QE-approved",
+    });
+    expect(result.failureCode).toBeUndefined();
+    expect(result.failureMessage).toBeUndefined();
+    expect(result.pendingAction).toBeUndefined();
+  });
+});

--- a/convex/tests/twilioA2p.test.ts
+++ b/convex/tests/twilioA2p.test.ts
@@ -534,4 +534,30 @@ describe("twilioA2p syncRegistration", () => {
     expect(result.failureMessage).toBeUndefined();
     expect(result.pendingAction).toBeUndefined();
   });
+
+  it("rethrows refresh errors when the registration is not approved", async () => {
+    const t = convexTest(schema, convexModules);
+    const { registrationId } = await seedRegistrationContext(t, {
+      registrationStatus: "pending_review",
+      trafficTier: "low_volume",
+      draft: buildValidDraft(),
+      twilioSids: {
+        customerProfileSid: "BU-customer",
+        brandRegistrationSid: "BN-pending",
+        messagingServiceSid: "MG-pending",
+        campaignSid: "QE-pending",
+      },
+    });
+
+    const fixture = createTwilioClientFixture();
+    fixture.mocks.brandFetchMock.mockRejectedValueOnce(new Error("Twilio timeout"));
+    getTwilioClientMock.mockReturnValue(fixture.client);
+
+    await expect(
+      t.action(internal.integrations.twilioA2p.syncRegistration, {
+        registrationId,
+        mode: "refresh",
+      }),
+    ).rejects.toThrow("Twilio timeout");
+  });
 });

--- a/convex/tests/twilioA2p.test.ts
+++ b/convex/tests/twilioA2p.test.ts
@@ -265,6 +265,20 @@ function createTwilioClientFixture() {
   const phoneNumbersCreateMock = vi.fn(async (_serviceSid: string, _params?: unknown) => ({}));
 
   const client = {
+    api: {
+      v2010: {
+        account: {
+          addresses: Object.assign(
+            (sid: string) => ({
+              update: (params: unknown) => addressUpdateMock(sid, params),
+            }),
+            {
+              create: addressCreateMock,
+            },
+          ),
+        },
+      },
+    },
     trusthub: {
       v1: {
         customerProfiles: Object.assign(
@@ -288,14 +302,6 @@ function createTwilioClientFixture() {
           }),
           {
             create: endUserCreateMock,
-          },
-        ),
-        addresses: Object.assign(
-          (sid: string) => ({
-            update: (params: unknown) => addressUpdateMock(sid, params),
-          }),
-          {
-            create: addressCreateMock,
           },
         ),
         supportingDocuments: Object.assign(

--- a/convex/tests/twilioSmsDelivery.test.ts
+++ b/convex/tests/twilioSmsDelivery.test.ts
@@ -115,7 +115,12 @@ function createTestHarness(): TestConvex<typeof schema> {
 
 async function insertBusiness(
   ctx: TestContext,
-  input: { slug: string; name: string; defaultLocale?: "en" | "fr" },
+  input: {
+    slug: string;
+    name: string;
+    defaultLocale?: "en" | "fr";
+    deploymentMode?: "cloud" | "manual";
+  },
 ): Promise<Id<"businesses">> {
   return await ctx.db.insert("businesses", {
     slug: input.slug,
@@ -123,7 +128,7 @@ async function insertBusiness(
     timezone: "America/Toronto",
     businessType: "service_company",
     defaultLocale: input.defaultLocale ?? "en",
-    deploymentMode: "manual",
+    deploymentMode: input.deploymentMode ?? "manual",
     status: "active",
   });
 }
@@ -1049,6 +1054,90 @@ describe("Twilio SMS delivery flow", () => {
       from: "+14165550111",
       body: "Auto-reply: Which line replies?",
       statusCallback: "https://example.convex.site/twilio/sms/status",
+    });
+  });
+
+  it("uses the approved business sender once hosted AI SMS is attached to a Messaging Service", async () => {
+    const t = createTestHarness();
+    sendTwilioMessageMock.mockResolvedValue({
+      sid: "SM-outbound-hosted-approved-reply",
+      status: "queued",
+    });
+
+    const { approvedPhoneNumber, businessId, inboundPhoneNumber } = await t.run(async (ctx) => {
+      const businessId = await insertBusiness(ctx, {
+        slug: "twilio-hosted-approved-reply",
+        name: "Twilio Hosted Approved Reply",
+        deploymentMode: "cloud",
+      });
+      const approvedPhoneNumberId = await insertSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550112",
+      });
+      await insertSmsPhoneNumber(ctx, {
+        businessId,
+        e164: "+14165550113",
+      });
+      await ctx.db.insert("billing_accounts", {
+        businessId,
+        billingKey: getBillingKey(businessId),
+        currentPlan: "pro",
+        activeAddons: ["ai_sms"],
+        subscriptionState: "active",
+        billingContactEmail: "owner@example.com",
+        billingContactName: "Hosted Reply Owner",
+        lastSyncedAt: "2026-04-18T12:00:00.000Z",
+      });
+      await ctx.db.insert("sms_compliance_registrations", {
+        businessId,
+        status: "approved",
+        customerType: "direct_customer",
+        brandKind: "standard_business",
+        trafficTier: "low_volume",
+        draft: {
+          businessName: "Twilio Hosted Approved Reply",
+          websiteUrl: "https://example.com",
+        },
+        approvedPhoneNumberId,
+        twilioMessagingServiceSid: "MG-hosted-approved-reply",
+      });
+
+      return {
+        approvedPhoneNumber: "+14165550112",
+        businessId,
+        inboundPhoneNumber: "+14165550113",
+      };
+    });
+
+    const response = await postTwilioForm(t, "/twilio/sms/inbound", {
+      MessageSid: "SM-inbound-hosted-approved-reply",
+      From: "+14165550186",
+      To: inboundPhoneNumber,
+      Body: "Use the approved sender",
+    });
+
+    expect(response.status).toBe(200);
+    expect(sendTwilioMessageMock).toHaveBeenCalledWith({
+      to: "+14165550186",
+      from: approvedPhoneNumber,
+      messagingServiceSid: "MG-hosted-approved-reply",
+      body: "Auto-reply: Use the approved sender",
+      statusCallback: "https://example.convex.site/twilio/sms/status",
+    });
+
+    await t.run(async (ctx) => {
+      const conversation = await ctx.db
+        .query("conversations")
+        .withIndex("by_business_id_and_channel", (q) => q.eq("businessId", businessId))
+        .unique();
+      if (!conversation) {
+        throw new Error("Expected hosted approved reply conversation.");
+      }
+      const messages = await fetchConversationMessages(ctx, conversation._id);
+      const outbound = messages.find((message) => message.direction === "outbound");
+      expect(outbound).toMatchObject({
+        fromPhoneNumber: approvedPhoneNumber,
+      });
     });
   });
 

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -235,11 +235,13 @@ export type BillingStatus = {
   subscriptionState: string;
   activeAddons: Array<BillingAddonSlug>;
   aiSmsEnabled: boolean;
+  aiSmsReady: boolean;
   overagesBillable: boolean;
   monthlyChargeCents: number | null;
   billingContactEmail: string | null;
   billingContactName: string | null;
   includedBusinessNumbers: number | null;
+  hasBillingManagementAccess: boolean;
   hasCustomerPortalAccess: boolean;
   hasCheckoutAccess: boolean;
   availableCheckoutPlans: Array<HostedCheckoutPlanSlug>;


### PR DESCRIPTION
## Summary
- Add Twilio A2P/10DLC registration flow to billing and settings surfaces
- Tighten SMS compliance enforcement across webhooks, reminders, dashboard messaging, and notification paths
- Update localization and billing UI coverage for the new self-serve registration experience
- Extend schema and generated API types to support the new billing/compliance data

## Testing
- Added and updated unit coverage for billing and SMS compliance behavior
- Updated settings page tests to cover the registration-related UI flow
- Not run (not requested)