### PR TITLE
Harden PostHog telemetry and observability coverage

### DIFF
--- a/apps/voice-gateway/src/index.ts
+++ b/apps/voice-gateway/src/index.ts
@@ -18,6 +18,7 @@ async function main(): Promise<void> {
     { createServer },
     {
       capturePostHogException,
+      installPostHogFatalHandlers,
       recordVoiceHeartbeat,
       shutdownPostHog,
       startPostHogObservability,
@@ -25,6 +26,7 @@ async function main(): Promise<void> {
   ] = await Promise.all([import("./http/server"), import("./observability/posthog")]);
 
   await startPostHogObservability();
+  installPostHogFatalHandlers();
 
   const server = createServer();
   const port = Number(process.env.PORT ?? 3001);
@@ -69,7 +71,15 @@ async function main(): Promise<void> {
 void main().catch(async (error: unknown) => {
   const unknownError = error instanceof Error ? error : new Error(String(error));
   console.error(unknownError);
-  const { shutdownPostHog } = await import("./observability/posthog");
+  const { capturePostHogException, shutdownPostHog } = await import("./observability/posthog");
+  capturePostHogException(unknownError, {
+    properties: {
+      operation: "voice_gateway_main",
+      $exception_level: "fatal",
+      alertable: true,
+      expected: false,
+    },
+  });
   await shutdownPostHog().catch(() => undefined);
   process.exitCode = 1;
 });

--- a/apps/voice-gateway/src/observability/posthog.test.ts
+++ b/apps/voice-gateway/src/observability/posthog.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { captureExceptionMock } = vi.hoisted(() => ({
+const { captureExceptionMock, shutdownMock } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
+  shutdownMock: vi.fn(),
 }));
 
 vi.mock("posthog-node", () => ({
@@ -9,7 +10,7 @@ vi.mock("posthog-node", () => ({
     return {
       capture: vi.fn(),
       captureException: captureExceptionMock,
-      shutdown: vi.fn(),
+      shutdown: shutdownMock,
     };
   }),
 }));
@@ -29,6 +30,7 @@ describe("voice-gateway PostHog provider exception telemetry", () => {
   beforeEach(() => {
     vi.resetModules();
     captureExceptionMock.mockClear();
+    shutdownMock.mockClear();
 
     for (const key of ENV_KEYS) {
       originalEnv.set(key, process.env[key]);
@@ -86,9 +88,43 @@ describe("voice-gateway PostHog provider exception telemetry", () => {
     expect(distinctId).toBe("system:business:business_123");
     expect(properties).toMatchObject({
       $exception_message: "[redacted]",
+      alertable: true,
+      expected: false,
       operation: "twilio_live_call_update",
+      provider: "twilio",
       providerErrorCode: "21211",
       providerErrorMessage: "[redacted]",
+      runtime: "voice-gateway",
+      service: "voice-gateway",
+    });
+  });
+
+  it("captures and flushes fatal process errors", async () => {
+    const { handleFatalPostHogException } = await import("./posthog");
+    const fatalError = new Error("fatal startup crash");
+    fatalError.name = "FatalStartupError";
+
+    await handleFatalPostHogException(fatalError, "uncaught_exception", {
+      exitProcess: false,
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(shutdownMock).toHaveBeenCalledOnce();
+
+    const [capturedError, distinctId, properties] =
+      captureExceptionMock.mock.calls[0] ?? [];
+    expect(capturedError).toBe(fatalError);
+    expect(distinctId).toBe("system:voice-gateway");
+    expect(properties).toMatchObject({
+      $exception_level: "fatal",
+      $exception_message: "[redacted]",
+      $exception_type: "FatalStartupError",
+      alertable: true,
+      expected: false,
+      fatalKind: "uncaught_exception",
+      operation: "voice_gateway_uncaught_exception",
+      runtime: "voice-gateway",
+      service: "voice-gateway",
     });
   });
 });

--- a/apps/voice-gateway/src/observability/posthog.test.ts
+++ b/apps/voice-gateway/src/observability/posthog.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { captureExceptionMock, shutdownMock } = vi.hoisted(() => ({
+const { captureExceptionMock, postHogConstructorMock, shutdownMock } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
+  postHogConstructorMock: vi.fn(),
   shutdownMock: vi.fn(),
 }));
 
 vi.mock("posthog-node", () => ({
-  PostHog: vi.fn().mockImplementation(function PostHog() {
+  PostHog: vi.fn().mockImplementation(function PostHog(...args: unknown[]) {
+    postHogConstructorMock(...args);
     return {
       capture: vi.fn(),
       captureException: captureExceptionMock,
@@ -30,6 +32,7 @@ describe("voice-gateway PostHog provider exception telemetry", () => {
   beforeEach(() => {
     vi.resetModules();
     captureExceptionMock.mockClear();
+    postHogConstructorMock.mockClear();
     shutdownMock.mockClear();
 
     for (const key of ENV_KEYS) {
@@ -103,13 +106,21 @@ describe("voice-gateway PostHog provider exception telemetry", () => {
     const { handleFatalPostHogException } = await import("./posthog");
     const fatalError = new Error("fatal startup crash");
     fatalError.name = "FatalStartupError";
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
 
-    await handleFatalPostHogException(fatalError, "uncaught_exception", {
-      exitProcess: false,
-    });
+    try {
+      await handleFatalPostHogException(fatalError, "uncaught_exception", {
+        exitProcess: false,
+      });
 
-    expect(captureExceptionMock).toHaveBeenCalledOnce();
-    expect(shutdownMock).toHaveBeenCalledOnce();
+      expect(captureExceptionMock).toHaveBeenCalledOnce();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(fatalError);
+      expect(shutdownMock).toHaveBeenCalledOnce();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
 
     const [capturedError, distinctId, properties] =
       captureExceptionMock.mock.calls[0] ?? [];
@@ -126,5 +137,18 @@ describe("voice-gateway PostHog provider exception telemetry", () => {
       runtime: "voice-gateway",
       service: "voice-gateway",
     });
+  });
+
+  it("leaves SDK fatal autocapture disabled for custom process handlers", async () => {
+    const { startPostHogObservability } = await import("./posthog");
+
+    await startPostHogObservability();
+
+    expect(postHogConstructorMock).toHaveBeenCalledWith(
+      "phc_test",
+      expect.objectContaining({
+        enableExceptionAutocapture: false,
+      }),
+    );
   });
 });

--- a/apps/voice-gateway/src/observability/posthog.ts
+++ b/apps/voice-gateway/src/observability/posthog.ts
@@ -93,7 +93,7 @@ function getClient(): PostHog | null {
     host: env.POSTHOG_HOST,
     flushAt: 1,
     flushInterval: 0,
-    enableExceptionAutocapture: true,
+    enableExceptionAutocapture: false,
     privacyMode: env.POSTHOG_PRIVACY_MODE,
   });
   return client;
@@ -654,6 +654,8 @@ export async function handleFatalPostHogException(
     exitProcess?: boolean;
   },
 ): Promise<void> {
+  console.error(reason);
+
   const error =
     reason instanceof Error
       ? reason

--- a/apps/voice-gateway/src/observability/posthog.ts
+++ b/apps/voice-gateway/src/observability/posthog.ts
@@ -10,6 +10,7 @@ import { PostHog } from "posthog-node";
 import { loadVoiceGatewayEnv, type VoiceGatewayEnv } from "@lobbystack/config";
 import {
   bucketLatencyMs,
+  buildAlertableExceptionTelemetryProperties,
   buildPostHogAiGenerationProperties,
   buildPostHogAiSpanProperties,
   buildPostHogAiTraceProperties,
@@ -17,6 +18,7 @@ import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
   getProviderErrorExceptionType,
+  PROVIDER_ERROR_PROVIDERS,
   redactAiTraceProperties,
   redactTelemetryProperties,
   classifyProviderError,
@@ -43,9 +45,19 @@ let client: PostHog | null | undefined;
 let loggerProvider: LoggerProvider | null = null;
 let operationalLogger: Logger | null = null;
 let runtimeEnv: VoiceGatewayEnv | null | undefined;
+let fatalHandlersInstalled = false;
 
 const VOICE_GATEWAY_DISTINCT_ID = "system:voice-gateway";
 const SLOW_TURN_THRESHOLD_MS = 2_500;
+const UNSAFE_EXCEPTION_PROPERTY_KEYS = new Set([
+  "args",
+  "body",
+  "input",
+  "payload",
+  "rawargs",
+  "rawrequest",
+  "requestbody",
+]);
 
 function getRuntimeEnv(): VoiceGatewayEnv | null {
   if (runtimeEnv !== undefined) {
@@ -505,6 +517,74 @@ export async function shutdownPostHog(): Promise<void> {
   }
 }
 
+function getErrorExceptionType(error: unknown): string {
+  if (error instanceof Error && error.name) {
+    return error.name;
+  }
+  return "ApplicationError";
+}
+
+function getSafeExceptionMessage(input: {
+  service: string;
+  operation: string;
+  error: unknown;
+}): string {
+  return `${input.service} ${input.operation} failed (${getErrorExceptionType(
+    input.error,
+  )})`;
+}
+
+function getBooleanProperty(
+  properties: TelemetryProperties | undefined,
+  key: string,
+  fallback: boolean,
+): boolean {
+  const value = properties?.[key];
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function getStringProperty(
+  properties: TelemetryProperties | undefined,
+  key: string,
+): string | undefined {
+  const value = properties?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getExceptionLevel(
+  properties: TelemetryProperties | undefined,
+): "fatal" | "error" | "warning" | "info" {
+  const value = getStringProperty(properties, "$exception_level");
+  if (value === "fatal" || value === "error" || value === "warning" || value === "info") {
+    return value;
+  }
+  return "error";
+}
+
+function getProviderProperty(
+  properties: TelemetryProperties | undefined,
+): ExternalProvider | undefined {
+  const value = getStringProperty(properties, "provider");
+  if (value && PROVIDER_ERROR_PROVIDERS.includes(value as ExternalProvider)) {
+    return value as ExternalProvider;
+  }
+  return undefined;
+}
+
+function getSafeExceptionProperties(
+  properties: TelemetryProperties | undefined,
+): TelemetryProperties {
+  const safeProperties: TelemetryProperties = {};
+  for (const [key, value] of Object.entries(properties ?? {})) {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z]/g, "");
+    if (UNSAFE_EXCEPTION_PROPERTY_KEYS.has(normalizedKey)) {
+      continue;
+    }
+    safeProperties[key] = value;
+  }
+  return safeProperties;
+}
+
 export function capturePostHogException(
   error: unknown,
   input?: {
@@ -523,11 +603,31 @@ export function capturePostHogException(
     return;
   }
 
+  const safeInputProperties = getSafeExceptionProperties(input?.properties);
+  const operation =
+    getStringProperty(safeInputProperties, "operation") ?? "voice_gateway_exception";
+  const exceptionType = getErrorExceptionType(error);
+  const exceptionMessage = getSafeExceptionMessage({
+    service: "voice-gateway",
+    operation,
+    error,
+  });
+  const provider = getProviderProperty(safeInputProperties);
   const additionalProperties: Record<string, unknown> = {
     ...redactTelemetryProperties({
-      ...input?.properties,
+      ...safeInputProperties,
+      ...buildAlertableExceptionTelemetryProperties({
+        runtime: "voice-gateway",
+        service: "voice-gateway",
+        operation,
+        alertable: getBooleanProperty(safeInputProperties, "alertable", true),
+        expected: getBooleanProperty(safeInputProperties, "expected", false),
+        ...(provider ? { provider } : {}),
+        exceptionLevel: getExceptionLevel(safeInputProperties),
+        exceptionType,
+        exceptionMessage,
+      }),
       deploymentMode: env.DEPLOYMENT_MODE,
-      runtime: "voice-gateway",
     }),
   };
 
@@ -545,6 +645,54 @@ export function capturePostHogException(
         : undefined),
     additionalProperties,
   );
+}
+
+export async function handleFatalPostHogException(
+  reason: unknown,
+  kind: "uncaught_exception" | "unhandled_rejection",
+  options?: {
+    exitProcess?: boolean;
+  },
+): Promise<void> {
+  const error =
+    reason instanceof Error
+      ? reason
+      : new Error(
+          typeof reason === "string"
+            ? reason
+            : `Voice gateway fatal ${kind}`,
+        );
+
+  capturePostHogException(error, {
+    distinctId: VOICE_GATEWAY_DISTINCT_ID,
+    properties: {
+      operation: `voice_gateway_${kind}`,
+      fatalKind: kind,
+      $exception_level: "fatal",
+      alertable: true,
+      expected: false,
+    },
+  });
+
+  await shutdownPostHog().catch(() => undefined);
+
+  if (options?.exitProcess ?? true) {
+    process.exit(1);
+  }
+}
+
+export function installPostHogFatalHandlers(): void {
+  if (fatalHandlersInstalled) {
+    return;
+  }
+  fatalHandlersInstalled = true;
+
+  process.on("uncaughtException", (error) => {
+    void handleFatalPostHogException(error, "uncaught_exception");
+  });
+  process.on("unhandledRejection", (reason) => {
+    void handleFatalPostHogException(reason, "unhandled_rejection");
+  });
 }
 
 function getSafeProviderErrorCode(code: string | undefined): string | undefined {

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -23,6 +23,11 @@
     "receptionist": "Receptionist",
     "prompt": "Prompt"
   },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "description": "Reload the dashboard and try again. The error has been reported.",
+    "reload": "Reload"
+  },
   "feedback": {
     "trigger": "Feedback",
     "title": "Send feedback",

--- a/apps/web/public/locales/fr/common.json
+++ b/apps/web/public/locales/fr/common.json
@@ -23,6 +23,11 @@
     "receptionist": "Réceptionniste",
     "prompt": "Demande"
   },
+  "errorBoundary": {
+    "title": "Une erreur est survenue",
+    "description": "Rechargez le tableau de bord et réessayez. L’erreur a été signalée.",
+    "reload": "Recharger"
+  },
   "feedback": {
     "trigger": "Feedback",
     "title": "Envoyer un commentaire",

--- a/apps/web/scripts/upload-posthog-sourcemaps.mjs
+++ b/apps/web/scripts/upload-posthog-sourcemaps.mjs
@@ -41,11 +41,22 @@ function runPostHogCli(args) {
   });
 }
 
+function isProductionDeploy() {
+  return (
+    process.env.DEPLOYMENT_MODE === "cloud" ||
+    process.env.NODE_ENV === "production" ||
+    process.env.CF_PAGES === "1"
+  );
+}
+
 const missingEnvVars = requiredEnvVars.filter((name) => !readOptionalEnv(name));
 if (missingEnvVars.length > 0) {
-  console.log(
-    `[posthog] skipping sourcemap upload; missing ${missingEnvVars.join(", ")}.`,
-  );
+  const message = `[posthog] sourcemap upload missing ${missingEnvVars.join(", ")}.`;
+  if (isProductionDeploy()) {
+    console.error(`${message} Production deploys must upload PostHog sourcemaps.`);
+    process.exit(1);
+  }
+  console.log(`${message} Skipping outside production deploy mode.`);
   process.exit(0);
 }
 

--- a/apps/web/scripts/upload-posthog-sourcemaps.mjs
+++ b/apps/web/scripts/upload-posthog-sourcemaps.mjs
@@ -42,11 +42,16 @@ function runPostHogCli(args) {
 }
 
 function isProductionDeploy() {
-  return (
-    process.env.DEPLOYMENT_MODE === "cloud" ||
-    process.env.NODE_ENV === "production" ||
-    process.env.CF_PAGES === "1"
-  );
+  if (process.env.DEPLOYMENT_MODE === "cloud") {
+    return true;
+  }
+
+  if (process.env.CF_PAGES === "1") {
+    const productionBranch = readOptionalEnv("CF_PAGES_PRODUCTION_BRANCH") ?? "main";
+    return readOptionalEnv("CF_PAGES_BRANCH") === productionBranch;
+  }
+
+  return process.env.NODE_ENV === "production";
 }
 
 const missingEnvVars = requiredEnvVars.filter((name) => !readOptionalEnv(name));

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
-import { useAction, useConvexAuth, useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
 
 import { api } from "../../../convex/_generated/api";
@@ -12,6 +12,7 @@ import {
   OnboardingVerifyRouteSkeleton,
   WorkspaceRouteSkeleton,
 } from "@/components/app-route-skeletons";
+import { useObservedAction } from "@/lib/observed-convex";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Main } from "@/components/layout/main";
@@ -501,7 +502,7 @@ function OnboardingVerifyPhoneRoute() {
   const navigate = useNavigate();
   const currentUser = useQuery(api.users.current, {});
   const businesses = useQuery(api.businesses.admin.listForCurrentUser, {});
-  const reuseVerifiedPhoneForOnboarding = useAction(
+  const reuseVerifiedPhoneForOnboarding = useObservedAction(
     api.onboarding.phoneVerification.reuseVerifiedPhoneForOnboarding,
   );
   const activeBusiness = selectActiveBusiness(currentUser, businesses);

--- a/apps/web/src/components/feedback-widget.tsx
+++ b/apps/web/src/components/feedback-widget.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { useMutation } from "convex/react";
+
 import { MessageSquareShare } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import {
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
+import { useObservedMutation } from "@/lib/observed-convex";
 import {
   Popover,
   PopoverContent,
@@ -34,7 +35,7 @@ type FeedbackWidgetProps = {
 export function FeedbackWidget({ businessId, className }: FeedbackWidgetProps) {
   const { t } = useTranslation("common");
   const location = useLocation();
-  const submitFeedback = useMutation(api.feedback.submit);
+  const submitFeedback = useObservedMutation(api.feedback.submit);
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
 

--- a/apps/web/src/components/locale-provider.tsx
+++ b/apps/web/src/components/locale-provider.tsx
@@ -6,7 +6,8 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useObservedMutation } from "@/lib/observed-convex";
+import { useConvexAuth, useQuery } from "convex/react";
 
 import i18n from "@/i18n";
 import { api } from "../../../../convex/_generated/api";
@@ -34,7 +35,7 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
     api.users.preferences.getPreferredLocale,
     auth.isAuthenticated ? {} : "skip",
   );
-  const updatePreferredLocale = useMutation(api.users.preferences.updatePreferredLocale);
+  const updatePreferredLocale = useObservedMutation(api.users.preferences.updatePreferredLocale);
   const [locale, setLocaleState] = useState<SupportedLocale>(
     resolveStartupLocale({
       storedLocale: readStoredLocale(),

--- a/apps/web/src/features/agent/AddKnowledgeSheet.tsx
+++ b/apps/web/src/features/agent/AddKnowledgeSheet.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useId, useMemo, useState } from "react";
-import { useMutation } from "convex/react";
+
 import { useTranslation } from "react-i18next";
 import { Plus } from "lucide-react";
 
@@ -14,6 +14,7 @@ import {
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
+import { useObservedMutation } from "@/lib/observed-convex";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -53,7 +54,7 @@ export function AddKnowledgeSheet({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { t } = useTranslation(["agent", "knowledge"]);
-  const upsertKnowledgeSnippet = useMutation(api.ai.context.knowledge.upsertKnowledgeSnippet);
+  const upsertKnowledgeSnippet = useObservedMutation(api.ai.context.knowledge.upsertKnowledgeSnippet);
   const isControlled = open !== undefined;
   const [internalOpen, setInternalOpen] = useState(false);
   const [title, setTitle] = useState("");

--- a/apps/web/src/features/agent/AgentBasicSettingsPage.tsx
+++ b/apps/web/src/features/agent/AgentBasicSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useMutation, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import type { AppointmentChangePolicy, RuntimeLocale } from "@lobbystack/shared";
 import { useTranslation } from "react-i18next";
 
@@ -14,6 +14,7 @@ import {
   ItemGroup,
   ItemTitle,
 } from "@/components/ui/item";
+import { useObservedMutation } from "@/lib/observed-convex";
 import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
 import { PhoneInput } from "@/components/ui/phone-input";
 import { Input } from "@/components/ui/input";
@@ -74,7 +75,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
     businessId,
   });
   const isLoadingConfiguration = configuration === undefined;
-  const saveProfile = useMutation(api.ai.context.snapshots.updateReceptionistProfile);
+  const saveProfile = useObservedMutation(api.ai.context.snapshots.updateReceptionistProfile);
   const persistedProfile = configuration?.profile;
 
   const [greeting, setGreeting] = useState("");

--- a/apps/web/src/features/agent/AgentKnowledgePage.tsx
+++ b/apps/web/src/features/agent/AgentKnowledgePage.tsx
@@ -290,7 +290,10 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
   const locale = resolveLocale(i18n.resolvedLanguage, i18n.language);
   const convex = useConvex();
   const deleteKnowledgeEntry = useObservedAction(api.ai.context.knowledge.deleteKnowledgeEntry);
-  const setKnowledgeEntryActive = useObservedAction(api.ai.context.knowledge.setKnowledgeEntryActive);
+  const setKnowledgeEntryActive = useObservedAction(
+    api.ai.context.knowledge.setKnowledgeEntryActive,
+    { reportFailures: false },
+  );
   const deleteWebsiteIngestionJob = useObservedMutation(
     api.ai.context.websiteIngestion.deleteWebsiteIngestionJob,
   );

--- a/apps/web/src/features/agent/AgentKnowledgePage.tsx
+++ b/apps/web/src/features/agent/AgentKnowledgePage.tsx
@@ -1,4 +1,4 @@
-import { useAction, useConvex, useMutation } from "convex/react";
+import { useConvex } from "convex/react";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import {
@@ -9,6 +9,7 @@ import {
   type ColumnDef,
   type PaginationState,
 } from "@tanstack/react-table";
+import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
 import { FileText, Globe, MoreHorizontal, Pause, Play, Search, Text, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -288,12 +289,12 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
   const headerActions = outletContext?.headerActions;
   const locale = resolveLocale(i18n.resolvedLanguage, i18n.language);
   const convex = useConvex();
-  const deleteKnowledgeEntry = useAction(api.ai.context.knowledge.deleteKnowledgeEntry);
-  const setKnowledgeEntryActive = useAction(api.ai.context.knowledge.setKnowledgeEntryActive);
-  const deleteWebsiteIngestionJob = useMutation(
+  const deleteKnowledgeEntry = useObservedAction(api.ai.context.knowledge.deleteKnowledgeEntry);
+  const setKnowledgeEntryActive = useObservedAction(api.ai.context.knowledge.setKnowledgeEntryActive);
+  const deleteWebsiteIngestionJob = useObservedMutation(
     api.ai.context.websiteIngestion.deleteWebsiteIngestionJob,
   );
-  const cancelWebsiteIngestionJob = useAction(
+  const cancelWebsiteIngestionJob = useObservedAction(
     api.ai.context.websiteIngestion.cancelWebsiteIngestionJob,
   );
   const { data: knowledge, isInitialLoading: isLoadingKnowledge } = useRememberedConvexQuery(

--- a/apps/web/src/features/agent/ImportWebsiteKnowledgeSheet.tsx
+++ b/apps/web/src/features/agent/ImportWebsiteKnowledgeSheet.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from "react";
-import { useAction } from "convex/react";
+
 import { Globe, LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -15,6 +15,7 @@ import {
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
+import { useObservedAction } from "@/lib/observed-convex";
 import { Input } from "@/components/ui/input";
 import {
   Dialog,
@@ -37,7 +38,7 @@ export function ImportWebsiteKnowledgeSheet({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { t } = useTranslation("agent");
-  const submitWebsiteIngestion = useAction(api.ai.context.websiteIngestion.submitWebsiteIngestion);
+  const submitWebsiteIngestion = useObservedAction(api.ai.context.websiteIngestion.submitWebsiteIngestion);
   const isControlled = open !== undefined;
   const [internalOpen, setInternalOpen] = useState(false);
   const [websiteUrl, setWebsiteUrl] = useState("");

--- a/apps/web/src/features/agent/ImportWebsiteKnowledgeSheet.tsx
+++ b/apps/web/src/features/agent/ImportWebsiteKnowledgeSheet.tsx
@@ -38,7 +38,10 @@ export function ImportWebsiteKnowledgeSheet({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { t } = useTranslation("agent");
-  const submitWebsiteIngestion = useObservedAction(api.ai.context.websiteIngestion.submitWebsiteIngestion);
+  const submitWebsiteIngestion = useObservedAction(
+    api.ai.context.websiteIngestion.submitWebsiteIngestion,
+    { reportFailures: false },
+  );
   const isControlled = open !== undefined;
   const [internalOpen, setInternalOpen] = useState(false);
   const [websiteUrl, setWebsiteUrl] = useState("");

--- a/apps/web/src/features/agent/UploadKnowledgeDocumentSheet.tsx
+++ b/apps/web/src/features/agent/UploadKnowledgeDocumentSheet.tsx
@@ -107,9 +107,13 @@ export function UploadKnowledgeDocumentSheet({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { t } = useTranslation("agent");
-  const generateUploadUrl = useObservedMutation(api.ai.context.knowledge.generateKnowledgeDocumentUploadUrl);
+  const generateUploadUrl = useObservedMutation(
+    api.ai.context.knowledge.generateKnowledgeDocumentUploadUrl,
+    { reportFailures: false },
+  );
   const finalizeKnowledgeDocumentUpload = useObservedAction(
     api.ai.context.knowledge.finalizeKnowledgeDocumentUpload,
+    { reportFailures: false },
   );
 
   const isControlled = open !== undefined;

--- a/apps/web/src/features/agent/UploadKnowledgeDocumentSheet.tsx
+++ b/apps/web/src/features/agent/UploadKnowledgeDocumentSheet.tsx
@@ -1,5 +1,5 @@
 import { type DragEvent, FormEvent, useMemo, useRef, useState } from "react";
-import { useAction, useMutation } from "convex/react";
+
 import { useTranslation } from "react-i18next";
 import { Upload } from "lucide-react";
 
@@ -15,6 +15,7 @@ import {
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
+import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
 import { Input } from "@/components/ui/input";
 import {
   Dialog,
@@ -106,8 +107,8 @@ export function UploadKnowledgeDocumentSheet({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { t } = useTranslation("agent");
-  const generateUploadUrl = useMutation(api.ai.context.knowledge.generateKnowledgeDocumentUploadUrl);
-  const finalizeKnowledgeDocumentUpload = useAction(
+  const generateUploadUrl = useObservedMutation(api.ai.context.knowledge.generateKnowledgeDocumentUploadUrl);
+  const finalizeKnowledgeDocumentUpload = useObservedAction(
     api.ai.context.knowledge.finalizeKnowledgeDocumentUpload,
   );
 

--- a/apps/web/src/features/analytics/AnalyticsPage.tsx
+++ b/apps/web/src/features/analytics/AnalyticsPage.tsx
@@ -1,10 +1,11 @@
-import { useMutation } from "convex/react";
+
 import { useEffect } from "react";
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import { api } from "../../../../../convex/_generated/api";
 import { Analytics } from "@/features/home/components/analytics";
 import { BusinessSetupCard } from "@/features/workspace/business-setup-card";
 
+import { useObservedMutation } from "@/lib/observed-convex";
 type AnalyticsPageProps = {
   businessId?: Id<"businesses">;
 };
@@ -18,7 +19,7 @@ type UnitEconomicsRefreshState = {
 };
 
 export function AnalyticsPage({ businessId }: AnalyticsPageProps) {
-  const refreshUnitEconomicsMonth = useMutation(api.unitEconomics.refreshMonth);
+  const refreshUnitEconomicsMonth = useObservedMutation(api.unitEconomics.refreshMonth);
 
   useEffect(() => {
     if (!businessId) {

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -1,7 +1,7 @@
 import type { FormEvent, ReactNode } from "react";
 import { useState } from "react";
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useAction, useConvexAuth } from "convex/react";
+import { useConvexAuth } from "convex/react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { Link, useSearchParams } from "react-router-dom";
@@ -13,6 +13,7 @@ import { SignupForm } from "@/components/signup-form";
 import { Button } from "@/components/ui/button";
 import { captureAnalyticsEvent, resetAnalyticsIdentity } from "@/lib/analytics";
 
+import { useObservedAction } from "@/lib/observed-convex";
 type AuthErrorFlow = "signIn" | "signUp" | "resetRequest" | "resetVerification";
 
 function capturePublicAuthEvent(name: "web.auth.login_succeeded" | "web.auth.signup_succeeded") {
@@ -293,7 +294,7 @@ export function ForgotPasswordPage() {
 export function ConfirmEmailChangePage() {
   const { t } = useTranslation("auth");
   const auth = useConvexAuth();
-  const confirmEmailChange = useAction(api.businesses.catalog.confirmEmailChange);
+  const confirmEmailChange = useObservedAction(api.businesses.catalog.confirmEmailChange);
   const [searchParams] = useSearchParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);

--- a/apps/web/src/features/calls/CallDetailPage.tsx
+++ b/apps/web/src/features/calls/CallDetailPage.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { useMutation } from "convex/react";
+
 import {
   ArrowLeft,
   CheckCircle2,
@@ -14,6 +14,7 @@ import {
   Phone,
   XCircle,
 } from "lucide-react";
+import { useObservedMutation } from "@/lib/observed-convex";
 import { useTranslation } from "react-i18next";
 
 import { api } from "../../../../../convex/_generated/api";
@@ -459,7 +460,7 @@ function DetailsTab({
   locale: string;
 }) {
   const { t } = useTranslation("calls");
-  const completeFollowUp = useMutation(
+  const completeFollowUp = useObservedMutation(
     api.voice.runtime.completeVoiceFollowUpTask,
   );
   const [isMarkingDone, setIsMarkingDone] = useState(false);

--- a/apps/web/src/features/contacts/ContactDetailPage.tsx
+++ b/apps/web/src/features/contacts/ContactDetailPage.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { useMutation } from "convex/react";
+
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -14,6 +14,7 @@ import {
   Activity,
   User,
 } from "lucide-react";
+import { useObservedMutation } from "@/lib/observed-convex";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -803,9 +804,9 @@ export function ContactDetailPage({ businessId }: ContactDetailPageProps) {
   const { contactId } = useParams<{ contactId: string }>();
   const { i18n, t } = useTranslation("contacts");
   const locale = resolveLocale(i18n.resolvedLanguage, i18n.language);
-  const blockContact = useMutation(api.dashboard.contacts.blockContact);
-  const deleteContact = useMutation(api.dashboard.contacts.deleteContact);
-  const unblockContact = useMutation(api.dashboard.contacts.unblockContact);
+  const blockContact = useObservedMutation(api.dashboard.contacts.blockContact);
+  const deleteContact = useObservedMutation(api.dashboard.contacts.deleteContact);
+  const unblockContact = useObservedMutation(api.dashboard.contacts.unblockContact);
   const navigate = useNavigate();
 
   const rememberedDetail = useRememberedConvexQuery(

--- a/apps/web/src/features/contacts/ContactsPage.tsx
+++ b/apps/web/src/features/contacts/ContactsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useMutation } from "convex/react";
+
 import { useNavigate } from "react-router-dom";
 import {
   flexRender,
@@ -9,6 +9,7 @@ import {
   type ColumnDef,
   type PaginationState,
 } from "@tanstack/react-table";
+import { useObservedMutation } from "@/lib/observed-convex";
 import { Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -68,9 +69,9 @@ export function ContactsPage({ businessId }: ContactsPageProps) {
     api.dashboard.contacts.listContacts,
     businessId ? { businessId } : "skip",
   );
-  const blockContact = useMutation(api.dashboard.contacts.blockContact);
-  const deleteContact = useMutation(api.dashboard.contacts.deleteContact);
-  const unblockContact = useMutation(api.dashboard.contacts.unblockContact);
+  const blockContact = useObservedMutation(api.dashboard.contacts.blockContact);
+  const deleteContact = useObservedMutation(api.dashboard.contacts.deleteContact);
+  const unblockContact = useObservedMutation(api.dashboard.contacts.unblockContact);
   const [searchValue, setSearchValue] = useState("");
   const navigate = useNavigate();
   const [contactPendingDelete, setContactPendingDelete] = useState<ContactRow | null>(null);

--- a/apps/web/src/features/messages/MessagesPage.tsx
+++ b/apps/web/src/features/messages/MessagesPage.tsx
@@ -8,7 +8,8 @@ import {
   type FormEvent,
   type ChangeEvent,
 } from "react";
-import { useAction, useMutation } from "convex/react";
+import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
+
 import {
   ArrowLeft,
   ChevronRight,
@@ -377,16 +378,16 @@ export function MessagesPage({ businessId }: MessagesPageProps) {
     api.dashboard.messages.listConversationSummaries,
     businessId ? { businessId } : "skip",
   );
-  const sendSmsReply = useAction(api.dashboard.messages.sendSmsReply);
-  const pauseConversationAutomation = useAction(api.dashboard.messages.pauseConversationAutomation);
-  const repairConversationAttachmentPreviews = useAction(
+  const sendSmsReply = useObservedAction(api.dashboard.messages.sendSmsReply);
+  const pauseConversationAutomation = useObservedAction(api.dashboard.messages.pauseConversationAutomation);
+  const repairConversationAttachmentPreviews = useObservedAction(
     api.dashboard.messages.repairConversationAttachmentPreviews,
   );
-  const resumeConversationAutomation = useAction(api.dashboard.messages.resumeConversationAutomation);
-  const generateAttachmentUploadUrl = useMutation(api.dashboard.messages.generateAttachmentUploadUrl);
-  const finalizeStagedAttachment = useAction(api.dashboard.messages.finalizeStagedAttachment);
-  const clearStagedAttachments = useMutation(api.dashboard.messages.clearStagedAttachments);
-  const removeStagedAttachment = useMutation(api.dashboard.messages.removeStagedAttachment);
+  const resumeConversationAutomation = useObservedAction(api.dashboard.messages.resumeConversationAutomation);
+  const generateAttachmentUploadUrl = useObservedMutation(api.dashboard.messages.generateAttachmentUploadUrl);
+  const finalizeStagedAttachment = useObservedAction(api.dashboard.messages.finalizeStagedAttachment);
+  const clearStagedAttachments = useObservedMutation(api.dashboard.messages.clearStagedAttachments);
+  const removeStagedAttachment = useObservedMutation(api.dashboard.messages.removeStagedAttachment);
 
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const documentInputRef = useRef<HTMLInputElement | null>(null);

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useAction } from "convex/react";
+
 import type { CountryCode } from "libphonenumber-js/min";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -15,6 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useObservedAction } from "@/lib/observed-convex";
 import {
   Dialog,
   DialogContent,
@@ -133,9 +134,9 @@ export function OnboardingNumberPage({
 }: OnboardingNumberPageProps) {
   const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
-  const getInitialNumberSuggestion = useAction(api.onboarding.phoneNumbers.getInitialNumberSuggestion);
-  const searchAvailableNumbers = useAction(api.onboarding.phoneNumbers.searchAvailableNumbers);
-  const claimOnboardingNumber = useAction(api.onboarding.phoneNumbers.claimOnboardingNumber);
+  const getInitialNumberSuggestion = useObservedAction(api.onboarding.phoneNumbers.getInitialNumberSuggestion);
+  const searchAvailableNumbers = useObservedAction(api.onboarding.phoneNumbers.searchAvailableNumbers);
+  const claimOnboardingNumber = useObservedAction(api.onboarding.phoneNumbers.claimOnboardingNumber);
   const [market, setMarket] = useState<VerifiedPhoneMarket | null>(null);
   const [selectedNumber, setSelectedNumber] = useState<AvailableNumberSummary | null>(null);
   const [pickerNumbers, setPickerNumbers] = useState<Array<AvailableNumberSummary>>([]);

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAction } from "convex/react";
+
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { LoaderCircle, LogOut, ShieldCheck, Smartphone } from "lucide-react";
@@ -14,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useObservedAction } from "@/lib/observed-convex";
 import {
   Field,
   FieldDescription,
@@ -57,8 +58,8 @@ export function OnboardingVerifyPhonePage({
 }: OnboardingVerifyPhonePageProps) {
   const { i18n, t } = useTranslation("onboarding");
   const navigate = useNavigate();
-  const startPhoneVerification = useAction(api.onboarding.phoneVerification.startPhoneVerification);
-  const checkPhoneVerification = useAction(api.onboarding.phoneVerification.checkPhoneVerification);
+  const startPhoneVerification = useObservedAction(api.onboarding.phoneVerification.startPhoneVerification);
+  const checkPhoneVerification = useObservedAction(api.onboarding.phoneVerification.checkPhoneVerification);
   const [phoneInput, setPhoneInput] = useState<string | undefined>(currentUserPhone ?? undefined);
   const [verificationPhone, setVerificationPhone] = useState<string | null>(null);
   const [codeInput, setCodeInput] = useState("");

--- a/apps/web/src/features/onboarding/OnboardingWebsitePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingWebsitePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAction, useMutation } from "convex/react";
+
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Globe, LoaderCircle, LogOut } from "lucide-react";
@@ -14,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
 import {
   Field,
   FieldDescription,
@@ -37,8 +38,8 @@ export function OnboardingWebsitePage({
 }: OnboardingWebsitePageProps) {
   const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
-  const submitOnboardingWebsite = useAction(api.onboarding.websites.submitOnboardingWebsite);
-  const skipOnboardingWebsite = useMutation(api.onboarding.websites.skipOnboardingWebsite);
+  const submitOnboardingWebsite = useObservedAction(api.onboarding.websites.submitOnboardingWebsite);
+  const skipOnboardingWebsite = useObservedMutation(api.onboarding.websites.skipOnboardingWebsite);
   const [websiteUrl, setWebsiteUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/apps/web/src/features/settings/IntegrationsPage.tsx
+++ b/apps/web/src/features/settings/IntegrationsPage.tsx
@@ -214,10 +214,16 @@ export function IntegrationsPage({ businessId }: IntegrationsPageProps) {
     businessId,
   });
   const isLoadingConnections = connections === undefined;
-  const connectGoogle = useObservedAction(api.integrations.calendar.connectGoogle);
+  const connectGoogle = useObservedAction(api.integrations.calendar.connectGoogle, {
+    reportFailures: false,
+  });
   const disconnectGoogleCalendar = useObservedAction(api.integrations.calendar.disconnectGoogleCalendar);
-  const listGoogleCalendars = useObservedAction(api.integrations.calendar.listGoogleCalendars);
-  const selectGoogleCalendar = useObservedAction(api.integrations.calendar.selectGoogleCalendar);
+  const listGoogleCalendars = useObservedAction(api.integrations.calendar.listGoogleCalendars, {
+    reportFailures: false,
+  });
+  const selectGoogleCalendar = useObservedAction(api.integrations.calendar.selectGoogleCalendar, {
+    reportFailures: false,
+  });
 
   const googleConnections = useMemo(
     () =>

--- a/apps/web/src/features/settings/IntegrationsPage.tsx
+++ b/apps/web/src/features/settings/IntegrationsPage.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useAction, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import { RefreshCcw, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
@@ -20,6 +20,7 @@ import {
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
+import { useObservedAction } from "@/lib/observed-convex";
 import {
   Select,
   SelectContent,
@@ -213,10 +214,10 @@ export function IntegrationsPage({ businessId }: IntegrationsPageProps) {
     businessId,
   });
   const isLoadingConnections = connections === undefined;
-  const connectGoogle = useAction(api.integrations.calendar.connectGoogle);
-  const disconnectGoogleCalendar = useAction(api.integrations.calendar.disconnectGoogleCalendar);
-  const listGoogleCalendars = useAction(api.integrations.calendar.listGoogleCalendars);
-  const selectGoogleCalendar = useAction(api.integrations.calendar.selectGoogleCalendar);
+  const connectGoogle = useObservedAction(api.integrations.calendar.connectGoogle);
+  const disconnectGoogleCalendar = useObservedAction(api.integrations.calendar.disconnectGoogleCalendar);
+  const listGoogleCalendars = useObservedAction(api.integrations.calendar.listGoogleCalendars);
+  const selectGoogleCalendar = useObservedAction(api.integrations.calendar.selectGoogleCalendar);
 
   const googleConnections = useMemo(
     () =>

--- a/apps/web/src/features/settings/SettingsAccountPage.tsx
+++ b/apps/web/src/features/settings/SettingsAccountPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAction, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
@@ -14,6 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useObservedAction } from "@/lib/observed-convex";
 import {
   Field,
   FieldError,
@@ -37,8 +38,8 @@ export function SettingsAccountPage() {
   const currentUser = useQuery(api.users.current, {});
   const isLoadingEmail = currentUser === undefined;
   
-  const changeEmail = useAction(api.businesses.catalog.changeEmail);
-  const changePassword = useAction(api.businesses.catalog.changePassword);
+  const changeEmail = useObservedAction(api.businesses.catalog.changeEmail);
+  const changePassword = useObservedAction(api.businesses.catalog.changePassword);
 
   const [email, setEmail] = useState("");
   const [currentEmailPassword, setCurrentEmailPassword] = useState("");

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useAction, useMutation } from "convex/react";
+
 import { Link, Navigate } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import {
@@ -11,6 +11,7 @@ import {
   Lock,
   RefreshCw,
 } from "lucide-react";
+import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
 
 import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
@@ -633,8 +634,8 @@ function PlanSection({
   locale: BillingLocale;
   t: BillingTranslation;
 }) {
-  const startCheckout = useAction(api.billing.startCheckout);
-  const openPortal = useAction(api.billing.openPortal);
+  const startCheckout = useObservedAction(api.billing.startCheckout);
+  const openPortal = useObservedAction(api.billing.openPortal);
   const [loading, setLoading] = useState<"checkout" | "portal" | null>(null);
 
   const planLabel = getPlanLabel(status.plan, t);
@@ -1137,7 +1138,7 @@ function AddonsSection({
   locale: BillingLocale;
   t: BillingTranslation;
 }) {
-  const startCheckout = useAction(api.billing.startCheckout);
+  const startCheckout = useObservedAction(api.billing.startCheckout);
   const [loading, setLoading] = useState<"ai_sms" | "pro" | null>(null);
   const isOperational = status.aiSmsReady;
   const setupRequired =
@@ -1439,10 +1440,10 @@ function AiSmsComplianceSection({
   compliance: SmsComplianceState;
   t: BillingTranslation;
 }) {
-  const saveComplianceForm = useMutation(api.smsCompliance.saveComplianceForm);
-  const startRegistration = useAction(api.smsCompliance.startRegistration);
-  const resumeRegistration = useAction(api.smsCompliance.resumeRegistration);
-  const refreshRegistration = useAction(api.smsCompliance.refreshStatus);
+  const saveComplianceForm = useObservedMutation(api.smsCompliance.saveComplianceForm);
+  const startRegistration = useObservedAction(api.smsCompliance.startRegistration);
+  const resumeRegistration = useObservedAction(api.smsCompliance.resumeRegistration);
+  const refreshRegistration = useObservedAction(api.smsCompliance.refreshStatus);
   const { data: campaignOptions } = useSmsComplianceCampaignOptions();
   const [form, setForm] = useState<SmsComplianceFormState>(() =>
     buildSmsComplianceFormState(compliance),

--- a/apps/web/src/features/settings/SettingsBusinessPage.tsx
+++ b/apps/web/src/features/settings/SettingsBusinessPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useMutation, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import { useTranslation } from "react-i18next";
 
 import { api } from "../../../../../convex/_generated/api";
@@ -14,6 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useObservedMutation } from "@/lib/observed-convex";
 import {
   Field,
   FieldGroup,
@@ -40,7 +41,7 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
     businessId: props.businessId,
   });
   const isLoadingConfigurationData = configuration === undefined;
-  const updateBusinessName = useMutation(api.businesses.catalog.updateBusinessName);
+  const updateBusinessName = useObservedMutation(api.businesses.catalog.updateBusinessName);
   const [businessName, setBusinessName] = useState("");
   const [isBusinessNameDialogOpen, setIsBusinessNameDialogOpen] = useState(false);
   const [businessNameStatus, setBusinessNameStatus] = useState<string | null>(null);

--- a/apps/web/src/features/settings/SettingsNotificationsPage.tsx
+++ b/apps/web/src/features/settings/SettingsNotificationsPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import {
   ItemDescription,
   ItemTitle,
 } from "@/components/ui/item";
+import { useObservedMutation } from "@/lib/observed-convex";
 import {
   NativeSelect,
   NativeSelectOption,
@@ -88,7 +89,7 @@ export function SettingsNotificationsPage({
     api.users.preferences.getNotificationPreferences,
     { businessId },
   );
-  const updateNotificationPreferences = useMutation(
+  const updateNotificationPreferences = useObservedMutation(
     api.users.preferences.updateNotificationPreferences,
   );
   const saveVersionRef = useRef(0);

--- a/apps/web/src/features/workspace/business-setup-card.tsx
+++ b/apps/web/src/features/workspace/business-setup-card.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from "react";
-import { useMutation } from "convex/react";
+
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useObservedMutation } from "@/lib/observed-convex";
 import {
   Field,
   FieldContent,
@@ -39,7 +40,7 @@ function slugify(value: string): string {
 export function BusinessSetupCard() {
   const { t } = useTranslation("dashboard");
   const navigate = useNavigate();
-  const bootstrapBusiness = useMutation(api.businesses.admin.bootstrapBusiness);
+  const bootstrapBusiness = useObservedMutation(api.businesses.admin.bootstrapBusiness);
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
   const [timezone, setTimezone] = useState("America/Toronto");

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 import posthog from "posthog-js";
 
 import {
+  buildAlertableExceptionTelemetryProperties,
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForOperator,
   redactTelemetryProperties,
@@ -304,10 +305,22 @@ export function captureAnalyticsException(
     return;
   }
 
+  const operation =
+    typeof properties?.operation === "string" ? properties.operation : "web_exception";
+  const normalized = normalizeException(error);
   const nextProperties: TelemetryProperties = redactTelemetryProperties({
     ...properties,
+    ...buildAlertableExceptionTelemetryProperties({
+      runtime: "web",
+      service: "web",
+      operation,
+      alertable:
+        typeof properties?.alertable === "boolean" ? properties.alertable : true,
+      expected: typeof properties?.expected === "boolean" ? properties.expected : false,
+      exceptionType: normalized.type,
+      exceptionMessage: `${operation} failed (${normalized.type})`,
+    }),
     deploymentMode: DEPLOYMENT_MODE,
-    runtime: "web",
     ...(typeof window !== "undefined" && !properties?.pathname
       ? { pathname: window.location.pathname }
       : {}),
@@ -318,8 +331,6 @@ export function captureAnalyticsException(
       business: getPostHogBusinessGroupKey(properties.businessId),
     };
   }
-  const normalized = normalizeException(error);
-
   const errorToCapture =
     error instanceof Error
       ? error

--- a/apps/web/src/lib/observability-coverage.test.ts
+++ b/apps/web/src/lib/observability-coverage.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WEB_SRC_ROOT = join(process.cwd(), "src");
+const DIRECT_CONVEX_WRITE_HOOK_IMPORT_PATTERN =
+  /import\s*\{[\s\S]*?\}\s*from\s*["']convex\/react["'];/g;
+
+function listSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...listSourceFiles(path));
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(entry) && !/\.test\.(ts|tsx)$/.test(entry)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+describe("observability coverage", () => {
+  it("routes web Convex writes through observed hooks", () => {
+    const offenders: string[] = [];
+
+    for (const file of listSourceFiles(WEB_SRC_ROOT)) {
+      if (relative(WEB_SRC_ROOT, file) === "lib/observed-convex.ts") {
+        continue;
+      }
+
+      const source = readFileSync(file, "utf8");
+      const imports = source.matchAll(DIRECT_CONVEX_WRITE_HOOK_IMPORT_PATTERN);
+      for (const importStatement of imports) {
+        if (/\buse(Action|Mutation)\b/.test(importStatement[0])) {
+          offenders.push(relative(WEB_SRC_ROOT, file));
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/observed-convex.test.tsx
+++ b/apps/web/src/lib/observed-convex.test.tsx
@@ -1,0 +1,87 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { actionMock, captureAnalyticsExceptionMock, mutationMock } = vi.hoisted(() => ({
+  actionMock: vi.fn(),
+  captureAnalyticsExceptionMock: vi.fn(),
+  mutationMock: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useAction: () => actionMock,
+  useMutation: () => mutationMock,
+}));
+
+vi.mock("convex/server", () => ({
+  getFunctionName: () => "dashboard/test:run",
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  captureAnalyticsException: captureAnalyticsExceptionMock,
+}));
+
+describe("observed Convex hooks", () => {
+  afterEach(() => {
+    actionMock.mockReset();
+    mutationMock.mockReset();
+    captureAnalyticsExceptionMock.mockReset();
+  });
+
+  it("captures rejected mutations and rethrows", async () => {
+    const error = new Error("mutation failed");
+    mutationMock.mockRejectedValueOnce(error);
+    const { useObservedMutation } = await import("./observed-convex");
+    let observedMutation: (() => Promise<unknown>) | undefined;
+
+    function Probe() {
+      observedMutation = useObservedMutation({} as never);
+      return null;
+    }
+
+    render(<Probe />);
+
+    await expect(observedMutation?.()).rejects.toBe(error);
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        alertable: true,
+        convexFunction: "dashboard/test:run",
+        convexFunctionType: "mutation",
+        expected: false,
+        operation: "convex_mutation:dashboard/test:run",
+      }),
+    );
+  });
+
+  it("captures rejected actions with explicit operation metadata and rethrows", async () => {
+    const error = new Error("action failed");
+    actionMock.mockRejectedValueOnce(error);
+    const { useObservedAction } = await import("./observed-convex");
+    let observedAction: (() => Promise<unknown>) | undefined;
+
+    function Probe() {
+      observedAction = useObservedAction({} as never, {
+        operation: "settings.connect_google",
+        properties: {
+          safeId: "calendar_123",
+        },
+      });
+      return null;
+    }
+
+    render(<Probe />);
+
+    await expect(observedAction?.()).rejects.toBe(error);
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        alertable: true,
+        convexFunction: "dashboard/test:run",
+        convexFunctionType: "action",
+        expected: false,
+        operation: "settings.connect_google",
+        safeId: "calendar_123",
+      }),
+    );
+  });
+});

--- a/apps/web/src/lib/observed-convex.test.tsx
+++ b/apps/web/src/lib/observed-convex.test.tsx
@@ -41,8 +41,16 @@ describe("observed Convex hooks", () => {
     render(<Probe />);
 
     await expect(observedMutation?.()).rejects.toBe(error);
-    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
-      error,
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledOnce();
+    const [capturedError, properties] =
+      captureAnalyticsExceptionMock.mock.calls[0] ?? [];
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).not.toBe(error);
+    expect((capturedError as Error).name).toBe("ConvexMutationError");
+    expect((capturedError as Error).message).toBe(
+      "Convex mutation dashboard/test:run failed.",
+    );
+    expect(properties).toEqual(
       expect.objectContaining({
         alertable: true,
         convexFunction: "dashboard/test:run",
@@ -72,8 +80,16 @@ describe("observed Convex hooks", () => {
     render(<Probe />);
 
     await expect(observedAction?.()).rejects.toBe(error);
-    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
-      error,
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledOnce();
+    const [capturedError, properties] =
+      captureAnalyticsExceptionMock.mock.calls[0] ?? [];
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).not.toBe(error);
+    expect((capturedError as Error).name).toBe("ConvexActionError");
+    expect((capturedError as Error).message).toBe(
+      "Convex action dashboard/test:run failed.",
+    );
+    expect(properties).toEqual(
       expect.objectContaining({
         alertable: true,
         convexFunction: "dashboard/test:run",
@@ -83,5 +99,81 @@ describe("observed Convex hooks", () => {
         safeId: "calendar_123",
       }),
     );
+  });
+
+  it("does not report raw provider messages from rejected actions", async () => {
+    const error = new Error("Twilio failed for +14165550123");
+    actionMock.mockRejectedValueOnce(error);
+    const { useObservedAction } = await import("./observed-convex");
+    let observedAction: (() => Promise<unknown>) | undefined;
+
+    function Probe() {
+      observedAction = useObservedAction({} as never);
+      return null;
+    }
+
+    render(<Probe />);
+
+    await expect(observedAction?.()).rejects.toBe(error);
+    const [capturedError] = captureAnalyticsExceptionMock.mock.calls[0] ?? [];
+    expect((capturedError as Error).message).not.toContain("+14165550123");
+    expect((capturedError as Error).message).not.toContain("Twilio failed");
+  });
+
+  it("keeps the observed action callback stable for equivalent references", async () => {
+    const { useObservedAction } = await import("./observed-convex");
+    const observedActions: unknown[] = [];
+
+    function Probe({ reference }: { reference: unknown }) {
+      observedActions.push(useObservedAction(reference as never));
+      return null;
+    }
+
+    const { rerender } = render(<Probe reference={{}} />);
+    rerender(<Probe reference={{}} />);
+
+    expect(observedActions[1]).toBe(observedActions[0]);
+  });
+
+  it("marks handled Convex action rejections as expected and non-alertable", async () => {
+    const error = new Error("InvalidSecret");
+    actionMock.mockRejectedValueOnce(error);
+    const { useObservedAction } = await import("./observed-convex");
+    let observedAction: (() => Promise<unknown>) | undefined;
+
+    function Probe() {
+      observedAction = useObservedAction({} as never);
+      return null;
+    }
+
+    render(<Probe />);
+
+    await expect(observedAction?.()).rejects.toBe(error);
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        alertable: false,
+        expected: true,
+      }),
+    );
+  });
+
+  it("can skip automatic failure reporting when the caller reports explicitly", async () => {
+    const error = new Error("action failed");
+    actionMock.mockRejectedValueOnce(error);
+    const { useObservedAction } = await import("./observed-convex");
+    let observedAction: (() => Promise<unknown>) | undefined;
+
+    function Probe() {
+      observedAction = useObservedAction({} as never, {
+        reportFailures: false,
+      });
+      return null;
+    }
+
+    render(<Probe />);
+
+    await expect(observedAction?.()).rejects.toBe(error);
+    expect(captureAnalyticsExceptionMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/observed-convex.test.tsx
+++ b/apps/web/src/lib/observed-convex.test.tsx
@@ -24,6 +24,7 @@ describe("observed Convex hooks", () => {
   afterEach(() => {
     actionMock.mockReset();
     mutationMock.mockReset();
+    delete (mutationMock as { withOptimisticUpdate?: unknown }).withOptimisticUpdate;
     captureAnalyticsExceptionMock.mockReset();
   });
 
@@ -57,6 +58,45 @@ describe("observed Convex hooks", () => {
         convexFunctionType: "mutation",
         expected: false,
         operation: "convex_mutation:dashboard/test:run",
+      }),
+    );
+  });
+
+  it("preserves optimistic mutation updates while reporting failures", async () => {
+    const error = new Error("optimistic mutation failed");
+    const optimisticMutationMock = vi.fn().mockRejectedValueOnce(error);
+    const withOptimisticUpdateMock = vi.fn(() => optimisticMutationMock);
+    (mutationMock as { withOptimisticUpdate?: typeof withOptimisticUpdateMock })
+      .withOptimisticUpdate = withOptimisticUpdateMock;
+
+    const { useObservedMutation } = await import("./observed-convex");
+    let observedMutation:
+      | {
+          withOptimisticUpdate: (
+            optimisticUpdate: (localStore: unknown, args: unknown) => void,
+          ) => () => Promise<unknown>;
+        }
+      | undefined;
+
+    function Probe() {
+      observedMutation = useObservedMutation({} as never);
+      return null;
+    }
+
+    render(<Probe />);
+
+    const optimisticUpdate = vi.fn();
+    const observedOptimisticMutation =
+      observedMutation?.withOptimisticUpdate(optimisticUpdate);
+
+    expect(withOptimisticUpdateMock).toHaveBeenCalledWith(optimisticUpdate);
+    await expect(observedOptimisticMutation?.()).rejects.toBe(error);
+    expect(optimisticMutationMock).toHaveBeenCalledOnce();
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        convexFunction: "dashboard/test:run",
+        convexFunctionType: "mutation",
       }),
     );
   });

--- a/apps/web/src/lib/observed-convex.ts
+++ b/apps/web/src/lib/observed-convex.ts
@@ -4,34 +4,65 @@ import type { FunctionReference } from "convex/server";
 import { useCallback } from "react";
 
 import { captureAnalyticsException } from "@/lib/analytics";
-import type { TelemetryProperties } from "@lobbystack/telemetry";
+import {
+  isExpectedConvexFailure,
+  type TelemetryProperties,
+} from "@lobbystack/telemetry";
 
 type ObservedConvexOptions = {
   operation?: string;
   alertable?: boolean;
   expected?: boolean;
+  reportFailures?: boolean;
   properties?: TelemetryProperties;
 };
-type AnyObservedFunctionReference = FunctionReference<
-  "query" | "mutation" | "action",
-  "public" | "internal"
->;
+
+function buildSanitizedConvexError(
+  referenceName: string,
+  type: "action" | "mutation",
+): Error {
+  const error = new Error(`Convex ${type} ${referenceName} failed.`);
+  error.name = type === "action" ? "ConvexActionError" : "ConvexMutationError";
+  return error;
+}
 
 function captureRejectedConvexCall(
   error: unknown,
-  reference: AnyObservedFunctionReference,
+  referenceName: string,
   type: "action" | "mutation",
   options?: ObservedConvexOptions,
 ): void {
-  const referenceName = getFunctionName(reference);
-  captureAnalyticsException(error, {
+  const expected = options?.expected ?? isExpectedConvexFailure(error);
+  captureAnalyticsException(buildSanitizedConvexError(referenceName, type), {
     ...options?.properties,
     operation: options?.operation ?? `convex_${type}:${referenceName}`,
     convexFunctionType: type,
     convexFunction: referenceName,
-    alertable: options?.alertable ?? true,
-    expected: options?.expected ?? false,
+    alertable: options?.alertable ?? !expected,
+    expected,
   });
+}
+
+function buildCaptureOptions(input: {
+  operation?: string | undefined;
+  alertable?: boolean | undefined;
+  expected?: boolean | undefined;
+  properties?: TelemetryProperties | undefined;
+}): ObservedConvexOptions | undefined {
+  const options: ObservedConvexOptions = {};
+  if (input.operation !== undefined) {
+    options.operation = input.operation;
+  }
+  if (input.alertable !== undefined) {
+    options.alertable = input.alertable;
+  }
+  if (input.expected !== undefined) {
+    options.expected = input.expected;
+  }
+  if (input.properties !== undefined) {
+    options.properties = input.properties;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
 }
 
 export function useObservedAction<
@@ -41,17 +72,30 @@ export function useObservedAction<
   options?: ObservedConvexOptions,
 ): ReturnType<typeof useAction<Reference>> {
   const actionFn = useAction(reference);
+  const referenceName = getFunctionName(reference);
+  const operation = options?.operation;
+  const alertable = options?.alertable;
+  const expected = options?.expected;
+  const properties = options?.properties;
+  const reportFailures = options?.reportFailures;
 
   return useCallback(
     (async (...args: Parameters<typeof actionFn>) => {
       try {
         return await actionFn(...args);
       } catch (error) {
-        captureRejectedConvexCall(error, reference, "action", options);
+        if (reportFailures !== false) {
+          captureRejectedConvexCall(
+            error,
+            referenceName,
+            "action",
+            buildCaptureOptions({ operation, alertable, expected, properties }),
+          );
+        }
         throw error;
       }
     }) as ReturnType<typeof useAction<Reference>>,
-    [actionFn, options, reference],
+    [actionFn, alertable, expected, operation, properties, referenceName, reportFailures],
   );
 }
 
@@ -62,17 +106,30 @@ export function useObservedMutation<
   options?: ObservedConvexOptions,
 ): ReturnType<typeof useMutation<Reference>> {
   const mutationFn = useMutation(reference);
+  const referenceName = getFunctionName(reference);
+  const operation = options?.operation;
+  const alertable = options?.alertable;
+  const expected = options?.expected;
+  const properties = options?.properties;
+  const reportFailures = options?.reportFailures;
 
   return useCallback(
     (async (...args: Parameters<typeof mutationFn>) => {
       try {
         return await mutationFn(...args);
       } catch (error) {
-        captureRejectedConvexCall(error, reference, "mutation", options);
+        if (reportFailures !== false) {
+          captureRejectedConvexCall(
+            error,
+            referenceName,
+            "mutation",
+            buildCaptureOptions({ operation, alertable, expected, properties }),
+          );
+        }
         throw error;
       }
     }) as ReturnType<typeof useMutation<Reference>>,
-    [mutationFn, options, reference],
+    [alertable, expected, mutationFn, operation, properties, referenceName, reportFailures],
   );
 }
 

--- a/apps/web/src/lib/observed-convex.ts
+++ b/apps/web/src/lib/observed-convex.ts
@@ -1,7 +1,7 @@
-import { useAction, useMutation } from "convex/react";
+import { useAction, useMutation, type ReactMutation } from "convex/react";
 import { getFunctionName } from "convex/server";
 import type { FunctionReference } from "convex/server";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { captureAnalyticsException } from "@/lib/analytics";
 import {
@@ -65,6 +65,34 @@ function buildCaptureOptions(input: {
   return Object.keys(options).length > 0 ? options : undefined;
 }
 
+function buildObservedMutation<
+  Reference extends FunctionReference<"mutation", "public">,
+>(
+  mutationFn: ReactMutation<Reference>,
+  referenceName: string,
+  options?: ObservedConvexOptions,
+): ReactMutation<Reference> {
+  const observedMutation = (async (...args: Parameters<ReactMutation<Reference>>) => {
+    try {
+      return await mutationFn(...args);
+    } catch (error) {
+      if (options?.reportFailures !== false) {
+        captureRejectedConvexCall(error, referenceName, "mutation", options);
+      }
+      throw error;
+    }
+  }) as ReactMutation<Reference>;
+
+  observedMutation.withOptimisticUpdate = ((optimisticUpdate) =>
+    buildObservedMutation(
+      mutationFn.withOptimisticUpdate(optimisticUpdate),
+      referenceName,
+      options,
+    )) as ReactMutation<Reference>["withOptimisticUpdate"];
+
+  return observedMutation;
+}
+
 export function useObservedAction<
   Reference extends FunctionReference<"action", "public">,
 >(
@@ -113,23 +141,17 @@ export function useObservedMutation<
   const properties = options?.properties;
   const reportFailures = options?.reportFailures;
 
-  return useCallback(
-    (async (...args: Parameters<typeof mutationFn>) => {
-      try {
-        return await mutationFn(...args);
-      } catch (error) {
-        if (reportFailures !== false) {
-          captureRejectedConvexCall(
-            error,
-            referenceName,
-            "mutation",
-            buildCaptureOptions({ operation, alertable, expected, properties }),
-          );
-        }
-        throw error;
-      }
-    }) as ReturnType<typeof useMutation<Reference>>,
-    [alertable, expected, mutationFn, operation, properties, referenceName, reportFailures],
+  const captureOptions = useMemo((): ObservedConvexOptions | undefined => {
+    const next = buildCaptureOptions({ operation, alertable, expected, properties }) ?? {};
+    if (reportFailures !== undefined) {
+      next.reportFailures = reportFailures;
+    }
+    return Object.keys(next).length > 0 ? next : undefined;
+  }, [alertable, expected, operation, properties, reportFailures]);
+
+  return useMemo(
+    () => buildObservedMutation(mutationFn, referenceName, captureOptions),
+    [captureOptions, mutationFn, referenceName],
   );
 }
 

--- a/apps/web/src/lib/observed-convex.ts
+++ b/apps/web/src/lib/observed-convex.ts
@@ -1,0 +1,79 @@
+import { useAction, useMutation } from "convex/react";
+import { getFunctionName } from "convex/server";
+import type { FunctionReference } from "convex/server";
+import { useCallback } from "react";
+
+import { captureAnalyticsException } from "@/lib/analytics";
+import type { TelemetryProperties } from "@lobbystack/telemetry";
+
+type ObservedConvexOptions = {
+  operation?: string;
+  alertable?: boolean;
+  expected?: boolean;
+  properties?: TelemetryProperties;
+};
+type AnyObservedFunctionReference = FunctionReference<
+  "query" | "mutation" | "action",
+  "public" | "internal"
+>;
+
+function captureRejectedConvexCall(
+  error: unknown,
+  reference: AnyObservedFunctionReference,
+  type: "action" | "mutation",
+  options?: ObservedConvexOptions,
+): void {
+  const referenceName = getFunctionName(reference);
+  captureAnalyticsException(error, {
+    ...options?.properties,
+    operation: options?.operation ?? `convex_${type}:${referenceName}`,
+    convexFunctionType: type,
+    convexFunction: referenceName,
+    alertable: options?.alertable ?? true,
+    expected: options?.expected ?? false,
+  });
+}
+
+export function useObservedAction<
+  Reference extends FunctionReference<"action", "public">,
+>(
+  reference: Reference,
+  options?: ObservedConvexOptions,
+): ReturnType<typeof useAction<Reference>> {
+  const actionFn = useAction(reference);
+
+  return useCallback(
+    (async (...args: Parameters<typeof actionFn>) => {
+      try {
+        return await actionFn(...args);
+      } catch (error) {
+        captureRejectedConvexCall(error, reference, "action", options);
+        throw error;
+      }
+    }) as ReturnType<typeof useAction<Reference>>,
+    [actionFn, options, reference],
+  );
+}
+
+export function useObservedMutation<
+  Reference extends FunctionReference<"mutation", "public">,
+>(
+  reference: Reference,
+  options?: ObservedConvexOptions,
+): ReturnType<typeof useMutation<Reference>> {
+  const mutationFn = useMutation(reference);
+
+  return useCallback(
+    (async (...args: Parameters<typeof mutationFn>) => {
+      try {
+        return await mutationFn(...args);
+      } catch (error) {
+        captureRejectedConvexCall(error, reference, "mutation", options);
+        throw error;
+      }
+    }) as ReturnType<typeof useMutation<Reference>>,
+    [mutationFn, options, reference],
+  );
+}
+
+export type { ObservedConvexOptions };

--- a/apps/web/src/lib/react-error-reporting.test.tsx
+++ b/apps/web/src/lib/react-error-reporting.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { captureAnalyticsExceptionMock } = vi.hoisted(() => ({
+  captureAnalyticsExceptionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  captureAnalyticsException: captureAnalyticsExceptionMock,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("React error reporting", () => {
+  afterEach(() => {
+    captureAnalyticsExceptionMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("captures render errors from the app error boundary", async () => {
+    const error = new Error("render failed");
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { AppErrorBoundary } = await import("./react-error-reporting");
+
+    function BrokenChild(): never {
+      throw error;
+    }
+
+    render(
+      <AppErrorBoundary fallback={<div>fallback rendered</div>}>
+        <BrokenChild />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByText("fallback rendered")).toBeTruthy();
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        alertable: true,
+        expected: false,
+        operation: "react_caught_error",
+        reactErrorKind: "caught",
+      }),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("captures React root uncaught errors", async () => {
+    const error = new Error("root failed");
+    const { onUncaughtReactError } = await import("./react-error-reporting");
+
+    onUncaughtReactError(error, {
+      componentStack: "at Root",
+    });
+
+    expect(captureAnalyticsExceptionMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        alertable: true,
+        componentStack: "at Root",
+        expected: false,
+        operation: "react_uncaught_error",
+        reactErrorKind: "uncaught",
+      }),
+    );
+  });
+});

--- a/apps/web/src/lib/react-error-reporting.tsx
+++ b/apps/web/src/lib/react-error-reporting.tsx
@@ -1,0 +1,138 @@
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+import { useTranslation } from "react-i18next";
+
+import { captureAnalyticsException } from "@/lib/analytics";
+
+const reportedErrors = new WeakSet<object>();
+
+type ReactErrorKind = "caught" | "uncaught" | "recoverable";
+type ReactErrorInfoLike = {
+  componentStack?: string | null | undefined;
+};
+
+type ReportReactErrorInput = {
+  error: unknown;
+  errorInfo?: ReactErrorInfoLike | undefined;
+  kind: ReactErrorKind;
+  operation?: string | undefined;
+};
+
+function shouldReport(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return true;
+  }
+  if (reportedErrors.has(error)) {
+    return false;
+  }
+  reportedErrors.add(error);
+  return true;
+}
+
+export function reportReactError(input: ReportReactErrorInput): void {
+  if (!shouldReport(input.error)) {
+    return;
+  }
+
+  captureAnalyticsException(input.error, {
+    operation: input.operation ?? `react_${input.kind}_error`,
+    reactErrorKind: input.kind,
+    componentStack: input.errorInfo?.componentStack,
+    alertable: true,
+    expected: false,
+  });
+}
+
+export function onCaughtReactError(
+  error: unknown,
+  errorInfo?: ReactErrorInfoLike | undefined,
+): void {
+  reportReactError({
+    error,
+    errorInfo,
+    kind: "caught",
+    operation: "react_caught_error",
+  });
+}
+
+export function onUncaughtReactError(
+  error: unknown,
+  errorInfo?: ReactErrorInfoLike | undefined,
+): void {
+  reportReactError({
+    error,
+    errorInfo,
+    kind: "uncaught",
+    operation: "react_uncaught_error",
+  });
+}
+
+export function onRecoverableReactError(
+  error: unknown,
+  errorInfo?: ReactErrorInfoLike | undefined,
+): void {
+  reportReactError({
+    error,
+    errorInfo,
+    kind: "recoverable",
+    operation: "react_recoverable_error",
+  });
+}
+
+export function RootErrorFallback(): ReactNode {
+  const { t } = useTranslation();
+
+  return (
+    <main className="flex min-h-svh items-center justify-center bg-background px-6 py-16 text-foreground">
+      <section className="w-full max-w-md space-y-4 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t("errorBoundary.title")}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t("errorBoundary.description")}
+        </p>
+        <button
+          className="inline-flex h-11 items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+          onClick={() => window.location.reload()}
+          type="button"
+        >
+          {t("errorBoundary.reload")}
+        </button>
+      </section>
+    </main>
+  );
+}
+
+type AppErrorBoundaryProps = {
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+    onCaughtReactError(error, errorInfo);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <RootErrorFallback />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,20 +11,32 @@ import { LocaleProvider } from "@/components/locale-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { initializeAnalytics } from "@/lib/analytics";
+import {
+  AppErrorBoundary,
+  onCaughtReactError,
+  onRecoverableReactError,
+  onUncaughtReactError,
+} from "@/lib/react-error-reporting";
 
 const convexUrl = import.meta.env.CONVEX_URL;
 const convex = new ConvexReactClient(convexUrl);
 
 initializeAnalytics();
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+ReactDOM.createRoot(document.getElementById("root")!, {
+  onCaughtError: onCaughtReactError,
+  onRecoverableError: onRecoverableReactError,
+  onUncaughtError: onUncaughtReactError,
+}).render(
   <React.StrictMode>
     <ConvexAuthProvider client={convex}>
       <ThemeProvider>
         <AppearanceProvider>
           <LocaleProvider>
-            <App />
-            <Toaster richColors />
+            <AppErrorBoundary>
+              <App />
+              <Toaster richColors />
+            </AppErrorBoundary>
           </LocaleProvider>
         </AppearanceProvider>
       </ThemeProvider>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -92,6 +92,7 @@ import type * as operatorNotifications from "../operatorNotifications.js";
 import type * as services_localizedNames from "../services/localizedNames.js";
 import type * as smsCompliance from "../smsCompliance.js";
 import type * as telemetry_ai from "../telemetry/ai.js";
+import type * as telemetry_observedFunctions from "../telemetry/observedFunctions.js";
 import type * as telemetry_posthog from "../telemetry/posthog.js";
 import type * as telemetry_shared from "../telemetry/shared.js";
 import type * as unitEconomics from "../unitEconomics.js";
@@ -190,6 +191,7 @@ declare const fullApi: ApiFromModules<{
   "services/localizedNames": typeof services_localizedNames;
   smsCompliance: typeof smsCompliance;
   "telemetry/ai": typeof telemetry_ai;
+  "telemetry/observedFunctions": typeof telemetry_observedFunctions;
   "telemetry/posthog": typeof telemetry_posthog;
   "telemetry/shared": typeof telemetry_shared;
   unitEconomics: typeof unitEconomics;

--- a/convex/ai/agents/runtime.ts
+++ b/convex/ai/agents/runtime.ts
@@ -1,13 +1,12 @@
-import { createThread, createTool, stepCountIs } from "@convex-dev/agent";
+import {
+  createThread,
+  createTool,
+  stepCountIs } from "@convex-dev/agent";
+import { observedInternalMutation as internalMutation } from "../../telemetry/observedFunctions";
 import { DateTime } from "luxon";
 import { v } from "convex/values";
 import { z } from "zod";
-import {
-  internalAction,
-  internalMutation,
-  internalQuery,
-  type ActionCtx,
-} from "../../_generated/server";
+import { internalQuery, type ActionCtx } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { receptionistAgent } from "../../lib/components";
@@ -43,6 +42,7 @@ import {
 } from "../../telemetry/shared";
 import { captureAiTraceStartedBestEffort } from "../../telemetry/ai";
 
+import { observedInternalAction as internalAction } from "../../telemetry/observedFunctions";
 function buildGroundedSystemPrompt(input: {
   locale: RuntimeLocale;
   summary: string;

--- a/convex/ai/context/knowledge.ts
+++ b/convex/ai/context/knowledge.ts
@@ -1,16 +1,14 @@
-import { createThread } from "@convex-dev/agent";
+import {
+  createThread } from "@convex-dev/agent";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation, observedMutation as mutation } from "../../telemetry/observedFunctions";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "../../telemetry/shared";
+  } from "../../telemetry/shared";
 import { v } from "convex/values";
 import {
-  action,
-  internalAction,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -52,6 +50,7 @@ import { scheduleSnapshotRefresh } from "../../businesses/admin";
 import { captureAiTraceStartedBestEffort } from "../../telemetry/ai";
 import { enqueuePostHogEventBestEffort } from "../../telemetry/posthog";
 
+import { observedAction as action } from "../../telemetry/observedFunctions";
 type KnowledgeSearchResult = Array<{ title?: string; text: string }>;
 type PreviewKnowledgeAnswer = { text: string; threadId: string };
 type BusinessIdArgs = { businessId: Id<"businesses"> };

--- a/convex/ai/context/knowledgeUploads.ts
+++ b/convex/ai/context/knowledgeUploads.ts
@@ -5,7 +5,7 @@ import { getConvexSize, v } from "convex/values";
 
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
-import { internalAction, type ActionCtx } from "../../_generated/server";
+import { type ActionCtx } from "../../_generated/server";
 import { getKnowledgeStorageLimitBytes } from "../../lib/billing";
 import {
   buildKnowledgeDocumentPreviewText,
@@ -22,6 +22,7 @@ import {
   extractPdfTextWithLocalOcr,
 } from "../../lib/node/knowledgeExtraction";
 
+import { observedInternalAction as internalAction } from "../../telemetry/observedFunctions";
 const KNOWLEDGE_DOCUMENT_UNREADABLE_ERROR =
   "We couldn't extract enough readable text from this file.";
 const KNOWLEDGE_STORAGE_LIMIT_ERROR_PREFIX = "Knowledge storage limit reached.";

--- a/convex/ai/context/snapshots.ts
+++ b/convex/ai/context/snapshots.ts
@@ -1,12 +1,11 @@
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "../../telemetry/shared";
+  } from "../../telemetry/shared";
+import { observedMutation as mutation } from "../../telemetry/observedFunctions";
 import { v } from "convex/values";
 import {
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type MutationCtx,
   type QueryCtx,
@@ -37,6 +36,7 @@ import {
   serializePostHogEvent,
 } from "../../telemetry/posthog";
 
+import { observedInternalMutation as internalMutation } from "../../telemetry/observedFunctions";
 type SnapshotBuilderInput = Parameters<typeof buildBusinessContextSnapshot>[0];
 type BusinessIdArgs = { businessId: Id<"businesses"> };
 type UpdateReceptionistProfileArgs = {

--- a/convex/ai/context/websiteIngestion.ts
+++ b/convex/ai/context/websiteIngestion.ts
@@ -1,14 +1,14 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
+import {
+  getAuthUserId } from "@convex-dev/auth/server";
+import { observedInternalMutation as internalMutation, observedMutation as mutation } from "../../telemetry/observedFunctions";
 import type { WorkflowId } from "@convex-dev/workflow";
 import { v } from "convex/values";
 
 import { internal } from "../../_generated/api";
-import type { Doc, Id } from "../../_generated/dataModel";
+import type { Doc,
+  Id } from "../../_generated/dataModel";
 import {
-  action,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -23,6 +23,7 @@ import {
   WEBSITE_INGESTION_PROVIDER,
 } from "../../lib/websiteIngestion";
 
+import { observedAction as action } from "../../telemetry/observedFunctions";
 type WebsiteIngestionJobIdArgs = {
   websiteIngestionJobId: Id<"website_ingestion_jobs">;
 };

--- a/convex/ai/context/websiteIngestionActions.ts
+++ b/convex/ai/context/websiteIngestionActions.ts
@@ -7,7 +7,7 @@ import { v } from "convex/values";
 
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
-import { internalAction, type ActionCtx } from "../../_generated/server";
+import { type ActionCtx } from "../../_generated/server";
 import { getKnowledgeStorageLimitBytes } from "../../lib/billing";
 import { bulkWorkpool, firecrawlScrape, KNOWLEDGE_INDEX_VERSION, rag } from "../../lib/components";
 import { buildKnowledgeDocumentPreviewText } from "../../lib/knowledgeDocuments";
@@ -31,6 +31,7 @@ import {
 } from "../../telemetry/shared";
 import { enqueuePostHogProviderExceptionBestEffort } from "../../telemetry/posthog";
 
+import { observedInternalAction as internalAction } from "../../telemetry/observedFunctions";
 type WebsiteIngestionJobIdArgs = {
   websiteIngestionJobId: Id<"website_ingestion_jobs">;
 };

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -1,14 +1,16 @@
 import {
   StreamId,
   StreamIdValidator,
-} from "@convex-dev/persistent-text-streaming";
-import { httpAction, mutation, query } from "../../_generated/server";
+  } from "@convex-dev/persistent-text-streaming";
+import { observedMutation as mutation } from "../../telemetry/observedFunctions";
+import { query } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { v } from "convex/values";
 import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../../lib/auth";
 import { persistentTextStreaming } from "../../lib/components";
 
+import { observedHttpAction as httpAction } from "../../telemetry/observedFunctions";
 // Convex component types can exceed local tsc recursion depth on these builders.
 // @ts-ignore Deep type instantiation from Convex component generics.
 export const createPreviewSession = mutation({

--- a/convex/ai/workflows/runtime.ts
+++ b/convex/ai/workflows/runtime.ts
@@ -1,6 +1,5 @@
 import type { WorkflowCtx } from "@convex-dev/workflow";
 import { v } from "convex/values";
-import { internalMutation } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { CALENDAR_RECONCILIATION_INTERVAL_MS } from "../../integrations/calendar";
@@ -15,6 +14,7 @@ import {
   getPostHogDistinctIdForBusinessSystem,
 } from "../../telemetry/shared";
 
+import { observedInternalMutation as internalMutation } from "../../telemetry/observedFunctions";
 const WEBSITE_CRAWL_RESULTS_POLL_DELAY_MS = 5_000;
 
 async function waitForFirecrawlWebsiteCrawlCompletion(

--- a/convex/appointments/booking.ts
+++ b/convex/appointments/booking.ts
@@ -1,13 +1,12 @@
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "../telemetry/shared";
+  } from "../telemetry/shared";
+import { observedMutation as mutation } from "../telemetry/observedFunctions";
 import { v } from "convex/values";
 import { DateTime } from "luxon";
 import {
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type MutationCtx,
   type QueryCtx,
@@ -23,6 +22,7 @@ import {
   serializePostHogEvent,
 } from "../telemetry/posthog";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 const SLOT_INTERVAL_MINUTES = 15;
 const DEFAULT_SLOT_LIMIT = 6;
 

--- a/convex/appointments/changeOtp.ts
+++ b/convex/appointments/changeOtp.ts
@@ -2,10 +2,10 @@
 
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
-import { internalAction } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { getTwilioClient, requireTwilioVerifyServiceSid } from "../lib/node/twilioClient";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 type TwilioVerificationResult = {
   sid: string;
   status: string;

--- a/convex/appointments/changes.ts
+++ b/convex/appointments/changes.ts
@@ -2,12 +2,7 @@ import { v } from "convex/values";
 import { DateTime } from "luxon";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
-import {
-  internalMutation,
-  internalQuery,
-  type MutationCtx,
-  type QueryCtx,
-} from "../_generated/server";
+import { internalQuery, type MutationCtx, type QueryCtx } from "../_generated/server";
 import { workflowManager } from "../lib/components";
 import {
   normalizeAppointmentChangePolicy,
@@ -15,6 +10,7 @@ import {
 } from "../lib/appointmentChangePolicy";
 import { getServiceNameCandidates } from "../lib/serviceNames";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 const VERIFICATION_TTL_MS = 10 * 60 * 1000;
 
 type AppointmentChangeAction = "cancel" | "reschedule";

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -1,4 +1,7 @@
-import { Polar as ConvexPolar, type PolarWebhookEvent } from "@convex-dev/polar";
+import {
+  Polar as ConvexPolar,
+  type PolarWebhookEvent } from "@convex-dev/polar";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation } from "./telemetry/observedFunctions";
 import { Polar as PolarSdk } from "@polar-sh/sdk";
 import type { HttpRouter } from "convex/server";
 import { v } from "convex/values";
@@ -14,11 +17,11 @@ import type {
   HostedCheckoutPlanSlug,
   SmsCapability,
   SmsSenderRole,
-} from "../packages/shared/src/billing";
+  } from "../packages/shared/src/billing";
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "./telemetry/shared";
+  } from "./telemetry/shared";
 import {
   billingAddonCatalog,
   billingErrorCodes,
@@ -26,13 +29,12 @@ import {
   getBillingMonthlyChargeCents,
   getKnowledgeStorageLimitBytes,
   getPolarMeteredUsagePayload,
-} from "../packages/shared/src/billing";
-import { components, internal } from "./_generated/api";
-import type { Doc, Id } from "./_generated/dataModel";
+  } from "../packages/shared/src/billing";
+import { components,
+  internal } from "./_generated/api";
+import type { Doc,
+  Id } from "./_generated/dataModel";
 import {
-  action,
-  internalAction,
-  internalMutation,
   internalQuery,
   query,
   type ActionCtx,
@@ -76,6 +78,7 @@ import {
   enqueuePostHogProviderExceptionBestEffort,
 } from "./telemetry/posthog";
 
+import { observedAction as action } from "./telemetry/observedFunctions";
 type BillingContact = {
   email: string | null;
   name: string | null;

--- a/convex/businesses/admin.ts
+++ b/convex/businesses/admin.ts
@@ -1,5 +1,7 @@
-import { v } from "convex/values";
-import { internalMutation, internalQuery, mutation, query } from "../_generated/server";
+import {
+  v } from "convex/values";
+import { observedMutation as mutation } from "../telemetry/observedFunctions";
+import { internalQuery, query } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { ensureCurrentUser, getCurrentUser, requireMembership } from "../lib/auth";
@@ -22,6 +24,7 @@ import {
 } from "../lib/receptionistProfileDefaults";
 import { DEFAULT_APPOINTMENT_CHANGE_POLICY } from "../lib/appointmentChangePolicy";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 /**
  * Create the initial tenant and owner membership for the authenticated user.
  */

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -1,18 +1,16 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
 import {
   getAuthSessionId,
   getAuthUserId,
   invalidateSessions,
   modifyAccountCredentials,
   retrieveAccount,
-} from "@convex-dev/auth/server";
+  } from "@convex-dev/auth/server";
 import { internal } from "../_generated/api";
 import {
-  action,
-  internalAction,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -51,6 +49,7 @@ import {
 } from "../lib/twilioUrls";
 import { scheduleSnapshotRefresh } from "./admin";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 const phoneNumberSaveArgs = {
   businessId: v.id("businesses"),
   phoneNumberId: v.optional(v.id("phone_numbers")),

--- a/convex/conversations/sessions.ts
+++ b/convex/conversations/sessions.ts
@@ -1,14 +1,10 @@
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
-import {
-  internalMutation,
-  internalQuery,
-  type MutationCtx,
-  type QueryCtx,
-} from "../_generated/server";
+import { internalQuery, type MutationCtx, type QueryCtx } from "../_generated/server";
 import { buildConversationOutcome } from "../dashboard/outcomes";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 export const SMS_SESSION_INACTIVITY_MS = 60 * 60 * 1000;
 
 export type PersistedConversationSessionSummary =

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -1,14 +1,13 @@
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "../telemetry/shared";
+  } from "../telemetry/shared";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 import { v } from "convex/values";
 import {
   type ActionCtx,
   type MutationCtx,
   type QueryCtx,
-  internalAction,
-  internalMutation,
   internalQuery,
 } from "../_generated/server";
 import { internal } from "../_generated/api";

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,7 +1,7 @@
 import { cronJobs } from "convex/server";
 import { internal } from "./_generated/api";
-import { internalAction } from "./_generated/server";
 
+import { observedInternalAction as internalAction } from "./telemetry/observedFunctions";
 const crons = cronJobs();
 
 export const dispatchDueNotifications = internalAction({
@@ -34,6 +34,12 @@ crons.interval(
   "emit telemetry observability heartbeat",
   { minutes: 5 },
   internal.telemetry.posthog.emitObservabilityHeartbeat,
+  {},
+);
+crons.interval(
+  "emit service health checks",
+  { minutes: 1 },
+  internal.telemetry.posthog.emitServiceHealthChecks,
   {},
 );
 

--- a/convex/dashboard/contacts.ts
+++ b/convex/dashboard/contacts.ts
@@ -1,10 +1,11 @@
 import { v } from "convex/values";
 
-import { mutation, query, type MutationCtx, type QueryCtx } from "../_generated/server";
+import { query, type MutationCtx, type QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireCurrentUser, requireMembership } from "../lib/auth";
 import { isContactBlocked } from "../lib/contactBlocking";
 
+import { observedMutation as mutation } from "../telemetry/observedFunctions";
 async function getCallsForConversation(
   ctx: QueryCtx,
   conversationId: Id<"conversations">,

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -1,13 +1,13 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
+import {
+  getAuthUserId } from "@convex-dev/auth/server";
+import { observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
-import type { Doc, Id } from "../_generated/dataModel";
+import type { Doc,
+  Id } from "../_generated/dataModel";
 import {
-  action,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -41,6 +41,7 @@ import {
   getPostHogDistinctIdForBusinessSystem,
 } from "../telemetry/shared";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 type MessageMediaRecord = NonNullable<Doc<"messages">["media"]>[number];
 type ConversationOutcome =
   | {

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,13 +1,17 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedInternalMutation as internalMutation, observedMutation as mutation } from "./telemetry/observedFunctions";
 
 import { internal } from "./_generated/api";
-import type { Doc, Id } from "./_generated/dataModel";
-import { internalAction, internalMutation, internalQuery, mutation } from "./_generated/server";
+import type { Doc,
+  Id } from "./_generated/dataModel";
+import { internalQuery } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { requireCurrentUser, requireMembership } from "./lib/auth";
 import { dashboardAbuseRateLimiter } from "./lib/components";
 import { sendTransactionalEmail } from "./lib/providers/email";
 
+import { observedInternalAction as internalAction } from "./telemetry/observedFunctions";
 const MAX_FEEDBACK_MESSAGE_LENGTH = 2_000;
 const MAX_PAGE_PATH_LENGTH = 500;
 const MAX_USER_AGENT_LENGTH = 1_000;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -4,13 +4,13 @@ import { billingErrorCodes } from "../packages/shared/src/billing";
 import {
   normalizeTwilioFormFields,
 } from "./lib/twilioSecurity";
-import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { auth } from "./auth";
 import { streamPreviewResponse } from "./ai/preview/stream";
 import { registerBillingRoutes } from "./billing";
 
+import { observedHttpAction as httpAction } from "./telemetry/observedFunctions";
 const http = httpRouter();
 
 registerBillingRoutes(http);

--- a/convex/integrations/calendar.ts
+++ b/convex/integrations/calendar.ts
@@ -1,16 +1,14 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
 import { paginationOptsValidator } from "convex/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "../telemetry/shared";
+  } from "../telemetry/shared";
 import {
-  action,
-  internalAction,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -26,6 +24,7 @@ import {
   serializePostHogEvent,
 } from "../telemetry/posthog";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 export const CALENDAR_RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
 const CALENDAR_SYNC_RETRY_DELAY_MS = CALENDAR_RECONCILIATION_INTERVAL_MS;
 const CALENDAR_SYNC_PENDING_TIMEOUT_MS = 15 * 60 * 1000;

--- a/convex/integrations/googleCalendar.ts
+++ b/convex/integrations/googleCalendar.ts
@@ -6,8 +6,9 @@ import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
-import { internalAction, type ActionCtx } from "../_generated/server";
+import { type ActionCtx } from "../_generated/server";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 const GOOGLE_AUTH_BASE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";

--- a/convex/integrations/messageMedia.ts
+++ b/convex/integrations/messageMedia.ts
@@ -3,10 +3,10 @@
 import { v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
-import { internalAction } from "../_generated/server";
 import { generateImagePreview } from "../lib/node/imagePreviews";
 import { isImageAttachment } from "../lib/messageAttachments";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 export const createImagePreviewForStorage = internalAction({
   args: {
     storageId: v.id("_storage"),

--- a/convex/integrations/twilioA2p.ts
+++ b/convex/integrations/twilioA2p.ts
@@ -4,7 +4,6 @@ import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import type { Doc } from "../_generated/dataModel";
-import { internalAction } from "../_generated/server";
 import { buildTwilioSmsInboundWebhookUrl } from "../lib/twilioUrls";
 import {
   assertSmsComplianceDraftReady,
@@ -19,6 +18,7 @@ import {
 } from "../lib/smsCompliance";
 import { getTwilioClient } from "../lib/node/twilioClient";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 const DEFAULT_TWILIO_A2P_TRUST_PRODUCT_POLICY_SID =
   "RNc97f3d2a7ccf01b0e53a29ee4c54d31a";
 

--- a/convex/integrations/twilioMessageStatus.ts
+++ b/convex/integrations/twilioMessageStatus.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
-import { internalMutation, type MutationCtx } from "../_generated/server";
+import { type MutationCtx } from "../_generated/server";
 import { mapTwilioStatusToMessageStatus, mapTwilioStatusToNotificationStatus, shouldApplyMessageStatusTransition, shouldApplyNotificationStatusTransition } from "../lib/twilioMessageStatus";
 import {
   getPostHogBusinessGroupKey,
@@ -9,6 +9,7 @@ import {
 } from "../telemetry/shared";
 import { serializePostHogEvent } from "../telemetry/posthog";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 type ReconcileTwilioMessageStatusArgs = {
   providerMessageSid: string;
   providerStatus: string;

--- a/convex/integrations/twilioSms.ts
+++ b/convex/integrations/twilioSms.ts
@@ -5,7 +5,6 @@ import twilio from "twilio";
 
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
-import { internalAction } from "../_generated/server";
 import {
   buildTwilioBasicAuthHeader,
   getTwilioClient,
@@ -19,6 +18,7 @@ import {
 } from "../lib/messageAttachments";
 import { generateImagePreview } from "../lib/node/imagePreviews";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 function extractAttachmentFileName(input: {
   contentDisposition: string | null;
   contentType: string;

--- a/convex/integrations/twilioVoice.ts
+++ b/convex/integrations/twilioVoice.ts
@@ -3,11 +3,11 @@
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
-import { internalAction } from "../_generated/server";
 import { isTerminalTwilioCallStatus } from "../lib/voiceCallStatus";
 import { getTwilioClient } from "../lib/node/twilioClient";
 import { enqueuePostHogProviderExceptionBestEffort } from "../telemetry/posthog";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 const CALL_PRICE_RETRY_DELAYS_MS = [
   30_000,
   120_000,

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -1,10 +1,9 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
 import {
   type ActionCtx,
-  internalAction,
-  internalMutation,
   internalQuery,
-  mutation,
 } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";

--- a/convex/onboarding/abuse.ts
+++ b/convex/onboarding/abuse.ts
@@ -2,14 +2,10 @@ import { v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
-import {
-  internalMutation,
-  internalQuery,
-  type ActionCtx,
-  type MutationCtx,
-} from "../_generated/server";
+import { internalQuery, type ActionCtx, type MutationCtx } from "../_generated/server";
 import { onboardingRateLimiter } from "../lib/components";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 const SUCCESSFUL_CLAIMS_PER_DAY = 2;
 const SUCCESSFUL_CLAIMS_PER_THIRTY_DAYS = 5;
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;

--- a/convex/onboarding/phoneNumbers.ts
+++ b/convex/onboarding/phoneNumbers.ts
@@ -4,7 +4,7 @@ import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
-import { action, type ActionCtx } from "../_generated/server";
+import { type ActionCtx } from "../_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import {
   type AvailableNumberSummary,
@@ -36,6 +36,7 @@ import {
   recordSuccessfulPurchaseLog,
 } from "./abuse";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 type TwilioAvailableNumber = {
   phoneNumber?: string | null;
   locality?: string | null;

--- a/convex/onboarding/phoneVerification.ts
+++ b/convex/onboarding/phoneVerification.ts
@@ -4,10 +4,11 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
-import { action, type ActionCtx } from "../_generated/server";
+import { type ActionCtx } from "../_generated/server";
 import { getTwilioClient, requireTwilioVerifyServiceSid } from "../lib/node/twilioClient";
 import { assertVerificationSendAllowed } from "./abuse";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 type TwilioLookupResult = {
   phoneNumber: string;
   countryCode: string;

--- a/convex/onboarding/phoneVerificationState.ts
+++ b/convex/onboarding/phoneVerificationState.ts
@@ -1,7 +1,8 @@
 import { v } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
-import { internalMutation, internalQuery } from "../_generated/server";
+import { internalQuery } from "../_generated/server";
 
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 function sortAttemptsDescending(
   attempts: Array<Doc<"onboarding_phone_verifications">>,
 ): Array<Doc<"onboarding_phone_verifications">> {

--- a/convex/onboarding/websites.ts
+++ b/convex/onboarding/websites.ts
@@ -1,17 +1,14 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
+import {
+  getAuthUserId } from "@convex-dev/auth/server";
+import { observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
-import {
-  action,
-  internalMutation,
-  mutation,
-  type ActionCtx,
-  type MutationCtx,
-} from "../_generated/server";
+import { type ActionCtx, type MutationCtx } from "../_generated/server";
 import { requireMembership } from "../lib/auth";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 type BusinessIdArgs = {
   businessId: Id<"businesses">;
 };

--- a/convex/operatorNotifications.ts
+++ b/convex/operatorNotifications.ts
@@ -1,13 +1,14 @@
-import { DateTime } from "luxon";
+import {
+  DateTime } from "luxon";
+import { observedInternalAction as internalAction, observedInternalMutation as internalMutation } from "./telemetry/observedFunctions";
 import { v } from "convex/values";
 
 import { internal } from "./_generated/api";
-import type { Doc, Id } from "./_generated/dataModel";
+import type { Doc,
+  Id } from "./_generated/dataModel";
 import {
   type ActionCtx,
   type QueryCtx,
-  internalAction,
-  internalMutation,
   internalQuery,
 } from "./_generated/server";
 import { sendTransactionalEmail } from "./lib/providers/email";

--- a/convex/services/localizedNames.ts
+++ b/convex/services/localizedNames.ts
@@ -1,12 +1,10 @@
-import { v } from "convex/values";
-import { internal } from "../_generated/api";
-import type { Doc, Id } from "../_generated/dataModel";
 import {
-  internalAction,
-  internalMutation,
-  internalQuery,
-  type ActionCtx,
-} from "../_generated/server";
+  v } from "convex/values";
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
+import { internal } from "../_generated/api";
+import type { Doc,
+  Id } from "../_generated/dataModel";
+import { internalQuery, type ActionCtx } from "../_generated/server";
 import { scheduleSnapshotRefresh } from "../businesses/admin";
 import { generateMissingLocalizedServiceNames } from "../lib/serviceNameGeneration";
 import {
@@ -15,6 +13,7 @@ import {
 } from "../lib/serviceNames";
 import { runtimeLocaleValidator } from "../lib/runtimeLocale";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 type ServiceLocalizationState = Pick<Doc<"services">, "_id" | "businessId" | "name"> & {
   localizedNames?: Doc<"services">["localizedNames"];
 };

--- a/convex/smsCompliance.ts
+++ b/convex/smsCompliance.ts
@@ -1,12 +1,12 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedInternalMutation as internalMutation, observedMutation as mutation } from "./telemetry/observedFunctions";
 
 import { internal } from "./_generated/api";
-import type { Doc, Id } from "./_generated/dataModel";
+import type { Doc,
+  Id } from "./_generated/dataModel";
 import {
-  action,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -33,6 +33,7 @@ import {
   type SmsSenderMode,
 } from "./lib/smsCompliance";
 
+import { observedAction as action } from "./telemetry/observedFunctions";
 type SmsPhoneNumberDoc = Pick<
   Doc<"phone_numbers">,
   "_id" | "e164" | "smsEnabled" | "status" | "twilioPhoneSid"

--- a/convex/telemetry/observedFunctions.ts
+++ b/convex/telemetry/observedFunctions.ts
@@ -1,0 +1,147 @@
+import {
+  action,
+  httpAction,
+  internalAction,
+  internalMutation,
+  mutation,
+} from "../_generated/server";
+import type { ActionCtx, MutationCtx } from "../_generated/server";
+
+import {
+  enqueuePostHogExceptionBestEffort,
+  getPostHogDistinctIdForConvexSystem,
+} from "./posthog";
+
+type ObservabilityOptions = {
+  operation?: string;
+  service?: string;
+  alertable?: boolean;
+  expected?: boolean;
+};
+
+type ObservableDefinition = {
+  handler?: unknown;
+  observability?: ObservabilityOptions;
+};
+
+type ConvexRunnerCtx = ActionCtx | MutationCtx;
+
+const DEFAULT_SERVICE = "convex";
+
+function getObservedOptions(definition: unknown): ObservabilityOptions {
+  if (!definition || typeof definition !== "object") {
+    return {};
+  }
+  const options = (definition as ObservableDefinition).observability;
+  return options && typeof options === "object" ? options : {};
+}
+
+function withoutObservabilityOption<T>(definition: T): T {
+  if (!definition || typeof definition !== "object") {
+    return definition;
+  }
+  const { observability: _observability, ...rest } =
+    definition as T & { observability?: ObservabilityOptions };
+  return rest as T;
+}
+
+async function reportConvexHandlerFailure(input: {
+  ctx: ConvexRunnerCtx;
+  error: unknown;
+  kind: "action" | "http_action" | "internal_action" | "mutation" | "internal_mutation";
+  options: ObservabilityOptions;
+}): Promise<void> {
+  await enqueuePostHogExceptionBestEffort(input.ctx, {
+    error: input.error,
+    service: input.options.service ?? DEFAULT_SERVICE,
+    operation: input.options.operation ?? `convex_${input.kind}`,
+    distinctId: getPostHogDistinctIdForConvexSystem(),
+    alertable: input.options.alertable ?? true,
+    expected: input.options.expected ?? false,
+    properties: {
+      convexFunctionType: input.kind,
+    },
+  });
+}
+
+function observeConfigHandler<T extends ObservableDefinition>(
+  definition: T,
+  kind: Parameters<typeof reportConvexHandlerFailure>[0]["kind"],
+): T {
+  const handler = definition.handler;
+  if (typeof handler !== "function") {
+    return withoutObservabilityOption(definition);
+  }
+  const options = getObservedOptions(definition);
+  return {
+    ...withoutObservabilityOption(definition),
+    handler: async (ctx: ConvexRunnerCtx, args: unknown) => {
+      try {
+        return await handler(ctx, args);
+      } catch (error) {
+        await reportConvexHandlerFailure({
+          ctx,
+          error,
+          kind,
+          options,
+        });
+        throw error;
+      }
+    },
+  } as T;
+}
+
+function observeHttpHandler<T extends (ctx: ActionCtx, request: Request) => unknown>(
+  handler: T,
+): T {
+  return (async (ctx: ActionCtx, request: Request) => {
+    try {
+      return await handler(ctx, request);
+    } catch (error) {
+      await reportConvexHandlerFailure({
+        ctx,
+        error,
+        kind: "http_action",
+        options: {},
+      });
+      throw error;
+    }
+  }) as T;
+}
+
+export const observedAction = ((definition: Parameters<typeof action>[0]) =>
+  action(
+    observeConfigHandler(definition as ObservableDefinition, "action") as Parameters<
+      typeof action
+    >[0],
+  )) as typeof action;
+
+export const observedInternalAction = ((
+  definition: Parameters<typeof internalAction>[0],
+) =>
+  internalAction(
+    observeConfigHandler(
+      definition as ObservableDefinition,
+      "internal_action",
+    ) as Parameters<typeof internalAction>[0],
+  )) as typeof internalAction;
+
+export const observedMutation = ((definition: Parameters<typeof mutation>[0]) =>
+  mutation(
+    observeConfigHandler(definition as ObservableDefinition, "mutation") as Parameters<
+      typeof mutation
+    >[0],
+  )) as typeof mutation;
+
+export const observedInternalMutation = ((
+  definition: Parameters<typeof internalMutation>[0],
+) =>
+  internalMutation(
+    observeConfigHandler(
+      definition as ObservableDefinition,
+      "internal_mutation",
+    ) as Parameters<typeof internalMutation>[0],
+  )) as typeof internalMutation;
+
+export const observedHttpAction = ((handler: Parameters<typeof httpAction>[0]) =>
+  httpAction(observeHttpHandler(handler))) as typeof httpAction;

--- a/convex/telemetry/observedFunctions.ts
+++ b/convex/telemetry/observedFunctions.ts
@@ -6,6 +6,7 @@ import {
   mutation,
 } from "../_generated/server";
 import type { ActionCtx, MutationCtx } from "../_generated/server";
+import { isExpectedConvexFailure } from "../../packages/telemetry/src/index";
 
 import {
   enqueuePostHogExceptionBestEffort,
@@ -51,13 +52,14 @@ async function reportConvexHandlerFailure(input: {
   kind: "action" | "http_action" | "internal_action" | "mutation" | "internal_mutation";
   options: ObservabilityOptions;
 }): Promise<void> {
+  const expected = input.options.expected ?? isExpectedConvexFailure(input.error);
   await enqueuePostHogExceptionBestEffort(input.ctx, {
     error: input.error,
     service: input.options.service ?? DEFAULT_SERVICE,
     operation: input.options.operation ?? `convex_${input.kind}`,
     distinctId: getPostHogDistinctIdForConvexSystem(),
-    alertable: input.options.alertable ?? true,
-    expected: input.options.expected ?? false,
+    alertable: input.options.alertable ?? !expected,
+    expected,
     properties: {
       convexFunctionType: input.kind,
     },
@@ -67,9 +69,17 @@ async function reportConvexHandlerFailure(input: {
 function observeConfigHandler<T extends ObservableDefinition>(
   definition: T,
   kind: Parameters<typeof reportConvexHandlerFailure>[0]["kind"],
+  wrapperOptions?: {
+    reportFailures?: boolean;
+  },
 ): T {
   const handler = definition.handler;
   if (typeof handler !== "function") {
+    return withoutObservabilityOption(definition);
+  }
+  if (wrapperOptions?.reportFailures === false) {
+    // Mutation failures roll back the whole transaction, including telemetry writes.
+    // Public mutations are observed by the web client and internal mutations bubble to actions.
     return withoutObservabilityOption(definition);
   }
   const options = getObservedOptions(definition);
@@ -128,9 +138,9 @@ export const observedInternalAction = ((
 
 export const observedMutation = ((definition: Parameters<typeof mutation>[0]) =>
   mutation(
-    observeConfigHandler(definition as ObservableDefinition, "mutation") as Parameters<
-      typeof mutation
-    >[0],
+    observeConfigHandler(definition as ObservableDefinition, "mutation", {
+      reportFailures: false,
+    }) as Parameters<typeof mutation>[0],
   )) as typeof mutation;
 
 export const observedInternalMutation = ((
@@ -140,6 +150,9 @@ export const observedInternalMutation = ((
     observeConfigHandler(
       definition as ObservableDefinition,
       "internal_mutation",
+      {
+        reportFailures: false,
+      },
     ) as Parameters<typeof internalMutation>[0],
   )) as typeof internalMutation;
 

--- a/convex/telemetry/posthog.test.ts
+++ b/convex/telemetry/posthog.test.ts
@@ -239,4 +239,68 @@ describe("PostHog provider exception telemetry", () => {
       service: "voice-gateway",
     });
   });
+
+  it("emits service health failures for malformed configured URLs", async () => {
+    type SerializedPostHogEvent = {
+      eventName: string;
+      distinctId: string;
+      payloadJson: string;
+    };
+    const originalAppBaseUrl = process.env.APP_BASE_URL;
+    const originalVoiceGatewayBaseUrl = process.env.VOICE_GATEWAY_BASE_URL;
+    process.env.APP_BASE_URL = "https://app.example.com";
+    process.env.VOICE_GATEWAY_BASE_URL = "voice.example.com";
+
+    const runMutation = vi.fn(
+      async (_reference: unknown, _serialized: SerializedPostHogEvent) => null,
+    );
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+
+    try {
+      const results = await emitServiceHealthCheckEvents(
+        { runMutation } as unknown as Parameters<
+          typeof emitServiceHealthCheckEvents
+        >[0],
+        undefined,
+        fetchImpl as unknown as typeof fetch,
+      );
+
+      expect(results).toMatchObject([
+        {
+          service: "web",
+          status: "healthy",
+        },
+        {
+          service: "voice-gateway",
+          status: "unhealthy",
+          errorKind: "invalid_config",
+        },
+      ]);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      const serializedEvents = runMutation.mock.calls.map((call) => call[1]);
+      expect(serializedEvents.map((event) => event.eventName)).toEqual([
+        "ops.service.health_check",
+        "ops.service.health_check_failed",
+        "$exception",
+      ]);
+      const failedPayload = JSON.parse(serializedEvents[1]?.payloadJson ?? "{}");
+      expect(failedPayload.properties).toMatchObject({
+        service: "voice-gateway",
+        status: "unhealthy",
+        errorKind: "invalid_config",
+      });
+    } finally {
+      if (originalAppBaseUrl === undefined) {
+        delete process.env.APP_BASE_URL;
+      } else {
+        process.env.APP_BASE_URL = originalAppBaseUrl;
+      }
+      if (originalVoiceGatewayBaseUrl === undefined) {
+        delete process.env.VOICE_GATEWAY_BASE_URL;
+      } else {
+        process.env.VOICE_GATEWAY_BASE_URL = originalVoiceGatewayBaseUrl;
+      }
+    }
+  });
 });

--- a/convex/telemetry/posthog.test.ts
+++ b/convex/telemetry/posthog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { enqueuePostHogProviderExceptionBestEffort } from "./posthog";
+import {
+  emitServiceHealthCheckEvents,
+  enqueuePostHogExceptionBestEffort,
+  enqueuePostHogProviderExceptionBestEffort,
+} from "./posthog";
 
 describe("PostHog provider exception telemetry", () => {
   it("enqueues provider failures with PostHog exception metadata", async () => {
@@ -49,9 +53,12 @@ describe("PostHog provider exception telemetry", () => {
     expect(payload.properties).toMatchObject({
       $exception_level: "error",
       $exception_type: "ProviderInvalidRequestError",
+      alertable: true,
+      expected: false,
       operation: "twilio.sms.send",
       providerErrorCode: "21211",
       runtime: "convex",
+      service: "convex",
     });
     expect(payload.properties.$exception_message).toBe("[redacted]");
     expect(payload.properties.providerErrorMessage).toBe("[redacted]");
@@ -79,5 +86,157 @@ describe("PostHog provider exception telemetry", () => {
         },
       },
     ]);
+  });
+
+  it("enqueues generic alertable exceptions without raw args", async () => {
+    type SerializedPostHogEvent = {
+      eventName: string;
+      distinctId: string;
+      payloadJson: string;
+    };
+    const runMutation = vi.fn(
+      async (_reference: unknown, _serialized: SerializedPostHogEvent) => null,
+    );
+    const error = new Error("database exploded with phone +14165550123");
+    error.name = "DatabaseUnavailableError";
+    error.stack = [
+      "DatabaseUnavailableError: database exploded with phone +14165550123",
+      "    at saveContact (/Users/raphael/Coding/ai-receptionist/convex/dashboard/contacts.ts:44:7)",
+    ].join("\n");
+
+    const ctx = { runMutation } as unknown as Parameters<
+      typeof enqueuePostHogExceptionBestEffort
+    >[0];
+
+    await enqueuePostHogExceptionBestEffort(ctx, {
+      error,
+      service: "convex",
+      operation: "dashboard.contacts.save",
+      distinctId: "system:convex:telemetry",
+      properties: {
+        rawArgs: {
+          phone: "+14165550123",
+        },
+        safeId: "contact_123",
+      },
+    });
+
+    expect(runMutation).toHaveBeenCalledOnce();
+    const serialized = runMutation.mock.calls[0]?.[1];
+    expect(serialized).toBeDefined();
+    if (!serialized) {
+      throw new Error("Expected serialized PostHog event payload.");
+    }
+    expect(serialized).toMatchObject({
+      eventName: "$exception",
+      distinctId: "system:convex:telemetry",
+    });
+
+    const payload = JSON.parse(serialized.payloadJson);
+    expect(payload.properties).toMatchObject({
+      $exception_level: "error",
+      $exception_type: "DatabaseUnavailableError",
+      alertable: true,
+      expected: false,
+      operation: "dashboard.contacts.save",
+      runtime: "convex",
+      safeId: "contact_123",
+      service: "convex",
+    });
+    expect(payload.properties).not.toHaveProperty("rawArgs");
+    expect(payload.properties.$exception_message).toBe("[redacted]");
+    expect(payload.properties.$exception_list).toMatchObject([
+      {
+        type: "DatabaseUnavailableError",
+        value: "convex dashboard.contacts.save failed (DatabaseUnavailableError)",
+        mechanism: {
+          handled: true,
+          synthetic: false,
+          type: "generic",
+        },
+      },
+    ]);
+  });
+
+  it("emits service health success and failure events", async () => {
+    type SerializedPostHogEvent = {
+      eventName: string;
+      distinctId: string;
+      payloadJson: string;
+    };
+    const runMutation = vi.fn(
+      async (_reference: unknown, _serialized: SerializedPostHogEvent) => null,
+    );
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).includes("voice.example.com")) {
+        return new Response("down", { status: 503 });
+      }
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const results = await emitServiceHealthCheckEvents(
+      { runMutation } as unknown as Parameters<typeof emitServiceHealthCheckEvents>[0],
+      [
+        {
+          service: "web",
+          url: "https://app.example.com",
+        },
+        {
+          service: "voice-gateway",
+          url: "https://voice.example.com/health",
+        },
+      ],
+      fetchImpl,
+    );
+
+    expect(results).toMatchObject([
+      {
+        service: "web",
+        status: "healthy",
+        httpStatusCode: 200,
+        targetUrlHost: "app.example.com",
+      },
+      {
+        service: "voice-gateway",
+        status: "unhealthy",
+        httpStatusCode: 503,
+        errorKind: "http_error",
+        targetUrlHost: "voice.example.com",
+      },
+    ]);
+    expect(runMutation).toHaveBeenCalledTimes(3);
+
+    const serializedEvents = runMutation.mock.calls.map((call) => call[1]);
+    expect(serializedEvents.map((event) => event.eventName)).toEqual([
+      "ops.service.health_check",
+      "ops.service.health_check_failed",
+      "$exception",
+    ]);
+
+    const healthyPayload = JSON.parse(serializedEvents[0]?.payloadJson ?? "{}");
+    expect(healthyPayload.properties).toMatchObject({
+      service: "web",
+      status: "healthy",
+      httpStatusCode: 200,
+      targetUrlHost: "app.example.com",
+    });
+
+    const failedPayload = JSON.parse(serializedEvents[1]?.payloadJson ?? "{}");
+    expect(failedPayload.properties).toMatchObject({
+      service: "voice-gateway",
+      status: "unhealthy",
+      httpStatusCode: 503,
+      errorKind: "http_error",
+      targetUrlHost: "voice.example.com",
+    });
+
+    const exceptionPayload = JSON.parse(serializedEvents[2]?.payloadJson ?? "{}");
+    expect(exceptionPayload.properties).toMatchObject({
+      $exception_type: "ServiceHealthCheckFailed",
+      alertable: true,
+      expected: false,
+      operation: "service_health_check",
+      service: "voice-gateway",
+    });
   });
 });

--- a/convex/telemetry/posthog.ts
+++ b/convex/telemetry/posthog.ts
@@ -5,6 +5,7 @@ import {
 } from "./shared";
 import { v } from "convex/values";
 import {
+  buildAlertableExceptionTelemetryProperties,
   buildProviderErrorTelemetryProperties,
   classifyProviderError,
   type ExternalProvider,
@@ -88,6 +89,22 @@ type EnqueueProviderFailureExceptionInput = TelemetryContext & {
   properties?: TelemetryProperties;
 };
 
+type EnqueueConvexExceptionInput = Omit<TelemetryContext, "provider"> & {
+  provider?: ExternalProvider;
+  error?: unknown;
+  service: string;
+  operation: string;
+  distinctId: string;
+  businessId?: Id<"businesses">;
+  groupKey?: string;
+  alertable?: boolean;
+  expected?: boolean;
+  exceptionLevel?: "fatal" | "error" | "warning" | "info";
+  exceptionType?: string;
+  exceptionMessage?: string;
+  properties?: TelemetryProperties;
+};
+
 type FlushResult = {
   attempted: number;
   delivered: number;
@@ -104,16 +121,44 @@ type OutboxHealthSnapshot = {
   lastError?: string;
 };
 
+type ServiceHealthTarget = {
+  service: string;
+  url?: string | undefined;
+};
+
+type ServiceHealthCheckResult = {
+  service: string;
+  status: "healthy" | "unhealthy" | "missing_config";
+  latencyMs: number;
+  targetUrlHost?: string;
+  httpStatusCode?: number;
+  errorKind?: string;
+};
+
 const TELEMETRY_DESTINATION = "posthog";
 const MAX_BATCH_SIZE = 25;
 const OUTBOX_HEALTH_QUERY_LIMIT = 26;
 const CLAIM_LEASE_MS = 60_000;
 const POSTHOG_REQUEST_TIMEOUT_MS = 30_000;
+const SERVICE_HEALTH_CHECK_TIMEOUT_MS = 5_000;
 const CLAIMED_STATUS = "processing";
 const CONVEX_TELEMETRY_DISTINCT_ID = "system:convex:telemetry";
+const UNSAFE_EXCEPTION_PROPERTY_KEYS = new Set([
+  "args",
+  "body",
+  "input",
+  "payload",
+  "rawargs",
+  "rawrequest",
+  "requestbody",
+]);
 
 function buildCaptureUrl(host: string): string {
   return new URL("/i/v0/e/", host).toString();
+}
+
+export function getPostHogDistinctIdForConvexSystem(): string {
+  return CONVEX_TELEMETRY_DISTINCT_ID;
 }
 
 function getRetryDelayMs(attemptCount: number): number {
@@ -224,6 +269,147 @@ function buildProviderExceptionList(input: {
         : {}),
     },
   ];
+}
+
+function getSafeExceptionProperties(
+  properties: TelemetryProperties | undefined,
+): TelemetryProperties {
+  const safeProperties: TelemetryProperties = {};
+  for (const [key, value] of Object.entries(properties ?? {})) {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z]/g, "");
+    if (UNSAFE_EXCEPTION_PROPERTY_KEYS.has(normalizedKey)) {
+      continue;
+    }
+    safeProperties[key] = value;
+  }
+  return safeProperties;
+}
+
+function getErrorExceptionType(error: unknown): string {
+  if (error instanceof Error && error.name) {
+    return error.name;
+  }
+  return "ApplicationError";
+}
+
+function buildGenericExceptionList(input: {
+  error?: unknown;
+  exceptionType: string;
+  exceptionMessage: string;
+}): PostHogException[] {
+  const stack = input.error instanceof Error ? input.error.stack : undefined;
+  const frames = stack ? parseNodeStackFrames(stack) : [];
+
+  return [
+    {
+      type: input.exceptionType,
+      value: input.exceptionMessage,
+      mechanism: {
+        handled: true,
+        synthetic: !(input.error instanceof Error),
+        type: "generic",
+      },
+      ...(frames.length > 0
+        ? {
+            stacktrace: {
+              type: "raw",
+              frames,
+            },
+          }
+        : {}),
+    },
+  ];
+}
+
+function getUrlHost(url: string): string | undefined {
+  try {
+    return new URL(url).host;
+  } catch {
+    return undefined;
+  }
+}
+
+function getVoiceGatewayHealthUrl(baseUrl: string): string {
+  return new URL("/health", baseUrl).toString();
+}
+
+function buildConfiguredServiceHealthTargets(): ServiceHealthTarget[] {
+  return [
+    {
+      service: "web",
+      url: process.env.APP_BASE_URL,
+    },
+    {
+      service: "voice-gateway",
+      url: process.env.VOICE_GATEWAY_BASE_URL
+        ? getVoiceGatewayHealthUrl(process.env.VOICE_GATEWAY_BASE_URL)
+        : undefined,
+    },
+  ];
+}
+
+function classifyServiceHealthError(error: unknown): string {
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return "timeout";
+  }
+  if (error instanceof Error && error.name === "AbortError") {
+    return "timeout";
+  }
+  if (error instanceof TypeError) {
+    return "network_error";
+  }
+  return "request_failed";
+}
+
+async function checkServiceHealthTarget(
+  target: ServiceHealthTarget,
+  fetchImpl: typeof fetch,
+): Promise<ServiceHealthCheckResult> {
+  if (!target.url) {
+    return {
+      service: target.service,
+      status: "missing_config",
+      latencyMs: 0,
+      errorKind: "missing_config",
+    };
+  }
+
+  const startedAt = Date.now();
+  const targetUrlHost = getUrlHost(target.url);
+  try {
+    const response = await fetchImpl(target.url, {
+      method: "GET",
+      signal: AbortSignal.timeout(SERVICE_HEALTH_CHECK_TIMEOUT_MS),
+    });
+    const latencyMs = Date.now() - startedAt;
+
+    if (response.ok) {
+      return {
+        service: target.service,
+        status: "healthy",
+        latencyMs,
+        ...(targetUrlHost ? { targetUrlHost } : {}),
+        httpStatusCode: response.status,
+      };
+    }
+
+    return {
+      service: target.service,
+      status: "unhealthy",
+      latencyMs,
+      ...(targetUrlHost ? { targetUrlHost } : {}),
+      httpStatusCode: response.status,
+      errorKind: "http_error",
+    };
+  } catch (error) {
+    return {
+      service: target.service,
+      status: "unhealthy",
+      latencyMs: Date.now() - startedAt,
+      ...(targetUrlHost ? { targetUrlHost } : {}),
+      errorKind: classifyServiceHealthError(error),
+    };
+  }
 }
 
 export function serializePostHogEvent(
@@ -360,8 +546,64 @@ export async function enqueuePostHogProviderExceptionBestEffort(
           : {}),
       }),
       operation: input.operation,
-      runtime: "convex",
-      ...input.properties,
+      ...getSafeExceptionProperties(input.properties),
+      ...buildAlertableExceptionTelemetryProperties({
+        runtime: "convex",
+        service: "convex",
+        operation: input.operation,
+        alertable: true,
+        expected: false,
+        provider: classification.provider,
+        exceptionType: getProviderErrorExceptionType(classification.kind),
+        exceptionMessage: `${classification.provider} provider failure (${classification.kind})`,
+      }),
+    },
+  });
+}
+
+export async function enqueuePostHogExceptionBestEffort(
+  ctx: TelemetryMutationRunner,
+  input: EnqueueConvexExceptionInput,
+): Promise<void> {
+  const exceptionType = input.exceptionType ?? getErrorExceptionType(input.error);
+  const exceptionMessage =
+    input.exceptionMessage ??
+    `${input.service} ${input.operation} failed (${exceptionType})`;
+
+  await enqueuePostHogEventBestEffort(ctx, {
+    eventName: "$exception",
+    distinctId: input.distinctId,
+    ...(input.businessId !== undefined ? { businessId: input.businessId } : {}),
+    ...(input.groupKey !== undefined ? { groupKey: input.groupKey } : {}),
+    ...(input.conversationId !== undefined ? { conversationId: input.conversationId } : {}),
+    ...(input.callId !== undefined ? { callId: input.callId } : {}),
+    ...(input.messageId !== undefined ? { messageId: input.messageId } : {}),
+    ...(input.appointmentId !== undefined
+      ? { appointmentId: input.appointmentId }
+      : {}),
+    ...(input.channel !== undefined ? { channel: input.channel } : {}),
+    ...(input.provider !== undefined ? { provider: input.provider } : {}),
+    ...(input.model !== undefined ? { model: input.model } : {}),
+    properties: {
+      ...getSafeExceptionProperties(input.properties),
+      ...buildAlertableExceptionTelemetryProperties({
+        runtime: "convex",
+        service: input.service,
+        operation: input.operation,
+        ...(input.alertable !== undefined ? { alertable: input.alertable } : {}),
+        ...(input.expected !== undefined ? { expected: input.expected } : {}),
+        ...(input.provider !== undefined ? { provider: input.provider } : {}),
+        ...(input.exceptionLevel !== undefined
+          ? { exceptionLevel: input.exceptionLevel }
+          : {}),
+        exceptionType,
+        exceptionMessage,
+      }),
+      $exception_list: buildGenericExceptionList({
+        error: input.error,
+        exceptionType,
+        exceptionMessage,
+      }),
     },
   });
 }
@@ -538,6 +780,64 @@ export const emitObservabilityHeartbeat = internalAction({
     }
 
     return snapshot;
+  },
+});
+
+export async function emitServiceHealthCheckEvents(
+  ctx: TelemetryMutationRunner,
+  targets: ServiceHealthTarget[] = buildConfiguredServiceHealthTargets(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<ServiceHealthCheckResult[]> {
+  const results: ServiceHealthCheckResult[] = [];
+
+  for (const target of targets) {
+    const result = await checkServiceHealthTarget(target, fetchImpl);
+    results.push(result);
+
+    const properties = {
+      runtime: "convex",
+      service: result.service,
+      status: result.status,
+      latencyMs: result.latencyMs,
+      ...(result.targetUrlHost ? { targetUrlHost: result.targetUrlHost } : {}),
+      ...(result.httpStatusCode !== undefined
+        ? { httpStatusCode: result.httpStatusCode }
+        : {}),
+      ...(result.errorKind ? { errorKind: result.errorKind } : {}),
+    } satisfies TelemetryProperties;
+
+    await enqueuePostHogEventBestEffort(ctx, {
+      eventName:
+        result.status === "healthy"
+          ? "ops.service.health_check"
+          : "ops.service.health_check_failed",
+      distinctId: CONVEX_TELEMETRY_DISTINCT_ID,
+      properties,
+    });
+
+    if (result.status !== "healthy") {
+      await enqueuePostHogExceptionBestEffort(ctx, {
+        service: result.service,
+        operation: "service_health_check",
+        distinctId: CONVEX_TELEMETRY_DISTINCT_ID,
+        exceptionType: "ServiceHealthCheckFailed",
+        exceptionMessage: `${result.service} health check failed (${result.status})`,
+        properties,
+      });
+    }
+  }
+
+  return results;
+}
+
+export const emitServiceHealthChecks = internalAction({
+  args: {},
+  handler: async (ctx): Promise<ServiceHealthCheckResult[] | null> => {
+    if (!isPostHogExportEnabled()) {
+      return null;
+    }
+
+    return await emitServiceHealthCheckEvents(ctx);
   },
 });
 

--- a/convex/telemetry/posthog.ts
+++ b/convex/telemetry/posthog.ts
@@ -124,6 +124,7 @@ type OutboxHealthSnapshot = {
 type ServiceHealthTarget = {
   service: string;
   url?: string | undefined;
+  configErrorKind?: string | undefined;
 };
 
 type ServiceHealthCheckResult = {
@@ -329,11 +330,20 @@ function getUrlHost(url: string): string | undefined {
   }
 }
 
-function getVoiceGatewayHealthUrl(baseUrl: string): string {
-  return new URL("/health", baseUrl).toString();
+function getVoiceGatewayHealthUrl(baseUrl: string): string | undefined {
+  try {
+    return new URL("/health", baseUrl).toString();
+  } catch {
+    return undefined;
+  }
 }
 
 function buildConfiguredServiceHealthTargets(): ServiceHealthTarget[] {
+  const voiceGatewayBaseUrl = process.env.VOICE_GATEWAY_BASE_URL;
+  const voiceGatewayHealthUrl = voiceGatewayBaseUrl
+    ? getVoiceGatewayHealthUrl(voiceGatewayBaseUrl)
+    : undefined;
+
   return [
     {
       service: "web",
@@ -341,9 +351,10 @@ function buildConfiguredServiceHealthTargets(): ServiceHealthTarget[] {
     },
     {
       service: "voice-gateway",
-      url: process.env.VOICE_GATEWAY_BASE_URL
-        ? getVoiceGatewayHealthUrl(process.env.VOICE_GATEWAY_BASE_URL)
-        : undefined,
+      url: voiceGatewayHealthUrl,
+      ...(voiceGatewayBaseUrl && !voiceGatewayHealthUrl
+        ? { configErrorKind: "invalid_config" }
+        : {}),
     },
   ];
 }
@@ -365,6 +376,15 @@ async function checkServiceHealthTarget(
   target: ServiceHealthTarget,
   fetchImpl: typeof fetch,
 ): Promise<ServiceHealthCheckResult> {
+  if (target.configErrorKind) {
+    return {
+      service: target.service,
+      status: "unhealthy",
+      latencyMs: 0,
+      errorKind: target.configErrorKind,
+    };
+  }
+
   if (!target.url) {
     return {
       service: target.service,

--- a/convex/unitEconomics.ts
+++ b/convex/unitEconomics.ts
@@ -1,6 +1,8 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedMutation as mutation } from "./telemetry/observedFunctions";
 
-import { internalMutation, mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
+import { query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { requireMembership } from "./lib/auth";
 import { enqueuePostHogEventBestEffort } from "./telemetry/posthog";
@@ -9,6 +11,7 @@ import {
   getPostHogDistinctIdForBusinessSystem,
 } from "./telemetry/shared";
 
+import { observedInternalMutation as internalMutation } from "./telemetry/observedFunctions";
 type UnitEconomicsEventKind =
   | "voice_provider"
   | "sms_provider"

--- a/convex/users/preferences.ts
+++ b/convex/users/preferences.ts
@@ -1,8 +1,11 @@
-import { v } from "convex/values";
+import {
+  v } from "convex/values";
+import { observedMutation as mutation } from "../telemetry/observedFunctions";
 
 import { internal } from "../_generated/api";
-import type { Doc, Id } from "../_generated/dataModel";
-import { action, internalQuery, mutation, query } from "../_generated/server";
+import type { Doc,
+  Id } from "../_generated/dataModel";
+import { internalQuery, query } from "../_generated/server";
 import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../lib/auth";
 import { dashboardAbuseRateLimiter } from "../lib/components";
 import {
@@ -16,6 +19,7 @@ import {
   type OperatorNotificationEventPreferences,
 } from "../lib/operatorNotificationPreferences";
 
+import { observedAction as action } from "../telemetry/observedFunctions";
 const localeValidator = v.union(v.literal("en"), v.literal("fr"));
 export const TEST_OPERATOR_NOTIFICATION_RATE_LIMIT_MESSAGE =
   "Too many test notifications. Please try again later.";

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -1,25 +1,23 @@
 import {
   getTerminalTwilioCallReconciliationFields,
   isTerminalTwilioCallStatus,
-} from "../lib/voiceCallStatus";
+  } from "../lib/voiceCallStatus";
+import { observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
 import type { BillingErrorCode } from "../../packages/shared/src/billing";
 import { billingErrorCodes } from "../../packages/shared/src/billing";
 import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
-} from "../telemetry/shared";
+  } from "../telemetry/shared";
 import { v } from "convex/values";
 import {
   enqueuePostHogOutboxRecord,
   serializePostHogEvent,
-} from "../telemetry/posthog";
+  } from "../telemetry/posthog";
 
 import { internal } from "../_generated/api";
 import {
-  internalAction,
-  internalMutation,
   internalQuery,
-  mutation,
   query,
   type ActionCtx,
   type MutationCtx,
@@ -43,6 +41,7 @@ import {
   finalizeVoiceSessionForCall,
 } from "../conversations/sessions";
 
+import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 type BusinessIdArgs = { businessId: Id<"businesses"> };
 type ServicesForBusinessArgs = BusinessIdArgs;
 type StaffAssignmentsForServiceArgs = {

--- a/docs/telemetry/architecture.md
+++ b/docs/telemetry/architecture.md
@@ -81,12 +81,27 @@ This means the app emits both:
 
 The browser also exposes a `captureAnalyticsException(...)` helper for explicit technical failures in high-signal flows such as calendar connection and knowledge document upload. This remains reserved for unexpected implementation or provider errors, not expected validation or business-rule failures.
 
+The React root is also wrapped with `AppErrorBoundary` and React 19 root error hooks. Render crashes, uncaught root errors, and recoverable root errors call `captureAnalyticsException(...)` with the shared alertable exception contract:
+
+- `runtime`
+- `service`
+- `operation`
+- `deploymentMode`
+- `alertable`
+- `expected`
+- `$exception_level`
+- `$exception_type`
+- `$exception_message`
+
+Client calls to Convex mutations and actions go through `useObservedMutation(...)` and `useObservedAction(...)`. Rejected calls are captured as alertable web exceptions and then rethrown so existing UI error handling still works.
+
 Production browser deploys continue to follow PostHog's source map flow:
 
 - `vite build` emits source maps
 - `apps/web/scripts/upload-posthog-sourcemaps.mjs` runs `posthog-cli sourcemap inject`
 - the same script uploads the injected assets to PostHog with a stable release name and commit-based release version
 - the static host serves the already-injected assets from `dist/`
+- production sourcemap uploads fail closed when `POSTHOG_CLI_API_KEY` or `POSTHOG_CLI_PROJECT_ID` is missing
 
 ### Managed reverse proxy browser ingestion
 
@@ -112,8 +127,14 @@ Convex also emits operational telemetry through the same outbox for:
 - `ops.convex.heartbeat`
 - `ops.convex.outbox_backlog_sample`
 - `ops.convex.outbox_flush_failed`
+- `ops.service.health_check`
+- `ops.service.health_check_failed`
 
 The heartbeat cron samples outbox backlog and retry state so PostHog dashboards and alerts can track delivery health without a second observability backend.
+
+The service health cron checks `APP_BASE_URL` and `${VOICE_GATEWAY_BASE_URL}/health` every minute with a short timeout. Healthy checks emit `ops.service.health_check`. Missing config, non-2xx responses, network failures, and timeouts emit both `ops.service.health_check_failed` and an alertable `$exception` with the target service and host.
+
+Production Convex write/action/http registrations use observed wrappers from `convex/telemetry/observedFunctions.ts`. These wrappers capture unexpected handler failures to PostHog Error Tracking and rethrow the original error. Queries stay unwrapped because Convex queries are side-effect-free.
 
 ### `apps/voice-gateway`
 
@@ -138,6 +159,8 @@ The gateway emits operational PostHog events for:
 - `ops.voice.recording_upload_failed`
 
 These events intentionally replace the previous runtime metrics path. Alerting is now based on event trends, thresholded slow-event volume, and heartbeat absence instead of external percentiles.
+
+Node exception autocapture remains enabled. The gateway also installs explicit `uncaughtException` and `unhandledRejection` handlers that capture a fatal PostHog exception, flush PostHog, and exit.
 
 Structured gateway logs sent to PostHog Logs should continue to include operational identifiers like:
 
@@ -180,10 +203,13 @@ The non-realtime Gemini wrapper uses the shared provider layer in `convex/lib/pr
 
 PostHog Error Tracking is enabled in both runtimes:
 
-- `apps/web` captures unhandled browser errors and unhandled promise rejections automatically, plus explicit technical exceptions through `captureAnalyticsException(...)`
-- `apps/voice-gateway` enables Node exception autocapture and uses `capturePostHogException(...)` for startup, request, and selected provider/runtime recovery failures
+- `apps/web` captures unhandled browser errors and unhandled promise rejections automatically, render/root failures through the React boundary/hooks, rejected observed Convex writes, and explicit technical exceptions through `captureAnalyticsException(...)`
+- `convex` captures observed action, mutation, internal action, internal mutation, HTTP action, provider, and service-health failures through the PostHog outbox
+- `apps/voice-gateway` enables Node exception autocapture and uses `capturePostHogException(...)` for startup, request, provider/runtime recovery, and fatal process failures
 
 Explicit exception capture should remain limited to technical failures where stack traces and runtime context materially help debugging. Business outcome failures such as `appointment.booking_failed` or `workflow.failed` should continue to be tracked as product/domain events instead of exceptions.
+
+Alertable exceptions use `alertable = true` and `expected = false`. Expected validation or business-rule outcomes should either stay as product/domain events or explicitly set `expected = true` when they must be captured for diagnostics.
 
 ## Environment variables
 
@@ -203,6 +229,8 @@ Explicit exception capture should remain limited to technical failures where sta
 - `POSTHOG_KEY`
 - `POSTHOG_HOST`
 - `POSTHOG_PRIVACY_MODE`
+- `APP_BASE_URL`
+- `VOICE_GATEWAY_BASE_URL`
 
 Telemetry export is only enabled automatically in `cloud` deployment mode.
 

--- a/docs/telemetry/architecture.md
+++ b/docs/telemetry/architecture.md
@@ -211,6 +211,10 @@ Explicit exception capture should remain limited to technical failures where sta
 
 Alertable exceptions use `alertable = true` and `expected = false`. Expected validation or business-rule outcomes should either stay as product/domain events or explicitly set `expected = true` when they must be captured for diagnostics.
 
+PostHog Error Tracking notifications are configured from Error Tracking -> Configuration -> Alerting. They are separate from the limited Product Analytics Alerts surface. Use Error Tracking notifications or internal destinations for new, reopened, and spiking exception issues; use Product Analytics Alerts only for signals that require trend or absence logic, such as a missing `ops.convex.heartbeat` window.
+
+The primary production notification destination is Discord. Creating the Discord Error Tracking notification requires a Discord webhook URL for the target incident channel, and PostHog then sends notifications automatically for the selected issue trigger.
+
 ## Environment variables
 
 ### Browser
@@ -254,3 +258,5 @@ This phase adds PostHog-first runtime assets:
 - `LobbyStack - Voice Gateway Operations`
 - `LobbyStack - AI Runtime`
 - `LobbyStack - Telemetry Delivery Health`
+
+Runtime dashboards are for triage and correlation. Production paging should come from Error Tracking notifications for alertable `$exception` issues, plus the smallest possible number of Product Analytics Alerts for missing heartbeat windows.

--- a/docs/telemetry/event-taxonomy.md
+++ b/docs/telemetry/event-taxonomy.md
@@ -80,6 +80,15 @@ Do not duplicate ownership between runtimes unless there is a specific analytics
 - `workflow.started`
 - `workflow.failed`
 
+### Operations events
+
+- `ops.convex.heartbeat`
+- `ops.convex.outbox_backlog_sample`
+- `ops.convex.outbox_flush_failed`
+- `ops.service.health_check`
+- `ops.service.health_check_failed`
+- `ops.voice.heartbeat`
+
 ## Shared defaults
 
 All meaningful product and business events should include:
@@ -182,6 +191,40 @@ Always include:
 - `businessId`
 - `deploymentMode`
 - `workflowName`
+
+### Service health events
+
+Always include:
+
+- `deploymentMode`
+- `service`
+- `status`
+- `latencyMs`
+
+Add when relevant:
+
+- `httpStatusCode`
+- `errorKind`
+- `targetUrlHost`
+
+### Alertable exceptions
+
+Unexpected crashes, provider failures, service health failures, and observed write/action/http handler failures should include:
+
+- `runtime`
+- `service`
+- `operation`
+- `deploymentMode`
+- `alertable`
+- `expected`
+- `$exception_level`
+- `$exception_type`
+- `$exception_message`
+
+Add when relevant:
+
+- `provider`
+- safe IDs such as `businessId`, `callId`, `conversationId`, `messageId`, or `appointmentId`
 
 ## Property guidelines
 

--- a/docs/telemetry/provider-failure-error-tracking.md
+++ b/docs/telemetry/provider-failure-error-tracking.md
@@ -1,14 +1,20 @@
 # Provider Failure Error Tracking
 
-Handled external provider failures are reported to PostHog Error Tracking as `$exception` events. This covers runtime or customer-impacting failures from OpenAI, Google, Twilio, Polar, and Firecrawl while keeping app/operator notifications out of v1.
+Handled external provider failures are reported to PostHog Error Tracking as `$exception` events. This covers runtime or customer-impacting failures from OpenAI, Google, Twilio, Polar, and Firecrawl.
 
 ## Alert To Configure In PostHog
 
-Create an Error Tracking alert for quota exhaustion:
+Create Error Tracking alerts for alertable provider failures:
 
-- Filter: `$exception_type` contains `ProviderQuotaExhaustedError`
-- Include properties in the notification: `provider`, `providerErrorCode`, `runtime`, and `deploymentMode`
-- Recommended destination: PostHog email or Slack alert
+- Filter: `deploymentMode = cloud`, `alertable = true`, and `expected = false`
+- Filter or break down by `provider`
+- Alert immediately for `$exception_type` values:
+  - `ProviderAuthFailedError`
+  - `ProviderQuotaExhaustedError`
+  - `ProviderUnavailableError`
+- Add a trend alert for repeated `providerErrorKind = rate_limited`
+- Include properties in the notification: `provider`, `providerErrorKind`, `providerErrorCode`, `runtime`, `service`, `operation`, and `deploymentMode`
+- Recommended destinations: Discord and email
 
 OpenAI credit exhaustion should appear with:
 
@@ -16,6 +22,15 @@ OpenAI credit exhaustion should appear with:
 - `providerErrorCode = insufficient_quota`
 - `$exception_type = ProviderQuotaExhaustedError`
 
+Firecrawl availability failures should appear with:
+
+- `provider = firecrawl`
+- `providerErrorKind = provider_unavailable` or `rate_limited`
+- `runtime = convex`
+- `service = convex`
+
 ## Notes
 
 The code also keeps existing operational events such as `ops.voice.openai_realtime_error` for product analytics. Those events include provider classification metadata, but alerting should be based on Error Tracking exceptions.
+
+Do not add paid or destructive synthetic provider probes by default. Provider availability is detected from real app traffic, while app and voice liveness are covered by `ops.service.health_check`, `ops.convex.heartbeat`, and `ops.voice.heartbeat`.

--- a/docs/telemetry/provider-failure-error-tracking.md
+++ b/docs/telemetry/provider-failure-error-tracking.md
@@ -2,19 +2,19 @@
 
 Handled external provider failures are reported to PostHog Error Tracking as `$exception` events. This covers runtime or customer-impacting failures from OpenAI, Google, Twilio, Polar, and Firecrawl.
 
-## Alert To Configure In PostHog
+## Notification To Configure In PostHog
 
-Create Error Tracking alerts for alertable provider failures:
+Create Error Tracking notifications or internal destinations for alertable provider failures:
 
 - Filter: `deploymentMode = cloud`, `alertable = true`, and `expected = false`
 - Filter or break down by `provider`
-- Alert immediately for `$exception_type` values:
+- Notify immediately for `$exception_type` values:
   - `ProviderAuthFailedError`
   - `ProviderQuotaExhaustedError`
   - `ProviderUnavailableError`
-- Add a trend alert for repeated `providerErrorKind = rate_limited`
+- Add the issue spiking notification for repeated `providerErrorKind = rate_limited` issues
 - Include properties in the notification: `provider`, `providerErrorKind`, `providerErrorCode`, `runtime`, `service`, `operation`, and `deploymentMode`
-- Recommended destinations: Discord and email
+- Recommended primary destination: Discord
 
 OpenAI credit exhaustion should appear with:
 
@@ -32,5 +32,7 @@ Firecrawl availability failures should appear with:
 ## Notes
 
 The code also keeps existing operational events such as `ops.voice.openai_realtime_error` for product analytics. Those events include provider classification metadata, but alerting should be based on Error Tracking exceptions.
+
+Do not spend Product Analytics alert slots on provider failures when they already emit alertable `$exception` events. Reserve those slots for absence checks, especially missing Convex heartbeats, because Error Tracking cannot notify on an event that never arrived.
 
 Do not add paid or destructive synthetic provider probes by default. Provider availability is detected from real app traffic, while app and voice liveness are covered by `ops.service.health_check`, `ops.convex.heartbeat`, and `ops.voice.heartbeat`.

--- a/docs/validation/posthog-otel-validation.md
+++ b/docs/validation/posthog-otel-validation.md
@@ -8,6 +8,7 @@ Validate that:
 - Convex domain events reach PostHog through the outbox
 - voice-gateway operational logs and health events reach PostHog
 - AI traces reach PostHog without leaking sensitive content
+- alertable production failures notify through PostHog-backed Discord and email destinations
 
 ## Required environment
 
@@ -26,6 +27,8 @@ Validate that:
 - `POSTHOG_KEY`
 - `POSTHOG_HOST`
 - `POSTHOG_PRIVACY_MODE=true`
+- `APP_BASE_URL`
+- `VOICE_GATEWAY_BASE_URL`
 
 Set `DEPLOYMENT_MODE=cloud` for provider validation runs.
 
@@ -51,9 +54,12 @@ Set `DEPLOYMENT_MODE=cloud` for provider validation runs.
 7. Validate browser error tracking:
    - trigger one unhandled error in the browser console and confirm it appears in PostHog Error Tracking
    - trigger one unhandled rejection and confirm it appears in PostHog Error Tracking
+   - trigger one render error and confirm it appears with `runtime = web`, `service = web`, `operation = react_caught_error`, `alertable = true`, and `expected = false`
+   - trigger one rejected Convex mutation or action from the UI and confirm it appears with `runtime = web`, `convexFunctionType`, and `convexFunction`
    - trigger one handled technical failure path such as a calendar connect error or knowledge upload error and confirm it appears with `runtime = web`
 8. Validate browser source maps:
-   - deploy the built web assets after running `pnpm build && pnpm posthog:sourcemaps`
+   - deploy the built web assets after running `pnpm build` and `pnpm --filter @lobbystack/web posthog:sourcemaps`
+   - confirm production deploys fail or are review-blocked when `POSTHOG_CLI_API_KEY` or `POSTHOG_CLI_PROJECT_ID` is missing
    - confirm the matching release exists in PostHog symbol sets
    - confirm browser stack traces resolve to source files instead of minified bundles
 
@@ -84,6 +90,12 @@ Set `DEPLOYMENT_MODE=cloud` for provider validation runs.
    - `ops.convex.heartbeat`
    - `ops.convex.outbox_backlog_sample`
    - `ops.convex.outbox_flush_failed` when retrying rows exist
+7. Verify service health events in PostHog:
+   - `ops.service.health_check` for `service = web`
+   - `ops.service.health_check` for `service = voice-gateway`
+   - one `ops.service.health_check_failed` when a target returns non-2xx, times out, or has missing config
+   - one matching `$exception` with `operation = service_health_check`, `runtime = convex`, and `alertable = true`
+8. Trigger one failing observed Convex action or HTTP action and confirm the `$exception` event includes `runtime = convex`, `service = convex`, `operation`, `alertable = true`, and `$exception_list`.
 
 ## Voice gateway validation
 
@@ -91,6 +103,7 @@ Set `DEPLOYMENT_MODE=cloud` for provider validation runs.
 2. Validate PostHog Error Tracking for the gateway:
    - confirm a startup or request-path failure appears with `runtime = voice-gateway`
    - confirm a provider recovery failure or call record initialization failure appears with `channel = voice` and `provider = twilio`
+   - trigger one fatal `unhandledRejection` or `uncaughtException` in a non-production validation deployment and confirm PostHog receives a fatal exception before the process exits
 3. Validate PostHog operational events for:
    - `ops.voice.heartbeat`
    - `ops.voice.invalid_signature`
@@ -165,7 +178,12 @@ Validate these runtime insights:
 
 Validate these alert policies in PostHog:
 
+- new or reopened Error Tracking issue where `deploymentMode = cloud`, `alertable = true`, and `expected = false`
+- trend alert on `$exception` where `deploymentMode = cloud`, `alertable = true`, and `expected = false`
+- any `ops.service.health_check_failed`
+- no `ops.convex.heartbeat` over a 10-minute window
 - no `ops.voice.heartbeat` for the interval
+- voice health check reports `service = voice-gateway` and `status != healthy`
 - spike in `ops.voice.openai_realtime_error`
 - spike in `ops.voice.turn_slow`
 - spike in `ops.voice.tool_failed`
@@ -174,6 +192,10 @@ Validate these alert policies in PostHog:
 - spike in `workflow.failed`
 - spike in `integration.calendar_sync_failed`
 - sustained `ops.convex.outbox_backlog_sample` with `backlogBucket = critical`
+- `ops.convex.outbox_flush_failed`
+- alertable provider exceptions for `provider = firecrawl`, `openai`, `twilio`, `polar`, and `google`
+
+Configure Discord and email destinations for health, provider, and exception alerts where PostHog supports both. If Error Tracking issue alerts only support one destination in the active PostHog edition, use the issue alert for Discord and a matching trend alert for email.
 
 ## Outbox validation
 
@@ -188,7 +210,13 @@ These checks should be run before review:
 
 - `pnpm --filter @lobbystack/telemetry test`
 - `pnpm --filter @lobbystack/web typecheck`
+- `pnpm --filter @lobbystack/web test`
 - `pnpm --filter @lobbystack/voice-gateway typecheck`
+- `pnpm --filter @lobbystack/voice-gateway test`
 - `pnpm typecheck:convex`
+- `pnpm test:convex`
+- `pnpm typecheck`
+- `pnpm build`
+- `pnpm test`
 
 Provider validation in real PostHog still requires live credentials and runtime traffic.

--- a/docs/validation/posthog-otel-validation.md
+++ b/docs/validation/posthog-otel-validation.md
@@ -176,26 +176,28 @@ Validate these runtime insights:
 - calendar sync failures
 - booking failures
 
-Validate these alert policies in PostHog:
+Validate these Error Tracking notifications in PostHog:
 
-- new or reopened Error Tracking issue where `deploymentMode = cloud`, `alertable = true`, and `expected = false`
-- trend alert on `$exception` where `deploymentMode = cloud`, `alertable = true`, and `expected = false`
-- any `ops.service.health_check_failed`
+- create an Error Tracking notification or internal destination for issue created events
+- create an Error Tracking notification or internal destination for issue reopened events
+- optionally create an Error Tracking notification or internal destination for issue spiking events
+- use the Discord destination for the primary "prod broke" channel
+- add email only where the active PostHog plan and destination type support it
+- filter or route to `deploymentMode = cloud`, `alertable = true`, and `expected = false` where the notification editor supports filtering
+- verify one alertable `$exception` from each critical surface reaches the notification destination:
+  - browser render/runtime crash
+  - rejected observed Convex action or mutation
+  - observed Convex action, mutation, or HTTP action failure
+  - voice-gateway request or fatal runtime failure
+  - service health check failure
+  - alertable provider exception for `provider = firecrawl`, `openai`, `twilio`, `polar`, or `google`
+
+PostHog Error Tracking notifications are separate from Product Analytics Alerts. Use Product Analytics Alerts only for signals that Error Tracking cannot infer from an exception issue, especially absence-based checks:
+
 - no `ops.convex.heartbeat` over a 10-minute window
-- no `ops.voice.heartbeat` for the interval
-- voice health check reports `service = voice-gateway` and `status != healthy`
-- spike in `ops.voice.openai_realtime_error`
-- spike in `ops.voice.turn_slow`
-- spike in `ops.voice.tool_failed`
-- drop in `voice.call_started`
-- spike in `appointment.booking_failed`
-- spike in `workflow.failed`
-- spike in `integration.calendar_sync_failed`
-- sustained `ops.convex.outbox_backlog_sample` with `backlogBucket = critical`
-- `ops.convex.outbox_flush_failed`
-- alertable provider exceptions for `provider = firecrawl`, `openai`, `twilio`, `polar`, and `google`
+- optionally no `ops.voice.heartbeat` for the expected interval when the plan has room for a second alert
 
-Configure Discord and email destinations for health, provider, and exception alerts where PostHog supports both. If Error Tracking issue alerts only support one destination in the active PostHog edition, use the issue alert for Discord and a matching trend alert for email.
+Health-check and provider failures emit alertable `$exception` events, so they should page through Error Tracking notifications instead of consuming Product Analytics alert slots. The heartbeat absence checks are the main remaining reason to use Product Analytics Alerts.
 
 ## Outbox validation
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "docs:broken-links": "pnpm --filter @lobbystack/docs broken-links",
     "dev:web": "pnpm --filter @lobbystack/web dev",
     "dev:voice": "pnpm --filter @lobbystack/voice-gateway dev",
+    "posthog:sourcemaps": "pnpm --filter @lobbystack/web posthog:sourcemaps",
     "dev:onboarding:website": "tsx scripts/prepare-onboarding-website.ts",
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck && pnpm typecheck:convex",

--- a/packages/telemetry/src/index.test.ts
+++ b/packages/telemetry/src/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { TelemetryEvent } from "./index";
 import {
   bucketLatencyMs,
+  buildAlertableExceptionTelemetryProperties,
   buildPostHogAiGenerationProperties,
   buildPostHogAiSpanProperties,
   buildPostHogAiTraceProperties,
@@ -14,6 +15,7 @@ import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
   getPostHogDistinctIdForOperator,
+  isExpectedConvexFailure,
   redactAiTraceProperties,
   redactTelemetryProperties,
   redactOtelAttributes,
@@ -161,6 +163,45 @@ describe("telemetry redaction", () => {
       provider: "unknown",
       kind: "unknown",
     });
+  });
+
+  it("classifies handled Convex rejections as expected", () => {
+    expect(isExpectedConvexFailure(new Error("InvalidSecret"))).toBe(true);
+    expect(
+      isExpectedConvexFailure(
+        new Error("This email is already on your account."),
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedConvexFailure(
+        new Error(
+          "That verification code is invalid or expired. Try requesting a new one.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedConvexFailure(
+        new Error("Invalid or expired email confirmation link."),
+      ),
+    ).toBe(true);
+    expect(isExpectedConvexFailure(new Error("database exploded"))).toBe(false);
+  });
+
+  it("only includes provider on alertable exceptions when provided", () => {
+    const withoutProvider = buildAlertableExceptionTelemetryProperties({
+      runtime: "web",
+      service: "web",
+      operation: "calendar_connect",
+    });
+    const withProvider = buildAlertableExceptionTelemetryProperties({
+      runtime: "web",
+      service: "web",
+      operation: "calendar_connect",
+      provider: "google",
+    });
+
+    expect(withoutProvider).not.toHaveProperty("provider");
+    expect(withProvider).toHaveProperty("provider", "google");
   });
 
   it("builds provider exception metadata and redacts raw provider messages", () => {

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -96,6 +96,8 @@ export const OPERATIONS_EVENT_NAMES = [
   "ops.convex.heartbeat",
   "ops.convex.outbox_backlog_sample",
   "ops.convex.outbox_flush_failed",
+  "ops.service.health_check",
+  "ops.service.health_check_failed",
 ] as const;
 
 export const TELEMETRY_EVENT_NAMES = [
@@ -216,6 +218,18 @@ export type ProviderErrorClassification = {
   providerErrorCode?: string;
   providerErrorMessage?: string;
   providerErrorStatus?: number;
+};
+
+export type AlertableExceptionTelemetryInput = {
+  runtime: "web" | "convex" | "voice-gateway";
+  service: string;
+  operation: string;
+  alertable?: boolean;
+  expected?: boolean;
+  provider?: ExternalProvider;
+  exceptionType?: string;
+  exceptionMessage?: string;
+  exceptionLevel?: "fatal" | "error" | "warning" | "info";
 };
 
 export type ClassifyProviderErrorInput = {
@@ -541,6 +555,18 @@ export const TELEMETRY_REQUIRED_PROPERTIES_BY_EVENT = {
   "ops.convex.heartbeat": ["deploymentMode"],
   "ops.convex.outbox_backlog_sample": ["deploymentMode", "backlogBucket"],
   "ops.convex.outbox_flush_failed": ["deploymentMode", "backlogBucket"],
+  "ops.service.health_check": [
+    "deploymentMode",
+    "service",
+    "status",
+    "latencyMs",
+  ],
+  "ops.service.health_check_failed": [
+    "deploymentMode",
+    "service",
+    "status",
+    "latencyMs",
+  ],
 } satisfies Record<TelemetryEventName, ReadonlyArray<string>>;
 
 export type TelemetryValidationInput = Partial<TelemetryContext> & {
@@ -1014,6 +1040,26 @@ export function buildProviderErrorTelemetryProperties(
     $exception_message:
       classification.providerErrorMessage ??
       `${classification.provider} provider failure (${classification.kind})`,
+  };
+}
+
+export function buildAlertableExceptionTelemetryProperties(
+  input: AlertableExceptionTelemetryInput,
+): TelemetryProperties {
+  const exceptionType = input.exceptionType ?? "ApplicationError";
+  const exceptionMessage =
+    input.exceptionMessage ?? `${input.service} ${input.operation} failed`;
+
+  return {
+    runtime: input.runtime,
+    service: input.service,
+    operation: input.operation,
+    alertable: input.alertable ?? true,
+    expected: input.expected ?? false,
+    provider: input.provider,
+    $exception_level: input.exceptionLevel ?? "error",
+    $exception_type: exceptionType,
+    $exception_message: exceptionMessage,
   };
 }
 

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -695,6 +695,36 @@ const SAFE_KEY_PATTERNS = [
   "workflowname",
 ];
 
+const EXPECTED_CONVEX_FAILURE_MESSAGE_SNIPPETS = [
+  "a billing contact email is required",
+  "already exists",
+  "already on your account",
+  "ai sms add-on is only available",
+  "calendar connection request expired",
+  "calendar connection request is no longer authorized",
+  "connect google calendar before choosing",
+  "contact is blocked",
+  "do not have access to this business",
+  "feedback is limited",
+  "feedback message is required",
+  "invalid credentials",
+  "invalid password",
+  "invalid or expired email confirmation link",
+  "invalidsecret",
+  "knowledge storage limit reached",
+  "new email is required",
+  "no email is configured",
+  "number provisioning limit reached",
+  "onboarding is no longer available",
+  "only free workspaces can start pro checkout",
+  "reconnect google calendar before choosing",
+  "requires admin access",
+  "selected google calendar was not found",
+  "selected phone number is no longer available",
+  "verification code is invalid or expired",
+  "verify your mobile number before choosing",
+];
+
 function normalizeKey(key: string): string {
   return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
 }
@@ -805,6 +835,30 @@ function hasPresentValue(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
+}
+
+function getErrorSearchText(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name} ${error.message}`.toLowerCase();
+  }
+  if (typeof error === "string") {
+    return error.toLowerCase();
+  }
+  if (isRecord(error) && typeof error.message === "string") {
+    return error.message.toLowerCase();
+  }
+  return "";
+}
+
+export function isExpectedConvexFailure(error: unknown): boolean {
+  const searchText = getErrorSearchText(error);
+  if (!searchText) {
+    return false;
+  }
+
+  return EXPECTED_CONVEX_FAILURE_MESSAGE_SNIPPETS.some((snippet) =>
+    searchText.includes(snippet),
+  );
 }
 
 function normalizeExternalProvider(
@@ -1056,7 +1110,7 @@ export function buildAlertableExceptionTelemetryProperties(
     operation: input.operation,
     alertable: input.alertable ?? true,
     expected: input.expected ?? false,
-    provider: input.provider,
+    ...(input.provider !== undefined ? { provider: input.provider } : {}),
     $exception_level: input.exceptionLevel ?? "error",
     $exception_type: exceptionType,
     $exception_message: exceptionMessage,

--- a/packages/telemetry/src/observability-coverage.test.ts
+++ b/packages/telemetry/src/observability-coverage.test.ts
@@ -1,0 +1,95 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(process.cwd(), "../..");
+const CONVEX_ROOT = join(REPO_ROOT, "convex");
+const DISALLOWED_GENERATED_SERVER_IMPORTS = new Set([
+  "action",
+  "httpAction",
+  "internalAction",
+  "internalMutation",
+  "mutation",
+]);
+
+function listSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const file = join(dir, entry);
+    const stat = statSync(file);
+    if (stat.isDirectory()) {
+      if (entry !== "_generated") {
+        files.push(...listSourceFiles(file));
+      }
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
+function importStatements(source: string): string[] {
+  const statements: string[] = [];
+  const lines = source.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.trim().startsWith("import ")) {
+      continue;
+    }
+    const statementLines = [line];
+    while (
+      index + 1 < lines.length &&
+      !(statementLines[statementLines.length - 1] ?? "").trimEnd().endsWith(";")
+    ) {
+      index += 1;
+      statementLines.push(lines[index] ?? "");
+    }
+    statements.push(statementLines.join("\n"));
+  }
+  return statements;
+}
+
+function importedNames(statement: string): string[] {
+  const match = statement.match(/\{([\s\S]*?)\}/);
+  if (!match) {
+    return [];
+  }
+  return (match[1] ?? "")
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter((specifier) => specifier && !specifier.startsWith("type "))
+    .map((specifier) => (specifier.split(/\s+as\s+/)[0] ?? "").trim());
+}
+
+describe("Convex observability coverage", () => {
+  it("routes production write/action/http registrations through observed wrappers", () => {
+    const offenders: string[] = [];
+
+    for (const file of listSourceFiles(CONVEX_ROOT)) {
+      const relativePath = relative(REPO_ROOT, file);
+      if (
+        relativePath === "convex/telemetry/posthog.ts" ||
+        relativePath === "convex/telemetry/observedFunctions.ts"
+      ) {
+        continue;
+      }
+
+      const source = readFileSync(file, "utf8");
+      for (const statement of importStatements(source)) {
+        if (!statement.includes("_generated/server")) {
+          continue;
+        }
+        const disallowedNames = importedNames(statement).filter((name) =>
+          DISALLOWED_GENERATED_SERVER_IMPORTS.has(name),
+        );
+        if (disallowedNames.length > 0) {
+          offenders.push(`${relativePath}: ${disallowedNames.join(", ")}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Harden PostHog tracking across the web app, Convex backend, and voice gateway with safer error handling and fallback behavior.
- Expand observability coverage for Convex functions, React error reporting, and analytics helpers so failures are easier to detect and validate.
- Update telemetry docs, source map upload workflow, and localized UI copy to reflect the new instrumentation paths.

## Testing
- Added and updated unit tests for PostHog utilities, observed function coverage, and React error reporting behavior.
- Validated telemetry-related changes across the web app and backend surfaces with focused regression coverage.
- Not run (not requested)