### PR TITLE
Add MVP privacy retention cleanup for sensitive content

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@base-ui/react": "^1.2.0",
     "@convex-dev/auth": "latest",
-    "@convex-dev/persistent-text-streaming": "latest",
+    "@convex-dev/persistent-text-streaming": "0.3.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/apps/web/src/features/calls/CallDetailPage.tsx
+++ b/apps/web/src/features/calls/CallDetailPage.tsx
@@ -399,13 +399,17 @@ function TranscriptTab({
 
 function RecordingTab({ call }: { call: CallRow }) {
   const { t } = useTranslation("calls");
+  const recordingExpired =
+    call.recordingRetentionStatus === "expired" ||
+    (typeof call.recordingExpiresAt === "string" &&
+      Date.parse(call.recordingExpiresAt) <= Date.now());
 
   if (!call.recordingUrl) {
     return (
       <div className="flex flex-col items-center gap-2 py-16 text-center">
         <Headphones className="size-8 text-muted-foreground/40" />
         <p className="type-empty-description">
-          {call.recordingStorageId
+          {call.recordingStorageId && !recordingExpired
             ? t("detail.recording.pending")
             : t("detail.recording.unavailable")}
         </p>

--- a/apps/web/src/features/calls/CallDetailPage.tsx
+++ b/apps/web/src/features/calls/CallDetailPage.tsx
@@ -399,10 +399,7 @@ function TranscriptTab({
 
 function RecordingTab({ call }: { call: CallRow }) {
   const { t } = useTranslation("calls");
-  const recordingExpired =
-    call.recordingRetentionStatus === "expired" ||
-    (typeof call.recordingExpiresAt === "string" &&
-      Date.parse(call.recordingExpiresAt) <= Date.now());
+  const recordingExpired = call.recordingRetentionStatus === "expired";
 
   if (!call.recordingUrl) {
     return (

--- a/apps/web/src/features/calls/CallsPage.test.ts
+++ b/apps/web/src/features/calls/CallsPage.test.ts
@@ -48,19 +48,8 @@ describe("getCallRecordingAvailability", () => {
     expect(
       getCallRecordingAvailability({
         recordingUrl: null,
-        recordingRetentionStatus: "expired",
-        disposition: "call_completed",
-      }),
-    ).toBe("unavailable");
-  });
-
-  it("marks recordings past their retention expiry as unavailable before cleanup", () => {
-    expect(
-      getCallRecordingAvailability({
-        recordingUrl: null,
         recordingStorageId: "recording-storage-id",
-        recordingRetentionStatus: "active",
-        recordingExpiresAt: "2000-01-01T00:00:00.000Z",
+        recordingRetentionStatus: "expired",
         disposition: "call_completed",
       }),
     ).toBe("unavailable");

--- a/apps/web/src/features/calls/CallsPage.test.ts
+++ b/apps/web/src/features/calls/CallsPage.test.ts
@@ -44,6 +44,16 @@ describe("getCallRecordingAvailability", () => {
     ).toBe("pending");
   });
 
+  it("marks expired retained recordings as unavailable", () => {
+    expect(
+      getCallRecordingAvailability({
+        recordingUrl: null,
+        recordingRetentionStatus: "expired",
+        disposition: "call_completed",
+      }),
+    ).toBe("unavailable");
+  });
+
   it("marks calls with a recording URL as ready", () => {
     expect(
       getCallRecordingAvailability({

--- a/apps/web/src/features/calls/CallsPage.test.ts
+++ b/apps/web/src/features/calls/CallsPage.test.ts
@@ -54,6 +54,18 @@ describe("getCallRecordingAvailability", () => {
     ).toBe("unavailable");
   });
 
+  it("marks recordings past their retention expiry as unavailable before cleanup", () => {
+    expect(
+      getCallRecordingAvailability({
+        recordingUrl: null,
+        recordingStorageId: "recording-storage-id",
+        recordingRetentionStatus: "active",
+        recordingExpiresAt: "2000-01-01T00:00:00.000Z",
+        disposition: "call_completed",
+      }),
+    ).toBe("unavailable");
+  });
+
   it("marks calls with a recording URL as ready", () => {
     expect(
       getCallRecordingAvailability({

--- a/apps/web/src/features/calls/CallsPage.tsx
+++ b/apps/web/src/features/calls/CallsPage.tsx
@@ -112,13 +112,18 @@ export function getCallRecordingAvailability(call: {
   recordingUrl: string | null;
   recordingStorageId?: unknown;
   recordingRetentionStatus?: string;
+  recordingExpiresAt?: string;
   disposition?: string;
 }): "ready" | "pending" | "unavailable" {
   if (call.recordingUrl) {
     return "ready";
   }
 
-  if (call.recordingRetentionStatus === "expired") {
+  if (
+    call.recordingRetentionStatus === "expired" ||
+    (typeof call.recordingExpiresAt === "string" &&
+      Date.parse(call.recordingExpiresAt) <= Date.now())
+  ) {
     return "unavailable";
   }
 

--- a/apps/web/src/features/calls/CallsPage.tsx
+++ b/apps/web/src/features/calls/CallsPage.tsx
@@ -112,18 +112,13 @@ export function getCallRecordingAvailability(call: {
   recordingUrl: string | null;
   recordingStorageId?: unknown;
   recordingRetentionStatus?: string;
-  recordingExpiresAt?: string;
   disposition?: string;
 }): "ready" | "pending" | "unavailable" {
   if (call.recordingUrl) {
     return "ready";
   }
 
-  if (
-    call.recordingRetentionStatus === "expired" ||
-    (typeof call.recordingExpiresAt === "string" &&
-      Date.parse(call.recordingExpiresAt) <= Date.now())
-  ) {
+  if (call.recordingRetentionStatus === "expired") {
     return "unavailable";
   }
 

--- a/apps/web/src/features/calls/CallsPage.tsx
+++ b/apps/web/src/features/calls/CallsPage.tsx
@@ -111,10 +111,15 @@ export function formatCallDispositionSummary(
 export function getCallRecordingAvailability(call: {
   recordingUrl: string | null;
   recordingStorageId?: unknown;
+  recordingRetentionStatus?: string;
   disposition?: string;
 }): "ready" | "pending" | "unavailable" {
   if (call.recordingUrl) {
     return "ready";
+  }
+
+  if (call.recordingRetentionStatus === "expired") {
+    return "unavailable";
   }
 
   if (call.recordingStorageId) {

--- a/apps/web/src/features/onboarding/components/OnboardingShell.tsx
+++ b/apps/web/src/features/onboarding/components/OnboardingShell.tsx
@@ -16,7 +16,7 @@ type OnboardingShellProps = {
   description?: ReactNode;
   /** Page-dot progress (current/total). Pass `null` to hide the indicator. */
   progress?: { current: number; navigableUntil?: number | undefined; total: number } | null;
-  /** Optional sign-out handler retained for route compatibility; not shown in onboarding UI. */
+  /** Optional sign-out handler rendered as a top-right logout link. */
   onSignOut?: () => void;
   /** Width of the central content column (defaults to `max-w-md`). */
   width?: "sm" | "md" | "lg" | "xl" | "wide";
@@ -64,11 +64,22 @@ export function OnboardingShell({
   width = "md",
   children,
   footer,
+  onSignOut,
 }: OnboardingShellProps) {
   const { t } = useTranslation("onboarding");
 
   return (
-    <div className="flex min-h-svh w-full flex-col bg-background text-foreground">
+    <div className="relative flex min-h-svh w-full flex-col bg-background text-foreground">
+      {onSignOut ? (
+        <button
+          className="absolute right-6 top-6 rounded-full px-4 py-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          onClick={onSignOut}
+          type="button"
+        >
+          {t("shell.signOut")}
+        </button>
+      ) : null}
+
       <main className="flex flex-1 flex-col items-center px-6 py-12">
         <div className={cn("my-auto flex w-full flex-col items-center", widthMap[width])}>
           <OnboardingHeader />

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -98,6 +98,7 @@ import type * as onboarding_phoneVerificationState from "../onboarding/phoneVeri
 import type * as onboarding_plan from "../onboarding/plan.js";
 import type * as onboarding_websites from "../onboarding/websites.js";
 import type * as operatorNotifications from "../operatorNotifications.js";
+import type * as privacy_retention from "../privacy/retention.js";
 import type * as services_localizedNames from "../services/localizedNames.js";
 import type * as smsCompliance from "../smsCompliance.js";
 import type * as telemetry_ai from "../telemetry/ai.js";
@@ -206,6 +207,7 @@ declare const fullApi: ApiFromModules<{
   "onboarding/plan": typeof onboarding_plan;
   "onboarding/websites": typeof onboarding_websites;
   operatorNotifications: typeof operatorNotifications;
+  "privacy/retention": typeof privacy_retention;
   "services/localizedNames": typeof services_localizedNames;
   smsCompliance: typeof smsCompliance;
   "telemetry/ai": typeof telemetry_ai;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -3791,6 +3791,12 @@ export declare const components: {
         any
       >;
       createStream: FunctionReference<"mutation", "internal", {}, any>;
+      deleteStream: FunctionReference<
+        "mutation",
+        "internal",
+        { streamId: string },
+        null
+      >;
       getStreamStatus: FunctionReference<
         "query",
         "internal",

--- a/convex/ai/agents/runtime.ts
+++ b/convex/ai/agents/runtime.ts
@@ -41,6 +41,7 @@ import {
   getPostHogDistinctIdForBusinessSystem,
 } from "../../telemetry/shared";
 import { captureAiTraceStartedBestEffort } from "../../telemetry/ai";
+import { isMessageContentExpired } from "../../privacy/retention";
 
 import { observedInternalAction as internalAction } from "../../telemetry/observedFunctions";
 function buildGroundedSystemPrompt(input: {
@@ -3398,6 +3399,21 @@ export const clearConversationAiState = internalMutation({
       .withIndex("by_conversation_id", (q) => q.eq("conversationId", args.conversationId))
       .unique();
     if (existing) {
+      if (typeof receptionistAgent.deleteThreadAsync === "function") {
+        try {
+          await receptionistAgent.deleteThreadAsync(ctx, { threadId: existing.threadId });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (
+            !message.includes("not found") &&
+            !message.includes("is not registered") &&
+            !message.includes("Invalid") &&
+            !message.includes("Value does not match validator")
+          ) {
+            throw error;
+          }
+        }
+      }
       await ctx.db.delete(existing._id);
     }
     return null;
@@ -3658,11 +3674,14 @@ export const getRecentConversationMessages = internalQuery({
       .order("desc")
       .take(args.limit ?? 6);
 
-    return messages.reverse().map((message) => ({
-      direction: message.direction,
-      body: message.body,
-      _creationTime: message._creationTime,
-    }));
+    return messages
+      .reverse()
+      .filter((message) => !isMessageContentExpired(message))
+      .map((message) => ({
+        direction: message.direction,
+        body: message.body,
+        _creationTime: message._creationTime,
+      }));
   },
 });
 

--- a/convex/ai/context/knowledge.ts
+++ b/convex/ai/context/knowledge.ts
@@ -567,9 +567,20 @@ async function enqueueStaleKnowledgeReindex(
   }
 }
 
+function isMissingOrInvalidComponentReferenceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("not found") ||
+    message.includes("is not registered") ||
+    message.includes("Invalid") ||
+    message.includes("Value does not match validator")
+  );
+}
+
 async function generatePreviewAnswer(
   ctx: ActionCtx,
   args: PreviewKnowledgeArgs,
+  options: { deleteThreadAfterGeneration?: boolean } = {},
 ): Promise<PreviewKnowledgeAnswer> {
   const snapshot = await ctx.runQuery(internal.ai.context.snapshots.getByBusinessId, {
     businessId: args.businessId,
@@ -605,47 +616,59 @@ async function generatePreviewAnswer(
     },
   });
 
-  const result = await receptionistAgent.generateText(
-    ctx,
-    { threadId },
-    withAiTelemetryContext({
-      prompt: [
-        `Business snapshot summary: ${snapshot.summary}`,
-        `Booking policy: ${snapshot.bookingPolicy}`,
-        `Knowledge digest: ${snapshot.knowledgeDigest || "No long-form knowledge configured."}`,
-        `Relevant knowledge: ${context.map((entry) => entry.text).join("\n---\n")}`,
-        `User prompt: ${args.prompt}`,
-      ].join("\n\n"),
-    } as any, {
-      traceId,
-      sessionId: threadId,
-      distinctId,
-      groupKey,
-      businessId: args.businessId,
-      mutationRunner: ctx,
-      properties: {
+  try {
+    const result = await receptionistAgent.generateText(
+      ctx,
+      { threadId },
+      withAiTelemetryContext({
+        prompt: [
+          `Business snapshot summary: ${snapshot.summary}`,
+          `Booking policy: ${snapshot.bookingPolicy}`,
+          `Knowledge digest: ${snapshot.knowledgeDigest || "No long-form knowledge configured."}`,
+          `Relevant knowledge: ${context.map((entry) => entry.text).join("\n---\n")}`,
+          `User prompt: ${args.prompt}`,
+        ].join("\n\n"),
+      } as any, {
+        traceId,
+        sessionId: threadId,
+        distinctId,
+        groupKey,
+        businessId: args.businessId,
+        mutationRunner: ctx,
+        properties: {
+          channel: "dashboard",
+          operation: "knowledge.preview_answer",
+        },
+      }),
+    );
+
+    const metrics = extractGenerationMetrics(result);
+    if (metrics.totalCostUsd !== undefined) {
+      await ctx.runMutation(internal.unitEconomics.recordAiGenerationCost, {
+        businessId: args.businessId,
+        occurredAt: new Date().toISOString(),
+        eventKey: `dashboard_ai:knowledge_preview:${traceId}`,
+        eventKind: "dashboard_ai",
         channel: "dashboard",
+        costUsd: metrics.totalCostUsd,
+        provider: "google",
+        model: getNonRealtimeTextModelId(),
         operation: "knowledge.preview_answer",
-      },
-    }),
-  );
+      });
+    }
 
-  const metrics = extractGenerationMetrics(result);
-  if (metrics.totalCostUsd !== undefined) {
-    await ctx.runMutation(internal.unitEconomics.recordAiGenerationCost, {
-      businessId: args.businessId,
-      occurredAt: new Date().toISOString(),
-      eventKey: `dashboard_ai:knowledge_preview:${traceId}`,
-      eventKind: "dashboard_ai",
-      channel: "dashboard",
-      costUsd: metrics.totalCostUsd,
-      provider: "google",
-      model: getNonRealtimeTextModelId(),
-      operation: "knowledge.preview_answer",
-    });
+    return { text: result.text, threadId };
+  } finally {
+    if (options.deleteThreadAfterGeneration) {
+      try {
+        await receptionistAgent.deleteThreadAsync(ctx, { threadId });
+      } catch (error) {
+        if (!isMissingOrInvalidComponentReferenceError(error)) {
+          throw error;
+        }
+      }
+    }
   }
-
-  return { text: result.text, threadId };
 }
 
 async function deleteKnowledgeEntryById(
@@ -1518,6 +1541,8 @@ export const previewKnowledgeAnswer = action({
   },
   handler: async (ctx: ActionCtx, args: PreviewKnowledgeArgs): Promise<PreviewKnowledgeAnswer> => {
     await requireKnowledgeAccess(ctx, args.businessId);
-    return await generatePreviewAnswer(ctx, args);
+    return await generatePreviewAnswer(ctx, args, {
+      deleteThreadAfterGeneration: true,
+    });
   },
 });

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -11,7 +11,7 @@ import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { v } from "convex/values";
 import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../../lib/auth";
-import { persistentTextStreaming } from "../../lib/components";
+import { persistentTextStreaming, receptionistAgent } from "../../lib/components";
 import {
   getSensitiveContentExpiresAt,
   isPreviewSessionExpired,
@@ -19,6 +19,16 @@ import {
 } from "../../privacy/retention";
 
 import { observedHttpAction as httpAction } from "../../telemetry/observedFunctions";
+
+function isMissingOrInvalidComponentReferenceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("not found") ||
+    message.includes("is not registered") ||
+    message.includes("Invalid") ||
+    message.includes("Value does not match validator")
+  );
+}
 // Convex component types can exceed local tsc recursion depth on these builders.
 // @ts-ignore Deep type instantiation from Convex component generics.
 export const createPreviewSession = mutation({
@@ -78,20 +88,20 @@ export const recordPreviewOutput = internalMutation({
     streamId: v.string(),
     threadId: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ recorded: boolean }> => {
     const previewSession = await ctx.db
       .query("preview_sessions")
       .withIndex("by_stream_id", (q) => q.eq("streamId", args.streamId))
       .unique();
 
-    if (!previewSession) {
-      return null;
+    if (!previewSession || isPreviewSessionExpired(previewSession)) {
+      return { recorded: false };
     }
 
     await ctx.db.patch(previewSession._id, {
       threadId: args.threadId,
     });
-    return null;
+    return { recorded: true };
   },
 });
 
@@ -117,10 +127,30 @@ export const streamPreviewResponse = httpAction(async (ctx, request) => {
       prompt: body.prompt,
     },
   );
-  await ctx.runMutation(internal.ai.preview.stream.recordPreviewOutput, {
-    streamId: body.streamId,
-    threadId: preview.threadId,
-  });
+  const recordResult: { recorded: boolean } = await ctx.runMutation(
+    internal.ai.preview.stream.recordPreviewOutput,
+    {
+      streamId: body.streamId,
+      threadId: preview.threadId,
+    },
+  );
+  if (!recordResult.recorded) {
+    try {
+      await receptionistAgent.deleteThreadAsync(ctx, { threadId: preview.threadId });
+    } catch (error) {
+      if (!isMissingOrInvalidComponentReferenceError(error)) {
+        throw error;
+      }
+    }
+    try {
+      await persistentTextStreaming.deleteStream(ctx, body.streamId);
+    } catch (error) {
+      if (!isMissingOrInvalidComponentReferenceError(error)) {
+        throw error;
+      }
+    }
+    return new Response("Preview session not found.", { status: 410 });
+  }
 
   const response = await persistentTextStreaming.stream(
     ctx,

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -9,6 +9,7 @@ import type { Id } from "../../_generated/dataModel";
 import { v } from "convex/values";
 import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../../lib/auth";
 import { persistentTextStreaming } from "../../lib/components";
+import { getSensitiveContentExpiresAt } from "../../privacy/retention";
 
 import { observedHttpAction as httpAction } from "../../telemetry/observedFunctions";
 // Convex component types can exceed local tsc recursion depth on these builders.
@@ -28,6 +29,7 @@ export const createPreviewSession = mutation({
       userId: user._id,
       prompt: args.prompt,
       streamId,
+      expiresAt: getSensitiveContentExpiresAt(),
     });
     return { previewSessionId, streamId };
   },

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -14,7 +14,7 @@ import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../../
 import { persistentTextStreaming } from "../../lib/components";
 import {
   getSensitiveContentExpiresAt,
-  isPreviewSessionExpired,
+  schedulePreviewSessionExpiration,
 } from "../../privacy/retention";
 
 import { observedHttpAction as httpAction } from "../../telemetry/observedFunctions";
@@ -30,13 +30,15 @@ export const createPreviewSession = mutation({
     await requireMembership(ctx, args.businessId);
     const streamId = await persistentTextStreaming.createStream(ctx);
     // @ts-ignore Deep type instantiation from Convex component generics.
+    const expiresAt = getSensitiveContentExpiresAt();
     const previewSessionId = await ctx.db.insert("preview_sessions", {
       businessId: args.businessId,
       userId: user._id,
       prompt: args.prompt,
       streamId,
-      expiresAt: getSensitiveContentExpiresAt(),
+      expiresAt,
     });
+    await schedulePreviewSessionExpiration(ctx, previewSessionId, expiresAt);
     return { previewSessionId, streamId };
   },
 });
@@ -55,8 +57,7 @@ export const getPreviewBody = query({
 
     if (
       !previewSession ||
-      previewSession.userId !== user._id ||
-      isPreviewSessionExpired(previewSession)
+      previewSession.userId !== user._id
     ) {
       throw new Error("Preview session not found.");
     }

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -1,8 +1,11 @@
 import {
   StreamId,
   StreamIdValidator,
-  } from "@convex-dev/persistent-text-streaming";
-import { observedMutation as mutation } from "../../telemetry/observedFunctions";
+} from "@convex-dev/persistent-text-streaming";
+import {
+  observedInternalMutation as internalMutation,
+  observedMutation as mutation,
+} from "../../telemetry/observedFunctions";
 import { query } from "../../_generated/server";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
@@ -60,6 +63,28 @@ export const getPreviewBody = query({
   },
 });
 
+export const recordPreviewOutput = internalMutation({
+  args: {
+    streamId: v.string(),
+    threadId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const previewSession = await ctx.db
+      .query("preview_sessions")
+      .withIndex("by_stream_id", (q) => q.eq("streamId", args.streamId))
+      .unique();
+
+    if (!previewSession) {
+      return null;
+    }
+
+    await ctx.db.patch(previewSession._id, {
+      threadId: args.threadId,
+    });
+    return null;
+  },
+});
+
 export const streamPreviewResponse = httpAction(async (ctx, request) => {
   const internalServiceToken = process.env.INTERNAL_SERVICE_TOKEN;
   if (
@@ -82,6 +107,10 @@ export const streamPreviewResponse = httpAction(async (ctx, request) => {
       prompt: body.prompt,
     },
   );
+  await ctx.runMutation(internal.ai.preview.stream.recordPreviewOutput, {
+    streamId: body.streamId,
+    threadId: preview.threadId,
+  });
 
   const response = await persistentTextStreaming.stream(
     ctx,

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -12,7 +12,10 @@ import type { Id } from "../../_generated/dataModel";
 import { v } from "convex/values";
 import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../../lib/auth";
 import { persistentTextStreaming } from "../../lib/components";
-import { getSensitiveContentExpiresAt } from "../../privacy/retention";
+import {
+  getSensitiveContentExpiresAt,
+  isPreviewSessionExpired,
+} from "../../privacy/retention";
 
 import { observedHttpAction as httpAction } from "../../telemetry/observedFunctions";
 // Convex component types can exceed local tsc recursion depth on these builders.
@@ -50,7 +53,11 @@ export const getPreviewBody = query({
       .withIndex("by_stream_id", (q) => q.eq("streamId", String(args.streamId)))
       .unique();
 
-    if (!previewSession || previewSession.userId !== user._id) {
+    if (
+      !previewSession ||
+      previewSession.userId !== user._id ||
+      isPreviewSessionExpired(previewSession)
+    ) {
       throw new Error("Preview session not found.");
     }
 

--- a/convex/ai/preview/stream.ts
+++ b/convex/ai/preview/stream.ts
@@ -14,6 +14,7 @@ import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../../
 import { persistentTextStreaming } from "../../lib/components";
 import {
   getSensitiveContentExpiresAt,
+  isPreviewSessionExpired,
   schedulePreviewSessionExpiration,
 } from "../../privacy/retention";
 
@@ -57,7 +58,8 @@ export const getPreviewBody = query({
 
     if (
       !previewSession ||
-      previewSession.userId !== user._id
+      previewSession.userId !== user._id ||
+      isPreviewSessionExpired(previewSession)
     ) {
       throw new Error("Preview session not found.");
     }

--- a/convex/conversations/sessions.ts
+++ b/convex/conversations/sessions.ts
@@ -3,6 +3,7 @@ import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import { internalQuery, type MutationCtx, type QueryCtx } from "../_generated/server";
 import { buildConversationOutcome } from "../dashboard/outcomes";
+import { isMessageContentExpired } from "../privacy/retention";
 
 import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 export const SMS_SESSION_INACTIVITY_MS = 60 * 60 * 1000;
@@ -109,11 +110,12 @@ function buildPlainSummaryFromMessages(
   locale: string | null | undefined,
 ): string | null {
   const summaryLocale = getSummaryLocale(locale);
-  const inboundBodies = messages
+  const visibleMessages = messages.filter((message) => !isMessageContentExpired(message));
+  const inboundBodies = visibleMessages
     .filter((message) => message.direction === "inbound")
     .map((message) => message.body.trim())
     .filter((body) => body.length > 0);
-  const outboundBodies = messages
+  const outboundBodies = visibleMessages
     .filter((message) => message.direction === "outbound")
     .map((message) => message.body.trim())
     .filter((body) => body.length > 0);
@@ -173,7 +175,7 @@ function buildPlainSummaryFromMessages(
     }
   }
 
-  const attachments = messages.flatMap((message) => message.media ?? []);
+  const attachments = visibleMessages.flatMap((message) => message.media ?? []);
   if (attachments.length > 0) {
     const imageCount = attachments.filter((attachment) =>
       (attachment.contentType ?? "").startsWith("image/"),

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -28,7 +28,7 @@ import {
   serializePostHogEvent,
 } from "../telemetry/posthog";
 import { ensureSessionForStoredMessage } from "./sessions";
-import { getSensitiveContentExpiresAt } from "../privacy/retention";
+import { getMessageContentExpiresAt } from "../privacy/retention";
 
 function asConversationId(value: string): Id<"conversations"> {
   return value as Id<"conversations">;
@@ -613,7 +613,7 @@ export const storeInboundMessage = internalMutation({
       status: "received",
       aiGenerated: false,
       contentRetentionStatus: "active",
-      contentExpiresAt: getSensitiveContentExpiresAt(),
+      contentExpiresAt: getMessageContentExpiresAt(),
     });
 
     await ensureSessionForStoredMessage(ctx, {
@@ -705,7 +705,7 @@ export const storeOutboundMessage = internalMutation({
       ...(args.senderRole !== undefined ? { senderRole: args.senderRole } : {}),
       aiGenerated: args.aiGenerated ?? true,
       contentRetentionStatus: "active",
-      contentExpiresAt: getSensitiveContentExpiresAt(),
+      contentExpiresAt: getMessageContentExpiresAt(),
     });
 
     await ensureSessionForStoredMessage(ctx, {
@@ -782,7 +782,7 @@ export const reserveOutboundAiMessage = internalMutation({
       senderRole: args.senderRole ?? "business_ai",
       aiGenerated: true,
       contentRetentionStatus: "active",
-      contentExpiresAt: getSensitiveContentExpiresAt(),
+      contentExpiresAt: getMessageContentExpiresAt(),
     });
   },
 });
@@ -826,7 +826,7 @@ export const finalizeReservedOutboundMessage = internalMutation({
       ...(args.appointmentId !== undefined ? { appointmentId: args.appointmentId } : {}),
       ...(args.media !== undefined && args.media.length > 0 ? { media: args.media } : {}),
       contentRetentionStatus: "active",
-      contentExpiresAt: getSensitiveContentExpiresAt(),
+      contentExpiresAt: getMessageContentExpiresAt(),
     });
 
     await ensureSessionForStoredMessage(ctx, {

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -28,7 +28,10 @@ import {
   serializePostHogEvent,
 } from "../telemetry/posthog";
 import { ensureSessionForStoredMessage } from "./sessions";
-import { getMessageContentExpiresAt } from "../privacy/retention";
+import {
+  getMessageContentExpiresAt,
+  scheduleMessageContentExpiration,
+} from "../privacy/retention";
 
 function asConversationId(value: string): Id<"conversations"> {
   return value as Id<"conversations">;
@@ -600,6 +603,7 @@ export const storeInboundMessage = internalMutation({
         automationState: "ai_active",
       }));
 
+    const contentExpiresAt = getMessageContentExpiresAt();
     const messageId = await ctx.db.insert("messages", {
       businessId: args.businessId,
       conversationId,
@@ -613,8 +617,9 @@ export const storeInboundMessage = internalMutation({
       status: "received",
       aiGenerated: false,
       contentRetentionStatus: "active",
-      contentExpiresAt: getMessageContentExpiresAt(),
+      contentExpiresAt,
     });
+    await scheduleMessageContentExpiration(ctx, messageId, contentExpiresAt);
 
     await ensureSessionForStoredMessage(ctx, {
       businessId: args.businessId,
@@ -692,6 +697,7 @@ export const storeOutboundMessage = internalMutation({
     senderRole: v.optional(v.literal("business_ai")),
   },
   handler: async (ctx: MutationCtx, args: StoreOutboundMessageArgs): Promise<Id<"messages">> => {
+    const contentExpiresAt = getMessageContentExpiresAt();
     const messageId = await ctx.db.insert("messages", {
       businessId: args.businessId,
       conversationId: args.conversationId,
@@ -705,8 +711,9 @@ export const storeOutboundMessage = internalMutation({
       ...(args.senderRole !== undefined ? { senderRole: args.senderRole } : {}),
       aiGenerated: args.aiGenerated ?? true,
       contentRetentionStatus: "active",
-      contentExpiresAt: getMessageContentExpiresAt(),
+      contentExpiresAt,
     });
+    await scheduleMessageContentExpiration(ctx, messageId, contentExpiresAt);
 
     await ensureSessionForStoredMessage(ctx, {
       businessId: args.businessId,
@@ -771,7 +778,8 @@ export const reserveOutboundAiMessage = internalMutation({
     ctx: MutationCtx,
     args: ReserveOutboundAiMessageArgs,
   ): Promise<Id<"messages">> => {
-    return await ctx.db.insert("messages", {
+    const contentExpiresAt = getMessageContentExpiresAt();
+    const messageId = await ctx.db.insert("messages", {
       businessId: args.businessId,
       conversationId: args.conversationId,
       direction: "outbound",
@@ -782,8 +790,10 @@ export const reserveOutboundAiMessage = internalMutation({
       senderRole: args.senderRole ?? "business_ai",
       aiGenerated: true,
       contentRetentionStatus: "active",
-      contentExpiresAt: getMessageContentExpiresAt(),
+      contentExpiresAt,
     });
+    await scheduleMessageContentExpiration(ctx, messageId, contentExpiresAt);
+    return messageId;
   },
 });
 
@@ -820,14 +830,16 @@ export const finalizeReservedOutboundMessage = internalMutation({
       throw new Error("Only outbound messages can be finalized.");
     }
 
+    const contentExpiresAt = getMessageContentExpiresAt();
     await ctx.db.patch(args.messageId, {
       body: args.body,
       status: "queued",
       ...(args.appointmentId !== undefined ? { appointmentId: args.appointmentId } : {}),
       ...(args.media !== undefined && args.media.length > 0 ? { media: args.media } : {}),
       contentRetentionStatus: "active",
-      contentExpiresAt: getMessageContentExpiresAt(),
+      contentExpiresAt,
     });
+    await scheduleMessageContentExpiration(ctx, args.messageId, contentExpiresAt);
 
     await ensureSessionForStoredMessage(ctx, {
       businessId: message.businessId,

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -28,6 +28,7 @@ import {
   serializePostHogEvent,
 } from "../telemetry/posthog";
 import { ensureSessionForStoredMessage } from "./sessions";
+import { getSensitiveContentExpiresAt } from "../privacy/retention";
 
 function asConversationId(value: string): Id<"conversations"> {
   return value as Id<"conversations">;
@@ -611,6 +612,8 @@ export const storeInboundMessage = internalMutation({
       body: args.body,
       status: "received",
       aiGenerated: false,
+      contentRetentionStatus: "active",
+      contentExpiresAt: getSensitiveContentExpiresAt(),
     });
 
     await ensureSessionForStoredMessage(ctx, {
@@ -701,6 +704,8 @@ export const storeOutboundMessage = internalMutation({
       status: "queued",
       ...(args.senderRole !== undefined ? { senderRole: args.senderRole } : {}),
       aiGenerated: args.aiGenerated ?? true,
+      contentRetentionStatus: "active",
+      contentExpiresAt: getSensitiveContentExpiresAt(),
     });
 
     await ensureSessionForStoredMessage(ctx, {
@@ -776,6 +781,8 @@ export const reserveOutboundAiMessage = internalMutation({
       status: "draft",
       senderRole: args.senderRole ?? "business_ai",
       aiGenerated: true,
+      contentRetentionStatus: "active",
+      contentExpiresAt: getSensitiveContentExpiresAt(),
     });
   },
 });
@@ -818,6 +825,8 @@ export const finalizeReservedOutboundMessage = internalMutation({
       status: "queued",
       ...(args.appointmentId !== undefined ? { appointmentId: args.appointmentId } : {}),
       ...(args.media !== undefined && args.media.length > 0 ? { media: args.media } : {}),
+      contentRetentionStatus: "active",
+      contentExpiresAt: getSensitiveContentExpiresAt(),
     });
 
     await ensureSessionForStoredMessage(ctx, {

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -30,6 +30,7 @@ import {
 import { ensureSessionForStoredMessage } from "./sessions";
 import {
   getMessageContentExpiresAt,
+  isMessageContentExpired,
   scheduleMessageContentExpiration,
 } from "../privacy/retention";
 
@@ -487,7 +488,12 @@ export const getOutboundMessageDeliveryContext = internalQuery({
     args: MessageIdArgs,
   ): Promise<OutboundMessageDeliveryContext | null> => {
     const message = await ctx.db.get(args.messageId);
-    if (!message || message.direction !== "outbound" || message.channel !== "sms") {
+    if (
+      !message ||
+      message.direction !== "outbound" ||
+      message.channel !== "sms" ||
+      isMessageContentExpired(message)
+    ) {
       return null;
     }
 
@@ -1211,7 +1217,10 @@ export const handleTwilioSmsInbound = internalAction({
             return {
               businessId: conversation.businessId,
               conversationId: conversation._id,
-              reply: latestReply?.body ?? "Thanks, we already received that message.",
+              reply:
+                latestReply && !isMessageContentExpired(latestReply)
+                  ? latestReply.body
+                  : "Thanks, we already received that message.",
             };
           }
         }

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -42,5 +42,11 @@ crons.interval(
   internal.telemetry.posthog.emitServiceHealthChecks,
   {},
 );
+crons.interval(
+  "cleanup expired sensitive content",
+  { hours: 24 },
+  internal.privacy.retention.runMvpRetentionCleanup,
+  {},
+);
 
 export default crons;

--- a/convex/dashboard/contacts.ts
+++ b/convex/dashboard/contacts.ts
@@ -4,6 +4,7 @@ import { query, type MutationCtx, type QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireCurrentUser, requireMembership } from "../lib/auth";
 import { isContactBlocked } from "../lib/contactBlocking";
+import { getVisibleMessageBody } from "../privacy/retention";
 
 import { observedMutation as mutation } from "../telemetry/observedFunctions";
 async function getCallsForConversation(
@@ -311,14 +312,15 @@ export const getContactDetail = query({
     }
 
     for (const message of allMessages) {
+      const visibleBody = getVisibleMessageBody(message);
       activityItems.push({
         kind: "message",
         timestamp: message._creationTime,
         messageDirection: message.direction,
         messageBody:
-          message.body.length > 120
-            ? message.body.slice(0, 120) + "…"
-            : message.body,
+          visibleBody.length > 120
+            ? visibleBody.slice(0, 120) + "…"
+            : visibleBody,
         messageChannel: message.channel,
       });
     }

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -932,6 +932,9 @@ export const materializeMessageAttachmentUrls = internalMutation({
     if (!message?.media || message.media.length === 0) {
       return null;
     }
+    if (isMessageContentExpired(message)) {
+      return null;
+    }
 
     const nextMedia = [];
     for (const attachment of message.media) {
@@ -1690,6 +1693,10 @@ export const repairConversationAttachmentPreviews = action({
     let repairedAttachments = 0;
 
     for (const message of messages) {
+      if (isMessageContentExpired(message)) {
+        continue;
+      }
+
       let currentMedia = message.media ?? [];
       const imageMediaMissingPreview = currentMedia.filter(
         (attachment) =>

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -75,6 +75,24 @@ type ConversationOutcome =
       kind: "none";
     };
 
+function isAttachmentUploadExpired(
+  attachment: Doc<"message_attachment_uploads">,
+  nowMs: number = Date.now(),
+): boolean {
+  if (typeof attachment.expiresAt !== "string" || attachment.expiresAt.length === 0) {
+    return false;
+  }
+  const parsed = Date.parse(attachment.expiresAt);
+  return Number.isFinite(parsed) && parsed <= nowMs;
+}
+
+function isAvailableStagedAttachment(
+  attachment: Doc<"message_attachment_uploads">,
+  nowMs: number = Date.now(),
+): boolean {
+  return attachment.status === "staged" && !isAttachmentUploadExpired(attachment, nowMs);
+}
+
 async function getContact(
   ctx: QueryCtx,
   contactId: Id<"contacts"> | undefined,
@@ -490,7 +508,7 @@ export const getSmsReplyContext = internalQuery({
             attachment.businessId !== args.businessId ||
             attachment.conversationId !== args.conversationId ||
             attachment.uploaderUserId !== args.userId ||
-            attachment.status !== "staged"
+            !isAvailableStagedAttachment(attachment)
           ) {
             throw new Error("Attachment is no longer available.");
           }
@@ -663,7 +681,9 @@ export const getFinalizeStagedAttachmentContext = internalQuery({
         q.eq("uploaderUserId", args.userId).eq("conversationId", args.conversationId),
       )
       .collect();
-    const activeAttachments = stagedAttachments.filter((attachment) => attachment.status === "staged");
+    const activeAttachments = stagedAttachments.filter((attachment) =>
+      isAvailableStagedAttachment(attachment),
+    );
     if (activeAttachments.length >= MAX_SMS_REPLY_ATTACHMENTS) {
       throw new Error(`You can send up to ${MAX_SMS_REPLY_ATTACHMENTS} attachments at a time.`);
     }
@@ -879,7 +899,7 @@ export const listStagedAttachments = query({
 
     return await Promise.all(
       attachments
-        .filter((attachment) => attachment.status === "staged")
+        .filter((attachment) => isAvailableStagedAttachment(attachment))
         .map(async (attachment) => {
           const previewUrl = attachment.previewStorageId
             ? await ctx.storage.getUrl(attachment.previewStorageId)
@@ -995,7 +1015,7 @@ export const claimStagedAttachmentsForSend = internalMutation({
         attachment.businessId !== args.businessId ||
         attachment.conversationId !== args.conversationId ||
         attachment.uploaderUserId !== args.userId ||
-        attachment.status !== "staged"
+        !isAvailableStagedAttachment(attachment)
       ) {
         throw new Error("Attachment is no longer available.");
       }

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -42,6 +42,7 @@ import {
 } from "../telemetry/shared";
 import {
   REDACTED_MESSAGE_BODY,
+  getUnsentAttachmentUploadExpiresAt,
   getVisibleMessageBody,
   isMessageContentExpired,
 } from "../privacy/retention";
@@ -709,6 +710,7 @@ export const insertStagedAttachment = internalMutation({
       ...(args.previewByteLength ? { previewByteLength: args.previewByteLength } : {}),
       deliveryMode: args.deliveryMode,
       status: "staged",
+      expiresAt: getUnsentAttachmentUploadExpiresAt(),
     });
   },
 });

--- a/convex/dashboard/messages.ts
+++ b/convex/dashboard/messages.ts
@@ -40,6 +40,11 @@ import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
 } from "../telemetry/shared";
+import {
+  REDACTED_MESSAGE_BODY,
+  getVisibleMessageBody,
+  isMessageContentExpired,
+} from "../privacy/retention";
 
 import { observedAction as action } from "../telemetry/observedFunctions";
 type MessageMediaRecord = NonNullable<Doc<"messages">["media"]>[number];
@@ -107,7 +112,7 @@ function getLatestMessagePreviewKind(
     return "text";
   }
 
-  if (message.body.trim().length > 0) {
+  if (getVisibleMessageBody(message).trim().length > 0) {
     return "text";
   }
 
@@ -233,11 +238,12 @@ function buildSummaryFromMessages(
   locale: string | null | undefined,
 ): string | null {
   const summaryLocale = getSummaryLocale(locale);
-  const inboundBodies = messages
+  const visibleMessages = messages.filter((message) => !isMessageContentExpired(message));
+  const inboundBodies = visibleMessages
     .filter((message) => message.direction === "inbound")
     .map((message) => message.body.trim())
     .filter((body) => body.length > 0);
-  const outboundBodies = messages
+  const outboundBodies = visibleMessages
     .filter((message) => message.direction === "outbound")
     .map((message) => message.body.trim())
     .filter((body) => body.length > 0);
@@ -297,7 +303,7 @@ function buildSummaryFromMessages(
     }
   }
 
-  const attachments = messages.flatMap((message) => message.media ?? []);
+  const attachments = visibleMessages.flatMap((message) => message.media ?? []);
   if (attachments.length > 0) {
     const imageCount = attachments.filter((attachment) =>
       (attachment.contentType ?? "").startsWith("image/"),
@@ -1075,10 +1081,20 @@ export const getMessageAttachmentDownloadToken = internalQuery({
     token: v.string(),
   },
   handler: async (ctx: QueryCtx, args) => {
-    return await ctx.db
+    const token = await ctx.db
       .query("message_attachment_download_tokens")
       .withIndex("by_nonce", (q) => q.eq("nonce", args.token))
       .unique();
+    if (!token) {
+      return null;
+    }
+
+    const message = await ctx.db.get(token.messageId);
+    if (!message || isMessageContentExpired(message)) {
+      return null;
+    }
+
+    return token;
   },
 });
 
@@ -1158,7 +1174,7 @@ export const listConversationSummaries = query({
           contactEmail: contact?.email ?? null,
           isBlocked: isContactBlocked(contact),
           messageCount: messages.length,
-          lastMessageBody: latestMessage?.body ?? null,
+          lastMessageBody: latestMessage ? getVisibleMessageBody(latestMessage) : null,
           lastMessagePreviewKind: getLatestMessagePreviewKind(latestMessage),
           lastMessageDirection: latestMessage?.direction ?? null,
           lastMessageAt: latestMessage?._creationTime ?? conversation._creationTime,
@@ -1176,6 +1192,10 @@ async function hydrateMessageAttachments(
   ctx: QueryCtx,
   message: Doc<"messages">,
 ) {
+  if (isMessageContentExpired(message)) {
+    return [];
+  }
+
   const now = Date.now();
   const tokens = await ctx.db
     .query("message_attachment_download_tokens")
@@ -1353,12 +1373,18 @@ export const getConversationThread = query({
         id: message._id,
         conversationSessionId: message.conversationSessionId ?? null,
         direction: message.direction,
-        body: message.body,
+        body: getVisibleMessageBody(message),
         status: message.status,
         channel: message.channel,
         createdAt: message._creationTime,
         attachments: await hydrateMessageAttachments(ctx, message),
       })),
+    );
+
+    const expiredMessageSessionIds = new Set(
+      messages
+        .filter((message) => isMessageContentExpired(message) && message.conversationSessionId)
+        .map((message) => String(message.conversationSessionId)),
     );
 
     const summaryTimelineItems = sessions
@@ -1371,10 +1397,19 @@ export const getConversationThread = query({
         startedAt: session.startedAt,
         closedAt: session.closedAt ?? session.lastMessageAt,
         summaryKind: session.summaryKind ?? session.summary!.kind,
-        summary: session.summary!,
+        summary: expiredMessageSessionIds.has(String(session._id))
+          ? {
+              ...session.summary!,
+              summary: REDACTED_MESSAGE_BODY,
+            }
+          : session.summary!,
       }));
 
     const legacyMessages = messages.filter((message) => message.conversationSessionId === undefined);
+    const hasExpiredLegacyMessages = legacyMessages.some((message) =>
+      isMessageContentExpired(message),
+    );
+    const hasExpiredMessages = messages.some((message) => isMessageContentExpired(message));
     const hasLegacyMessages = legacyMessages.length > 0;
     const legacyOutcome =
       sessions.length === 0
@@ -1393,7 +1428,9 @@ export const getConversationThread = query({
               legacyMessages[legacyMessages.length - 1]?._creationTime ??
               hydratedMessages[hydratedMessages.length - 1]?.createdAt ??
               conversation._creationTime,
-            legacySummary: normalizeSummary(conversation.summary),
+            legacySummary: hasExpiredLegacyMessages
+              ? REDACTED_MESSAGE_BODY
+              : normalizeSummary(conversation.summary),
           })
         : null;
 
@@ -1420,7 +1457,7 @@ export const getConversationThread = query({
         automationPausedByName: conversation.automationPausedByUserId
           ? formatOperatorDisplayName(await ctx.db.get(conversation.automationPausedByUserId))
           : null,
-        summary: conversation.summary ?? null,
+        summary: hasExpiredMessages ? REDACTED_MESSAGE_BODY : (conversation.summary ?? null),
         currentIntent: conversation.currentIntent ?? null,
       },
       contact: contact

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -7,6 +7,7 @@ import { getLocalizedServiceName } from "../lib/serviceNames";
 import {
   getVisibleMessageBody,
   isCallRecordingExpired,
+  isTranscriptExpired,
 } from "../privacy/retention";
 
 type KpiWindow = {
@@ -487,7 +488,9 @@ export const getHomeSummary = query({
               .withIndex("by_call_id_and_sequence", (q) => q.eq("callId", call._id))
               .take(1),
           ]);
-          const visibleTranscriptPreview = transcriptPreview[0];
+          const visibleTranscriptPreview = transcriptPreview.find(
+            (transcript) => !isTranscriptExpired(transcript),
+          );
 
           return {
             id: call._id,

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -7,7 +7,6 @@ import { getLocalizedServiceName } from "../lib/serviceNames";
 import {
   getVisibleMessageBody,
   isCallRecordingExpired,
-  isTranscriptExpired,
 } from "../privacy/retention";
 
 type KpiWindow = {
@@ -488,9 +487,7 @@ export const getHomeSummary = query({
               .withIndex("by_call_id_and_sequence", (q) => q.eq("callId", call._id))
               .take(1),
           ]);
-          const visibleTranscriptPreview = transcriptPreview.find(
-            (transcript) => !isTranscriptExpired(transcript),
-          );
+          const visibleTranscriptPreview = transcriptPreview[0];
 
           return {
             id: call._id,

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -421,6 +421,10 @@ export const getHomeSummary = query({
     );
 
     const allMessages = messagesByConversation.flatMap((entry) => entry.messages);
+    const messagesByConversationId = new Map<Id<"conversations">, Array<Doc<"messages">>>();
+    for (const entry of messagesByConversation) {
+      messagesByConversationId.set(entry.conversationId, entry.messages);
+    }
     const callsThisMonth = buildKpiWindow(
       calls.map((call) => Date.parse(call.startedAt)),
       currentMonthStart,
@@ -538,15 +542,13 @@ export const getHomeSummary = query({
 
     const actionRequiredFromHandoffs = await Promise.all(
       handoffConversations.map(async (conversation) => {
-        const [contact, conversationMessages] = await Promise.all([
-          conversation.contactId ? ctx.db.get(conversation.contactId) : Promise.resolve(null),
-          ctx.db
-            .query("messages")
-            .withIndex("by_conversation_id", (q) => q.eq("conversationId", conversation._id))
-            .order("desc")
-            .collect(),
-        ]);
-        const latestMessage = conversationMessages[0] ?? null;
+        const contact = conversation.contactId ? await ctx.db.get(conversation.contactId) : null;
+        const conversationMessages = messagesByConversationId.get(conversation._id) ?? [];
+        const latestMessage = conversationMessages.reduce<Doc<"messages"> | null>(
+          (latest, message) =>
+            latest === null || message._creationTime > latest._creationTime ? message : latest,
+          null,
+        );
         const hasExpiredMessages = conversationMessages.some((message) =>
           isMessageContentExpired(message),
         );

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -4,6 +4,10 @@ import { query, type QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
 import { getLocalizedServiceName } from "../lib/serviceNames";
+import {
+  isCallRecordingExpired,
+  isTranscriptExpired,
+} from "../privacy/retention";
 
 type KpiWindow = {
   current: number;
@@ -483,6 +487,9 @@ export const getHomeSummary = query({
               .withIndex("by_call_id_and_sequence", (q) => q.eq("callId", call._id))
               .take(1),
           ]);
+          const visibleTranscriptPreview = transcriptPreview.find(
+            (transcript) => !isTranscriptExpired(transcript),
+          );
 
           return {
             id: call._id,
@@ -490,8 +497,9 @@ export const getHomeSummary = query({
             status: call.status,
             disposition: call.disposition ?? null,
             durationSeconds: call.providerCallDurationSeconds ?? null,
-            transcriptReady: transcriptPreview.length > 0,
-            recordingAvailable: call.recordingStorageId !== undefined,
+            transcriptReady: visibleTranscriptPreview !== undefined,
+            recordingAvailable:
+              call.recordingStorageId !== undefined && !isCallRecordingExpired(call),
             contactName: contact?.name ?? null,
             contactPhone: contact?.phone ?? null,
           };

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -5,6 +5,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
 import { getLocalizedServiceName } from "../lib/serviceNames";
 import {
+  getVisibleMessageBody,
   isCallRecordingExpired,
   isTranscriptExpired,
 } from "../privacy/retention";
@@ -543,6 +544,9 @@ export const getHomeSummary = query({
             .take(1),
         ]);
         const latestMessage = latestMessages[0] ?? null;
+        const latestMessageBody = latestMessage
+          ? getVisibleMessageBody(latestMessage).trim()
+          : "";
         const latestMessageTimestamp =
           latestMessage?._creationTime ??
           (conversation.automationPausedAt
@@ -554,8 +558,8 @@ export const getHomeSummary = query({
           kind: "human_handoff",
           title: contact?.name ?? contact?.phone ?? "Human handoff",
           body:
-            latestMessage?.body?.trim() ||
-            conversation.summary ||
+            latestMessageBody ||
+            (latestMessage === null ? conversation.summary : null) ||
             "AI is paused and waiting for an operator reply.",
           createdAt:
             latestMessage !== null

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -559,7 +559,7 @@ export const getHomeSummary = query({
           title: contact?.name ?? contact?.phone ?? "Human handoff",
           body:
             latestMessageBody ||
-            (latestMessage === null ? conversation.summary : null) ||
+            conversation.summary ||
             "AI is paused and waiting for an operator reply.",
           createdAt:
             latestMessage !== null

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -5,8 +5,11 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership } from "../lib/auth";
 import { getLocalizedServiceName } from "../lib/serviceNames";
 import {
+  getVisibleInboxItemBody,
+  getVisibleInboxItemTitle,
   getVisibleMessageBody,
   isCallRecordingExpired,
+  isMessageContentExpired,
   isTranscriptExpired,
 } from "../privacy/retention";
 
@@ -518,8 +521,8 @@ export const getHomeSummary = query({
       .map((item) => ({
         id: String(item._id),
         kind: item.kind,
-        title: item.title,
-        body: item.body,
+        title: getVisibleInboxItemTitle(item),
+        body: getVisibleInboxItemBody(item),
         createdAt: new Date(item._creationTime).toISOString(),
         taskId: item._id,
         ...(item.relatedId ? { callId: item.relatedId as Id<"calls"> } : {}),
@@ -535,15 +538,18 @@ export const getHomeSummary = query({
 
     const actionRequiredFromHandoffs = await Promise.all(
       handoffConversations.map(async (conversation) => {
-        const [contact, latestMessages] = await Promise.all([
+        const [contact, conversationMessages] = await Promise.all([
           conversation.contactId ? ctx.db.get(conversation.contactId) : Promise.resolve(null),
           ctx.db
             .query("messages")
             .withIndex("by_conversation_id", (q) => q.eq("conversationId", conversation._id))
             .order("desc")
-            .take(1),
+            .collect(),
         ]);
-        const latestMessage = latestMessages[0] ?? null;
+        const latestMessage = conversationMessages[0] ?? null;
+        const hasExpiredMessages = conversationMessages.some((message) =>
+          isMessageContentExpired(message),
+        );
         const latestMessageBody = latestMessage
           ? getVisibleMessageBody(latestMessage).trim()
           : "";
@@ -559,7 +565,7 @@ export const getHomeSummary = query({
           title: contact?.name ?? contact?.phone ?? "Human handoff",
           body:
             latestMessageBody ||
-            conversation.summary ||
+            (hasExpiredMessages ? "" : conversation.summary) ||
             "AI is paused and waiting for an operator reply.",
           createdAt:
             latestMessage !== null

--- a/convex/operatorNotifications.ts
+++ b/convex/operatorNotifications.ts
@@ -21,6 +21,10 @@ import {
   type OperatorNotificationEventKey,
   type OperatorNotificationEventPreferences,
 } from "./lib/operatorNotificationPreferences";
+import {
+  getMessageContentExpiresAt,
+  scheduleOperatorNotificationDeliveryContentExpiration,
+} from "./privacy/retention";
 
 type EffectivePreferences = {
   emailEnabled: boolean;
@@ -139,6 +143,14 @@ function estimateSmsSegments(body: string): number {
   return gsmSeptetLength <= 160
     ? 1
     : Math.max(1, Math.ceil(gsmSeptetLength / 153));
+}
+
+function getSensitiveDeliveryContentExpiresAt(
+  eventKind: "dailyDigest" | "test" | OperatorNotificationEventKey,
+): string | undefined {
+  return eventKind === "voiceMessage" || eventKind === "pausedSms"
+    ? getMessageContentExpiresAt()
+    : undefined;
 }
 
 function parseSendTime(sendTime: string): { hour: number; minute: number } {
@@ -353,6 +365,7 @@ export const reserveDelivery = internalMutation({
     scheduledFor: v.optional(v.string()),
     digestForDate: v.optional(v.string()),
     recipientEmail: v.optional(v.string()),
+    contentExpiresAt: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -412,8 +425,21 @@ export const reserveDelivery = internalMutation({
       body: args.body,
       ...(args.scheduledFor !== undefined ? { scheduledFor: args.scheduledFor } : {}),
       ...(args.digestForDate !== undefined ? { digestForDate: args.digestForDate } : {}),
+      ...(args.contentExpiresAt !== undefined
+        ? {
+            contentRetentionStatus: "active" as const,
+            contentExpiresAt: args.contentExpiresAt,
+          }
+        : {}),
       createdAt: new Date().toISOString(),
     });
+    if (args.contentExpiresAt !== undefined) {
+      await scheduleOperatorNotificationDeliveryContentExpiration(
+        ctx,
+        deliveryId,
+        args.contentExpiresAt,
+      );
+    }
 
     return { deliveryId, created: true };
   },
@@ -642,6 +668,7 @@ async function deliverChannel(
     body: string;
     scheduledFor?: string;
     digestForDate?: string;
+    contentExpiresAt?: string;
   },
 ): Promise<{ attempted: boolean; sent: boolean; error?: string }> {
   const reservation: { deliveryId: Id<"operator_notification_deliveries">; created: boolean } =
@@ -655,6 +682,9 @@ async function deliverChannel(
       body: input.body,
       ...(input.scheduledFor !== undefined ? { scheduledFor: input.scheduledFor } : {}),
       ...(input.digestForDate !== undefined ? { digestForDate: input.digestForDate } : {}),
+      ...(input.contentExpiresAt !== undefined
+        ? { contentExpiresAt: input.contentExpiresAt }
+        : {}),
       ...(input.eventKind === "dailyDigest" && input.channel === "email"
         ? { recipientEmail: input.to }
         : {}),
@@ -725,6 +755,7 @@ export const dispatchEvent = internalAction({
       ...(business?.name ? { businessName: business.name } : {}),
       body: args.body,
     });
+    const contentExpiresAt = getSensitiveDeliveryContentExpiresAt(args.eventKind);
     let attempted = 0;
     let sent = 0;
 
@@ -739,6 +770,7 @@ export const dispatchEvent = internalAction({
           eventKey: args.eventKey,
           subject: args.subject,
           body,
+          ...(contentExpiresAt !== undefined ? { contentExpiresAt } : {}),
         });
         attempted += result.attempted ? 1 : 0;
         sent += result.sent ? 1 : 0;
@@ -754,6 +786,7 @@ export const dispatchEvent = internalAction({
           eventKey: args.eventKey,
           subject: args.subject,
           body,
+          ...(contentExpiresAt !== undefined ? { contentExpiresAt } : {}),
         });
         attempted += result.attempted ? 1 : 0;
         sent += result.sent ? 1 : 0;

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -30,7 +30,6 @@ export const REDACTED_MESSAGE_BODY = "[Expired by 365-day retention policy]";
 
 const DEFAULT_RETENTION_CLEANUP_LIMIT = 100;
 const MAX_RETENTION_CLEANUP_LIMIT = 200;
-const MAX_RETENTION_SCHEDULE_DELAY_MS = 2_000_000_000;
 
 type CleanupArgs = {
   nowIso: string;
@@ -140,8 +139,7 @@ function parseScheduleTime(expiresAt: string): number | null {
   if (!Number.isFinite(parsed)) {
     return null;
   }
-  const now = Date.now();
-  return Math.min(Math.max(parsed, now), now + MAX_RETENTION_SCHEDULE_DELAY_MS);
+  return Math.max(parsed, Date.now());
 }
 
 function isRetentionDue(expiresAt: string): boolean {
@@ -334,26 +332,22 @@ async function deleteSentAttachmentUploads(
   ctx: MutationCtx,
   messageId: Id<"messages">,
   storageIds: Set<Id<"_storage">>,
-): Promise<number> {
-  let deleted = 0;
+): Promise<{ deleted: number; hasMore: boolean }> {
+  const uploads = await ctx.db
+    .query("message_attachment_uploads")
+    .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", messageId))
+    .take(MAX_RETENTION_CLEANUP_LIMIT);
 
-  while (true) {
-    const uploads = await ctx.db
-      .query("message_attachment_uploads")
-      .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", messageId))
-      .take(MAX_RETENTION_CLEANUP_LIMIT);
-
-    if (uploads.length === 0) {
-      return deleted;
-    }
-
-    for (const upload of uploads) {
-      addStorageId(storageIds, upload.storageId);
-      addStorageId(storageIds, upload.previewStorageId);
-      await ctx.db.delete(upload._id);
-      deleted += 1;
-    }
+  for (const upload of uploads) {
+    addStorageId(storageIds, upload.storageId);
+    addStorageId(storageIds, upload.previewStorageId);
+    await ctx.db.delete(upload._id);
   }
+
+  return {
+    deleted: uploads.length,
+    hasMore: uploads.length === MAX_RETENTION_CLEANUP_LIMIT,
+  };
 }
 
 function collectMessageStorageIds(
@@ -372,7 +366,7 @@ async function scrubMessageContent(
 ): Promise<void> {
   const storageIds = new Set<Id<"_storage">>();
   collectMessageStorageIds(message, storageIds);
-  await deleteSentAttachmentUploads(ctx, message._id, storageIds);
+  const sentAttachmentUploads = await deleteSentAttachmentUploads(ctx, message._id, storageIds);
   await deleteMessageAttachmentTokens(ctx, message._id);
   await deleteStorageIds(ctx, storageIds);
   await scrubPausedSmsNotificationMirrors(ctx, message);
@@ -386,6 +380,14 @@ async function scrubMessageContent(
     media: undefined,
     contentRetentionStatus: "expired",
   });
+
+  if (sentAttachmentUploads.hasMore) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.privacy.retention.deleteSentAttachmentUploadsForExpiredMessage,
+      { messageId: message._id },
+    );
+  }
 }
 
 async function deleteConversationAgentThread(
@@ -639,6 +641,40 @@ async function scrubCallRecordingContent(
   });
 }
 
+export const deleteSentAttachmentUploadsForExpiredMessage = internalMutation({
+  args: {
+    messageId: v.id("messages"),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const message = await ctx.db.get(args.messageId);
+    if (!message || !isMessageContentExpired(message)) {
+      return {
+        scanned: message ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    const storageIds = new Set<Id<"_storage">>();
+    const sentAttachmentUploads = await deleteSentAttachmentUploads(ctx, message._id, storageIds);
+    await deleteStorageIds(ctx, storageIds);
+
+    if (sentAttachmentUploads.hasMore) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.privacy.retention.deleteSentAttachmentUploadsForExpiredMessage,
+        { messageId: message._id },
+      );
+    }
+
+    return {
+      scanned: sentAttachmentUploads.deleted,
+      deleted: sentAttachmentUploads.deleted,
+      scrubbed: 0,
+    };
+  },
+});
+
 export const scrubMessageContentAtExpiry = internalMutation({
   args: {
     messageId: v.id("messages"),
@@ -648,7 +684,7 @@ export const scrubMessageContentAtExpiry = internalMutation({
     const message = await ctx.db.get(args.messageId);
     if (
       !message ||
-      message.contentRetentionStatus !== "active" ||
+      message.contentRetentionStatus === "expired" ||
       message.contentExpiresAt !== args.expiresAt
     ) {
       return {
@@ -716,7 +752,7 @@ export const scrubCallRecordingAtExpiry = internalMutation({
     const call = await ctx.db.get(args.callId);
     if (
       !call ||
-      call.recordingRetentionStatus !== "active" ||
+      call.recordingRetentionStatus === "expired" ||
       call.recordingExpiresAt !== args.expiresAt
     ) {
       return {
@@ -786,7 +822,7 @@ export const scrubInboxItemContentAtExpiry = internalMutation({
     const item = await ctx.db.get(args.inboxItemId);
     if (
       !item ||
-      item.contentRetentionStatus !== "active" ||
+      item.contentRetentionStatus === "expired" ||
       item.contentExpiresAt !== args.expiresAt
     ) {
       return {
@@ -822,7 +858,7 @@ export const scrubOperatorNotificationDeliveryContentAtExpiry = internalMutation
     const delivery = await ctx.db.get(args.deliveryId);
     if (
       !delivery ||
-      delivery.contentRetentionStatus !== "active" ||
+      delivery.contentRetentionStatus === "expired" ||
       delivery.contentExpiresAt !== args.expiresAt
     ) {
       return {
@@ -860,15 +896,23 @@ export const scrubExpiredMessages = internalMutation({
   },
   handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
     const limit = normalizeLimit(args.limit);
-    const messages = await ctx.db
-      .query("messages")
-      .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
-        q
-          .eq("contentRetentionStatus", "active")
-          .gt("contentExpiresAt", "")
-          .lte("contentExpiresAt", args.nowIso),
-      )
-      .take(limit);
+    const messages: Array<Doc<"messages">> = [];
+    for (const retentionStatus of ["active", undefined] as const) {
+      const remaining = limit - messages.length;
+      if (remaining <= 0) {
+        break;
+      }
+      const batch = await ctx.db
+        .query("messages")
+        .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
+          q
+            .eq("contentRetentionStatus", retentionStatus)
+            .gt("contentExpiresAt", "")
+            .lte("contentExpiresAt", args.nowIso),
+        )
+        .take(remaining);
+      messages.push(...batch);
+    }
 
     let scrubbed = 0;
     for (const message of messages) {
@@ -923,15 +967,23 @@ export const scrubExpiredCallRecordings = internalMutation({
   },
   handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
     const limit = normalizeLimit(args.limit);
-    const calls = await ctx.db
-      .query("calls")
-      .withIndex("by_recording_retention_status_and_recording_expires_at", (q) =>
-        q
-          .eq("recordingRetentionStatus", "active")
-          .gt("recordingExpiresAt", "")
-          .lte("recordingExpiresAt", args.nowIso),
-      )
-      .take(limit);
+    const calls: Array<Doc<"calls">> = [];
+    for (const retentionStatus of ["active", undefined] as const) {
+      const remaining = limit - calls.length;
+      if (remaining <= 0) {
+        break;
+      }
+      const batch = await ctx.db
+        .query("calls")
+        .withIndex("by_recording_retention_status_and_recording_expires_at", (q) =>
+          q
+            .eq("recordingRetentionStatus", retentionStatus)
+            .gt("recordingExpiresAt", "")
+            .lte("recordingExpiresAt", args.nowIso),
+        )
+        .take(remaining);
+      calls.push(...batch);
+    }
 
     let scrubbed = 0;
     for (const call of calls) {
@@ -988,15 +1040,23 @@ export const scrubExpiredInboxItems = internalMutation({
   },
   handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
     const limit = normalizeLimit(args.limit);
-    const items = await ctx.db
-      .query("inbox_items")
-      .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
-        q
-          .eq("contentRetentionStatus", "active")
-          .gt("contentExpiresAt", "")
-          .lte("contentExpiresAt", args.nowIso),
-      )
-      .take(limit);
+    const items: Array<Doc<"inbox_items">> = [];
+    for (const retentionStatus of ["active", undefined] as const) {
+      const remaining = limit - items.length;
+      if (remaining <= 0) {
+        break;
+      }
+      const batch = await ctx.db
+        .query("inbox_items")
+        .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
+          q
+            .eq("contentRetentionStatus", retentionStatus)
+            .gt("contentExpiresAt", "")
+            .lte("contentExpiresAt", args.nowIso),
+        )
+        .take(remaining);
+      items.push(...batch);
+    }
 
     let scrubbed = 0;
     for (const item of items) {
@@ -1022,15 +1082,23 @@ export const scrubExpiredOperatorNotificationDeliveries = internalMutation({
   },
   handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
     const limit = normalizeLimit(args.limit);
-    const deliveries = await ctx.db
-      .query("operator_notification_deliveries")
-      .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
-        q
-          .eq("contentRetentionStatus", "active")
-          .gt("contentExpiresAt", "")
-          .lte("contentExpiresAt", args.nowIso),
-      )
-      .take(limit);
+    const deliveries: Array<Doc<"operator_notification_deliveries">> = [];
+    for (const retentionStatus of ["active", undefined] as const) {
+      const remaining = limit - deliveries.length;
+      if (remaining <= 0) {
+        break;
+      }
+      const batch = await ctx.db
+        .query("operator_notification_deliveries")
+        .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
+          q
+            .eq("contentRetentionStatus", retentionStatus)
+            .gt("contentExpiresAt", "")
+            .lte("contentExpiresAt", args.nowIso),
+        )
+        .take(remaining);
+      deliveries.push(...batch);
+    }
 
     let scrubbed = 0;
     for (const delivery of deliveries) {

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -27,6 +27,7 @@ export const REDACTED_MESSAGE_BODY = "[Expired by 365-day retention policy]";
 
 const DEFAULT_RETENTION_CLEANUP_LIMIT = 100;
 const MAX_RETENTION_CLEANUP_LIMIT = 200;
+const MAX_RETENTION_SCHEDULE_DELAY_MS = 2_000_000_000;
 
 type CleanupArgs = {
   nowIso: string;
@@ -63,49 +64,98 @@ export function getMessageContentExpiresAt(nowMs: number = Date.now()): string {
 
 export function isMessageContentExpired(
   message: Doc<"messages">,
-  nowMs: number = Date.now(),
 ): boolean {
-  if (message.contentRetentionStatus === "expired") {
-    return true;
-  }
-  return (
-    typeof message.contentExpiresAt === "string" &&
-    Date.parse(message.contentExpiresAt) <= nowMs
-  );
+  return message.contentRetentionStatus === "expired";
 }
 
 export function isCallRecordingExpired(
   call: Doc<"calls">,
-  nowMs: number = Date.now(),
 ): boolean {
-  if (call.recordingRetentionStatus === "expired") {
-    return true;
-  }
-  return (
-    typeof call.recordingExpiresAt === "string" &&
-    Date.parse(call.recordingExpiresAt) <= nowMs
-  );
-}
-
-export function isTranscriptExpired(
-  transcript: Doc<"transcripts">,
-  nowMs: number = Date.now(),
-): boolean {
-  return typeof transcript.expiresAt === "string" && Date.parse(transcript.expiresAt) <= nowMs;
-}
-
-export function isPreviewSessionExpired(
-  session: Doc<"preview_sessions">,
-  nowMs: number = Date.now(),
-): boolean {
-  return typeof session.expiresAt === "string" && Date.parse(session.expiresAt) <= nowMs;
+  return call.recordingRetentionStatus === "expired";
 }
 
 export function getVisibleMessageBody(
   message: Doc<"messages">,
-  nowMs: number = Date.now(),
 ): string {
-  return isMessageContentExpired(message, nowMs) ? REDACTED_MESSAGE_BODY : message.body;
+  return isMessageContentExpired(message) ? REDACTED_MESSAGE_BODY : message.body;
+}
+
+function parseScheduleTime(expiresAt: string): number | null {
+  const parsed = Date.parse(expiresAt);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  const now = Date.now();
+  return Math.min(Math.max(parsed, now), now + MAX_RETENTION_SCHEDULE_DELAY_MS);
+}
+
+function isRetentionDue(expiresAt: string): boolean {
+  const parsed = Date.parse(expiresAt);
+  return Number.isFinite(parsed) && parsed <= Date.now();
+}
+
+export async function scheduleMessageContentExpiration(
+  ctx: MutationCtx,
+  messageId: Id<"messages">,
+  expiresAt: string,
+): Promise<void> {
+  const scheduledAt = parseScheduleTime(expiresAt);
+  if (scheduledAt === null) {
+    return;
+  }
+  await ctx.scheduler.runAt(
+    scheduledAt,
+    internal.privacy.retention.scrubMessageContentAtExpiry,
+    { messageId, expiresAt },
+  );
+}
+
+export async function scheduleCallRecordingExpiration(
+  ctx: MutationCtx,
+  callId: Id<"calls">,
+  expiresAt: string,
+): Promise<void> {
+  const scheduledAt = parseScheduleTime(expiresAt);
+  if (scheduledAt === null) {
+    return;
+  }
+  await ctx.scheduler.runAt(
+    scheduledAt,
+    internal.privacy.retention.scrubCallRecordingAtExpiry,
+    { callId, expiresAt },
+  );
+}
+
+export async function scheduleTranscriptExpiration(
+  ctx: MutationCtx,
+  transcriptId: Id<"transcripts">,
+  expiresAt: string,
+): Promise<void> {
+  const scheduledAt = parseScheduleTime(expiresAt);
+  if (scheduledAt === null) {
+    return;
+  }
+  await ctx.scheduler.runAt(
+    scheduledAt,
+    internal.privacy.retention.deleteTranscriptAtExpiry,
+    { transcriptId, expiresAt },
+  );
+}
+
+export async function schedulePreviewSessionExpiration(
+  ctx: MutationCtx,
+  previewSessionId: Id<"preview_sessions">,
+  expiresAt: string,
+): Promise<void> {
+  const scheduledAt = parseScheduleTime(expiresAt);
+  if (scheduledAt === null) {
+    return;
+  }
+  await ctx.scheduler.runAt(
+    scheduledAt,
+    internal.privacy.retention.deletePreviewSessionAtExpiry,
+    { previewSessionId, expiresAt },
+  );
 }
 
 function normalizeLimit(limit: number): number {
@@ -446,6 +496,144 @@ async function scrubCallRecordingContent(
     recordingRetentionStatus: "expired",
   });
 }
+
+export const scrubMessageContentAtExpiry = internalMutation({
+  args: {
+    messageId: v.id("messages"),
+    expiresAt: v.string(),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const message = await ctx.db.get(args.messageId);
+    if (
+      !message ||
+      message.contentRetentionStatus !== "active" ||
+      message.contentExpiresAt !== args.expiresAt
+    ) {
+      return {
+        scanned: message ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+    if (!isRetentionDue(args.expiresAt)) {
+      await scheduleMessageContentExpiration(ctx, message._id, args.expiresAt);
+      return {
+        scanned: 1,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    await scrubMessageContent(ctx, message);
+    return {
+      scanned: 1,
+      deleted: 0,
+      scrubbed: 1,
+    };
+  },
+});
+
+export const deleteTranscriptAtExpiry = internalMutation({
+  args: {
+    transcriptId: v.id("transcripts"),
+    expiresAt: v.string(),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const transcript = await ctx.db.get(args.transcriptId);
+    if (!transcript || transcript.expiresAt !== args.expiresAt) {
+      return {
+        scanned: transcript ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+    if (!isRetentionDue(args.expiresAt)) {
+      await scheduleTranscriptExpiration(ctx, transcript._id, args.expiresAt);
+      return {
+        scanned: 1,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    await ctx.db.delete(transcript._id);
+    return {
+      scanned: 1,
+      deleted: 1,
+      scrubbed: 0,
+    };
+  },
+});
+
+export const scrubCallRecordingAtExpiry = internalMutation({
+  args: {
+    callId: v.id("calls"),
+    expiresAt: v.string(),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const call = await ctx.db.get(args.callId);
+    if (
+      !call ||
+      call.recordingRetentionStatus !== "active" ||
+      call.recordingExpiresAt !== args.expiresAt
+    ) {
+      return {
+        scanned: call ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+    if (!isRetentionDue(args.expiresAt)) {
+      await scheduleCallRecordingExpiration(ctx, call._id, args.expiresAt);
+      return {
+        scanned: 1,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    await scrubCallRecordingContent(ctx, call);
+    return {
+      scanned: 1,
+      deleted: 0,
+      scrubbed: 1,
+    };
+  },
+});
+
+export const deletePreviewSessionAtExpiry = internalMutation({
+  args: {
+    previewSessionId: v.id("preview_sessions"),
+    expiresAt: v.string(),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const session = await ctx.db.get(args.previewSessionId);
+    if (!session || session.expiresAt !== args.expiresAt) {
+      return {
+        scanned: session ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+    if (!isRetentionDue(args.expiresAt)) {
+      await schedulePreviewSessionExpiration(ctx, session._id, args.expiresAt);
+      return {
+        scanned: 1,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    await deletePreviewAgentThread(ctx, session.threadId);
+    await deletePreviewStream(ctx, session.streamId);
+    await ctx.db.delete(session._id);
+    return {
+      scanned: 1,
+      deleted: 1,
+      scrubbed: 0,
+    };
+  },
+});
 
 export const scrubExpiredMessages = internalMutation({
   args: {

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -220,6 +220,7 @@ async function scrubMessageContent(
   await deleteSentAttachmentUploads(ctx, message._id, storageIds);
   await deleteMessageAttachmentTokens(ctx, message._id);
   await deleteStorageIds(ctx, storageIds);
+  await scrubPausedSmsNotificationMirrors(ctx, message);
   await scrubVoiceMessageMirrors(ctx, message);
   await deleteConversationAgentThread(ctx, message.conversationId);
 
@@ -288,6 +289,49 @@ async function deletePreviewStream(
   return 1;
 }
 
+async function scrubOperatorNotificationDeliveries(
+  ctx: MutationCtx,
+  input: {
+    businessId: Id<"businesses">;
+    eventKind: Doc<"operator_notification_deliveries">["eventKind"];
+    eventKey: string;
+    subject: string;
+  },
+): Promise<void> {
+  const deliveries = await ctx.db
+    .query("operator_notification_deliveries")
+    .withIndex("by_business_id_and_event_kind_and_event_key", (q) =>
+      q
+        .eq("businessId", input.businessId)
+        .eq("eventKind", input.eventKind)
+        .eq("eventKey", input.eventKey),
+    )
+    .take(MAX_RETENTION_CLEANUP_LIMIT);
+
+  for (const delivery of deliveries) {
+    await ctx.db.patch(delivery._id, {
+      subject: input.subject,
+      body: REDACTED_MESSAGE_BODY,
+    });
+  }
+}
+
+async function scrubPausedSmsNotificationMirrors(
+  ctx: MutationCtx,
+  message: Doc<"messages">,
+): Promise<void> {
+  if (message.channel !== "sms") {
+    return;
+  }
+
+  await scrubOperatorNotificationDeliveries(ctx, {
+    businessId: message.businessId,
+    eventKind: "pausedSms",
+    eventKey: `pausedSms:${String(message._id)}`,
+    subject: "Expired paused SMS message",
+  });
+}
+
 async function scrubVoiceMessageMirrors(
   ctx: MutationCtx,
   message: Doc<"messages">,
@@ -327,27 +371,6 @@ async function scrubVoiceMessageMirrors(
     return;
   }
 
-  async function scrubOperatorNotificationDeliveries(
-    inboxItemId: Id<"inbox_items">,
-  ): Promise<void> {
-    const deliveries = await ctx.db
-      .query("operator_notification_deliveries")
-      .withIndex("by_business_id_and_event_kind_and_event_key", (q) =>
-        q
-          .eq("businessId", message.businessId)
-          .eq("eventKind", "voiceMessage")
-          .eq("eventKey", `voiceMessage:${String(inboxItemId)}`),
-      )
-      .take(MAX_RETENTION_CLEANUP_LIMIT);
-
-    for (const delivery of deliveries) {
-      await ctx.db.patch(delivery._id, {
-        subject: "Expired voice message",
-        body: REDACTED_MESSAGE_BODY,
-      });
-    }
-  }
-
   const inboxItems = await ctx.db
     .query("inbox_items")
     .withIndex("by_kind_and_related_id", (q) =>
@@ -355,7 +378,12 @@ async function scrubVoiceMessageMirrors(
     )
     .take(MAX_RETENTION_CLEANUP_LIMIT);
   for (const item of inboxItems) {
-    await scrubOperatorNotificationDeliveries(item._id);
+    await scrubOperatorNotificationDeliveries(ctx, {
+      businessId: message.businessId,
+      eventKind: "voiceMessage",
+      eventKey: `voiceMessage:${String(item._id)}`,
+      subject: "Expired voice message",
+    });
     await ctx.db.patch(item._id, {
       title: "Expired voice message",
       body: REDACTED_MESSAGE_BODY,

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -64,14 +64,36 @@ export function getMessageContentExpiresAt(nowMs: number = Date.now()): string {
 
 export function isMessageContentExpired(
   message: Doc<"messages">,
+  nowMs: number = Date.now(),
 ): boolean {
-  return message.contentRetentionStatus === "expired";
+  return (
+    message.contentRetentionStatus === "expired" ||
+    isExpiredByTimestamp(message.contentExpiresAt, nowMs)
+  );
 }
 
 export function isCallRecordingExpired(
   call: Doc<"calls">,
+  nowMs: number = Date.now(),
 ): boolean {
-  return call.recordingRetentionStatus === "expired";
+  return (
+    call.recordingRetentionStatus === "expired" ||
+    isExpiredByTimestamp(call.recordingExpiresAt, nowMs)
+  );
+}
+
+export function isTranscriptExpired(
+  transcript: Doc<"transcripts">,
+  nowMs: number = Date.now(),
+): boolean {
+  return isExpiredByTimestamp(transcript.expiresAt, nowMs);
+}
+
+export function isPreviewSessionExpired(
+  session: Doc<"preview_sessions">,
+  nowMs: number = Date.now(),
+): boolean {
+  return isExpiredByTimestamp(session.expiresAt, nowMs);
 }
 
 export function getVisibleMessageBody(
@@ -92,6 +114,17 @@ function parseScheduleTime(expiresAt: string): number | null {
 function isRetentionDue(expiresAt: string): boolean {
   const parsed = Date.parse(expiresAt);
   return Number.isFinite(parsed) && parsed <= Date.now();
+}
+
+function isExpiredByTimestamp(
+  expiresAt: string | undefined,
+  nowMs: number,
+): boolean {
+  if (typeof expiresAt !== "string" || expiresAt.length === 0) {
+    return false;
+  }
+  const parsed = Date.parse(expiresAt);
+  return Number.isFinite(parsed) && parsed <= nowMs;
 }
 
 export async function scheduleMessageContentExpiration(

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -16,12 +16,15 @@ import {
 export const RAW_SENSITIVE_CONTENT_RETENTION_DAYS = 90;
 export const CALL_RECORDING_RETENTION_DAYS = RAW_SENSITIVE_CONTENT_RETENTION_DAYS;
 export const MESSAGE_CONTENT_RETENTION_DAYS = 365;
+export const UNSENT_ATTACHMENT_UPLOAD_RETENTION_DAYS = 1;
 export const SENSITIVE_CONTENT_RETENTION_DAYS = RAW_SENSITIVE_CONTENT_RETENTION_DAYS;
 export const RAW_SENSITIVE_CONTENT_RETENTION_MS =
   RAW_SENSITIVE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 export const CALL_RECORDING_RETENTION_MS = RAW_SENSITIVE_CONTENT_RETENTION_MS;
 export const MESSAGE_CONTENT_RETENTION_MS =
   MESSAGE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+export const UNSENT_ATTACHMENT_UPLOAD_RETENTION_MS =
+  UNSENT_ATTACHMENT_UPLOAD_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 export const SENSITIVE_CONTENT_RETENTION_MS = RAW_SENSITIVE_CONTENT_RETENTION_MS;
 export const REDACTED_MESSAGE_BODY = "[Expired by 365-day retention policy]";
 
@@ -48,6 +51,7 @@ type RetentionCleanupSummary = {
   previewSessions: CleanupCount;
   messageAttachmentDownloadTokens: CleanupCount;
   callRecordingDownloadTokens: CleanupCount;
+  abandonedMessageAttachmentUploads: CleanupCount;
 };
 
 export function getSensitiveContentExpiresAt(nowMs: number = Date.now()): string {
@@ -60,6 +64,12 @@ export function getCallRecordingExpiresAt(nowMs: number = Date.now()): string {
 
 export function getMessageContentExpiresAt(nowMs: number = Date.now()): string {
   return new Date(nowMs + MESSAGE_CONTENT_RETENTION_MS).toISOString();
+}
+
+export function getUnsentAttachmentUploadExpiresAt(
+  nowMs: number = Date.now(),
+): string {
+  return new Date(nowMs + UNSENT_ATTACHMENT_UPLOAD_RETENTION_MS).toISOString();
 }
 
 export function isMessageContentExpired(
@@ -844,6 +854,53 @@ export const deleteExpiredCallRecordingDownloadTokens = internalMutation({
   },
 });
 
+export const deleteExpiredAbandonedMessageAttachmentUploads = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const uploads: Array<Doc<"message_attachment_uploads">> = [];
+    for (const status of ["staged", "sending"]) {
+      const remaining = limit - uploads.length;
+      if (remaining <= 0) {
+        break;
+      }
+      const batch = await ctx.db
+        .query("message_attachment_uploads")
+        .withIndex("by_status_and_expires_at", (q) =>
+          q.eq("status", status).gt("expiresAt", "").lte("expiresAt", args.nowIso),
+        )
+        .take(remaining);
+      uploads.push(...batch);
+    }
+
+    let deleted = 0;
+    for (const upload of uploads) {
+      if (
+        upload.sentMessageId !== undefined ||
+        !isExpired(upload.expiresAt, args.nowIso)
+      ) {
+        continue;
+      }
+
+      const storageIds = new Set<Id<"_storage">>();
+      addStorageId(storageIds, upload.storageId);
+      addStorageId(storageIds, upload.previewStorageId);
+      await deleteStorageIds(ctx, storageIds);
+      await ctx.db.delete(upload._id);
+      deleted += 1;
+    }
+
+    return {
+      scanned: uploads.length,
+      deleted,
+      scrubbed: 0,
+    };
+  },
+});
+
 export const runMvpRetentionCleanup = internalAction({
   args: {
     nowIso: v.optional(v.string()),
@@ -898,6 +955,14 @@ export const runMvpRetentionCleanup = internalAction({
         await ctx.runMutation(
           internal.privacy.retention.deleteExpiredCallRecordingDownloadTokens,
           { nowIso, limit },
+      ),
+      limit,
+    );
+    const abandonedMessageAttachmentUploads = await drainCleanup(
+      async () =>
+        await ctx.runMutation(
+          internal.privacy.retention.deleteExpiredAbandonedMessageAttachmentUploads,
+          { nowIso, limit },
         ),
       limit,
     );
@@ -910,6 +975,7 @@ export const runMvpRetentionCleanup = internalAction({
       previewSessions,
       messageAttachmentDownloadTokens,
       callRecordingDownloadTokens,
+      abandonedMessageAttachmentUploads,
     };
   },
 });

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -67,6 +67,16 @@ function isMissingOrInvalidComponentReferenceError(error: unknown): boolean {
   );
 }
 
+function isMissingOrInvalidStorageError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("not found") ||
+    message.includes("non-existent doc") ||
+    message.includes("Invalid storage ID") ||
+    message.includes("does not exist")
+  );
+}
+
 function addStorageId(
   storageIds: Set<Id<"_storage">>,
   storageId: Id<"_storage"> | undefined,
@@ -82,8 +92,14 @@ async function deleteStorageIds(
 ): Promise<number> {
   let deleted = 0;
   for (const storageId of storageIds) {
-    await ctx.storage.delete(storageId);
-    deleted += 1;
+    try {
+      await ctx.storage.delete(storageId);
+      deleted += 1;
+    } catch (error) {
+      if (!isMissingOrInvalidStorageError(error)) {
+        throw error;
+      }
+    }
   }
   return deleted;
 }
@@ -229,6 +245,27 @@ async function scrubVoiceMessageMirrors(
     return;
   }
 
+  async function scrubOperatorNotificationDeliveries(
+    inboxItemId: Id<"inbox_items">,
+  ): Promise<void> {
+    const deliveries = await ctx.db
+      .query("operator_notification_deliveries")
+      .withIndex("by_business_id_and_event_kind_and_event_key", (q) =>
+        q
+          .eq("businessId", message.businessId)
+          .eq("eventKind", "voiceMessage")
+          .eq("eventKey", `voiceMessage:${String(inboxItemId)}`),
+      )
+      .take(MAX_RETENTION_CLEANUP_LIMIT);
+
+    for (const delivery of deliveries) {
+      await ctx.db.patch(delivery._id, {
+        subject: "Expired voice message",
+        body: REDACTED_MESSAGE_BODY,
+      });
+    }
+  }
+
   const inboxItems = await ctx.db
     .query("inbox_items")
     .withIndex("by_kind_and_related_id", (q) =>
@@ -236,6 +273,7 @@ async function scrubVoiceMessageMirrors(
     )
     .take(MAX_RETENTION_CLEANUP_LIMIT);
   for (const item of inboxItems) {
+    await scrubOperatorNotificationDeliveries(item._id);
     await ctx.db.patch(item._id, {
       title: "Expired voice message",
       body: REDACTED_MESSAGE_BODY,

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -878,10 +878,14 @@ export const deleteExpiredAbandonedMessageAttachmentUploads = internalMutation({
 
     let deleted = 0;
     for (const upload of uploads) {
-      if (
-        upload.sentMessageId !== undefined ||
-        !isExpired(upload.expiresAt, args.nowIso)
-      ) {
+      if (!isExpired(upload.expiresAt, args.nowIso)) {
+        continue;
+      }
+
+      if (upload.sentMessageId !== undefined) {
+        await ctx.db.patch(upload._id, {
+          status: "consumed",
+        });
         continue;
       }
 

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -1,8 +1,13 @@
 import { v } from "convex/values";
+import type { StreamId } from "@convex-dev/persistent-text-streaming";
 
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
+import {
+  persistentTextStreaming,
+  receptionistAgent,
+} from "../lib/components";
 import {
   observedInternalAction as internalAction,
   observedInternalMutation as internalMutation,
@@ -50,6 +55,16 @@ function normalizeLimit(limit: number): number {
 
 function isExpired(expiresAt: string | undefined, nowIso: string): expiresAt is string {
   return typeof expiresAt === "string" && expiresAt.length > 0 && expiresAt <= nowIso;
+}
+
+function isMissingOrInvalidComponentReferenceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("not found") ||
+    message.includes("is not registered") ||
+    message.includes("Invalid") ||
+    message.includes("Value does not match validator")
+  );
 }
 
 function addStorageId(
@@ -118,6 +133,138 @@ function collectMessageStorageIds(
   }
 }
 
+async function deleteConversationAgentThread(
+  ctx: MutationCtx,
+  conversationId: Id<"conversations">,
+): Promise<number> {
+  const aiState = await ctx.db
+    .query("conversation_ai_state")
+    .withIndex("by_conversation_id", (q) => q.eq("conversationId", conversationId))
+    .unique();
+  if (!aiState) {
+    return 0;
+  }
+
+  try {
+    await receptionistAgent.deleteThreadAsync(ctx, {
+      threadId: aiState.threadId,
+    });
+  } catch (error) {
+    if (!isMissingOrInvalidComponentReferenceError(error)) {
+      throw error;
+    }
+  }
+  await ctx.db.delete(aiState._id);
+  return 1;
+}
+
+async function deletePreviewAgentThread(
+  ctx: MutationCtx,
+  threadId: string | undefined,
+): Promise<number> {
+  if (!threadId) {
+    return 0;
+  }
+
+  try {
+    await receptionistAgent.deleteThreadAsync(ctx, { threadId });
+  } catch (error) {
+    if (!isMissingOrInvalidComponentReferenceError(error)) {
+      throw error;
+    }
+  }
+  return 1;
+}
+
+async function deletePreviewStream(
+  ctx: MutationCtx,
+  streamId: string,
+): Promise<number> {
+  try {
+    await persistentTextStreaming.deleteStream(ctx, streamId as StreamId);
+  } catch (error) {
+    if (!isMissingOrInvalidComponentReferenceError(error)) {
+      throw error;
+    }
+  }
+  return 1;
+}
+
+async function scrubVoiceMessageMirrors(
+  ctx: MutationCtx,
+  message: Doc<"messages">,
+): Promise<void> {
+  if (message.channel !== "voice") {
+    return;
+  }
+
+  const conversation = await ctx.db.get(message.conversationId);
+  if (
+    conversation &&
+    (conversation.currentIntent === "message_taking" ||
+      conversation.summary?.includes(message.body))
+  ) {
+    await ctx.db.patch(conversation._id, {
+      summary: REDACTED_MESSAGE_BODY,
+    });
+  }
+
+  const session = message.conversationSessionId
+    ? await ctx.db.get(message.conversationSessionId)
+    : null;
+  if (!session || session.channel !== "voice") {
+    return;
+  }
+
+  if (session.summary) {
+    await ctx.db.patch(session._id, {
+      summary: {
+        ...session.summary,
+        summary: REDACTED_MESSAGE_BODY,
+      },
+    });
+  }
+
+  if (!session.callId) {
+    return;
+  }
+
+  const inboxItems = await ctx.db
+    .query("inbox_items")
+    .withIndex("by_kind_and_related_id", (q) =>
+      q.eq("kind", "voice_message").eq("relatedId", String(session.callId)),
+    )
+    .take(MAX_RETENTION_CLEANUP_LIMIT);
+  for (const item of inboxItems) {
+    await ctx.db.patch(item._id, {
+      title: "Expired voice message",
+      body: REDACTED_MESSAGE_BODY,
+    });
+  }
+}
+
+async function drainCleanup(
+  runBatch: () => Promise<CleanupCount>,
+  limit: number,
+): Promise<CleanupCount> {
+  const total: CleanupCount = {
+    scanned: 0,
+    deleted: 0,
+    scrubbed: 0,
+  };
+
+  while (true) {
+    const batch = await runBatch();
+    total.scanned += batch.scanned;
+    total.deleted += batch.deleted;
+    total.scrubbed += batch.scrubbed;
+
+    if (batch.scanned < limit) {
+      return total;
+    }
+  }
+}
+
 async function deleteCallRecordingTokens(
   ctx: MutationCtx,
   callId: Id<"calls">,
@@ -162,6 +309,8 @@ export const scrubExpiredMessages = internalMutation({
       await deleteSentAttachmentUploads(ctx, message._id, storageIds);
       await deleteMessageAttachmentTokens(ctx, message._id);
       await deleteStorageIds(ctx, storageIds);
+      await scrubVoiceMessageMirrors(ctx, message);
+      await deleteConversationAgentThread(ctx, message.conversationId);
 
       await ctx.db.patch(message._id, {
         body: REDACTED_MESSAGE_BODY,
@@ -272,6 +421,8 @@ export const deleteExpiredPreviewSessions = internalMutation({
       if (!isExpired(session.expiresAt, args.nowIso)) {
         continue;
       }
+      await deletePreviewAgentThread(ctx, session.threadId);
+      await deletePreviewStream(ctx, session.streamId);
       await ctx.db.delete(session._id);
       deleted += 1;
     }
@@ -341,29 +492,53 @@ export const runMvpRetentionCleanup = internalAction({
     const nowIso = args.nowIso ?? new Date().toISOString();
     const limit = normalizeLimit(args.limit ?? DEFAULT_RETENTION_CLEANUP_LIMIT);
 
-    const messages: CleanupCount = await ctx.runMutation(
-      internal.privacy.retention.scrubExpiredMessages,
-      { nowIso, limit },
+    const messages = await drainCleanup(
+      async () =>
+        await ctx.runMutation(internal.privacy.retention.scrubExpiredMessages, {
+          nowIso,
+          limit,
+        }),
+      limit,
     );
-    const transcripts: CleanupCount = await ctx.runMutation(
-      internal.privacy.retention.deleteExpiredTranscripts,
-      { nowIso, limit },
+    const transcripts = await drainCleanup(
+      async () =>
+        await ctx.runMutation(internal.privacy.retention.deleteExpiredTranscripts, {
+          nowIso,
+          limit,
+        }),
+      limit,
     );
-    const callRecordings: CleanupCount = await ctx.runMutation(
-      internal.privacy.retention.scrubExpiredCallRecordings,
-      { nowIso, limit },
+    const callRecordings = await drainCleanup(
+      async () =>
+        await ctx.runMutation(internal.privacy.retention.scrubExpiredCallRecordings, {
+          nowIso,
+          limit,
+        }),
+      limit,
     );
-    const previewSessions: CleanupCount = await ctx.runMutation(
-      internal.privacy.retention.deleteExpiredPreviewSessions,
-      { nowIso, limit },
+    const previewSessions = await drainCleanup(
+      async () =>
+        await ctx.runMutation(internal.privacy.retention.deleteExpiredPreviewSessions, {
+          nowIso,
+          limit,
+        }),
+      limit,
     );
-    const messageAttachmentDownloadTokens: CleanupCount = await ctx.runMutation(
-      internal.privacy.retention.deleteExpiredMessageAttachmentDownloadTokens,
-      { nowIso, limit },
+    const messageAttachmentDownloadTokens = await drainCleanup(
+      async () =>
+        await ctx.runMutation(
+          internal.privacy.retention.deleteExpiredMessageAttachmentDownloadTokens,
+          { nowIso, limit },
+        ),
+      limit,
     );
-    const callRecordingDownloadTokens: CleanupCount = await ctx.runMutation(
-      internal.privacy.retention.deleteExpiredCallRecordingDownloadTokens,
-      { nowIso, limit },
+    const callRecordingDownloadTokens = await drainCleanup(
+      async () =>
+        await ctx.runMutation(
+          internal.privacy.retention.deleteExpiredCallRecordingDownloadTokens,
+          { nowIso, limit },
+        ),
+      limit,
     );
 
     return {

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -13,10 +13,17 @@ import {
   observedInternalMutation as internalMutation,
 } from "../telemetry/observedFunctions";
 
-export const SENSITIVE_CONTENT_RETENTION_DAYS = 90;
-export const SENSITIVE_CONTENT_RETENTION_MS =
-  SENSITIVE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
-export const REDACTED_MESSAGE_BODY = "[Expired by 90-day retention policy]";
+export const RAW_SENSITIVE_CONTENT_RETENTION_DAYS = 90;
+export const CALL_RECORDING_RETENTION_DAYS = RAW_SENSITIVE_CONTENT_RETENTION_DAYS;
+export const MESSAGE_CONTENT_RETENTION_DAYS = 365;
+export const SENSITIVE_CONTENT_RETENTION_DAYS = RAW_SENSITIVE_CONTENT_RETENTION_DAYS;
+export const RAW_SENSITIVE_CONTENT_RETENTION_MS =
+  RAW_SENSITIVE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+export const CALL_RECORDING_RETENTION_MS = RAW_SENSITIVE_CONTENT_RETENTION_MS;
+export const MESSAGE_CONTENT_RETENTION_MS =
+  MESSAGE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+export const SENSITIVE_CONTENT_RETENTION_MS = RAW_SENSITIVE_CONTENT_RETENTION_MS;
+export const REDACTED_MESSAGE_BODY = "[Expired by 365-day retention policy]";
 
 const DEFAULT_RETENTION_CLEANUP_LIMIT = 100;
 const MAX_RETENTION_CLEANUP_LIMIT = 200;
@@ -44,6 +51,14 @@ type RetentionCleanupSummary = {
 
 export function getSensitiveContentExpiresAt(nowMs: number = Date.now()): string {
   return new Date(nowMs + SENSITIVE_CONTENT_RETENTION_MS).toISOString();
+}
+
+export function getCallRecordingExpiresAt(nowMs: number = Date.now()): string {
+  return new Date(nowMs + CALL_RECORDING_RETENTION_MS).toISOString();
+}
+
+export function getMessageContentExpiresAt(nowMs: number = Date.now()): string {
+  return new Date(nowMs + MESSAGE_CONTENT_RETENTION_MS).toISOString();
 }
 
 function normalizeLimit(limit: number): number {

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -1,0 +1,379 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import {
+  observedInternalAction as internalAction,
+  observedInternalMutation as internalMutation,
+} from "../telemetry/observedFunctions";
+
+export const SENSITIVE_CONTENT_RETENTION_DAYS = 90;
+export const SENSITIVE_CONTENT_RETENTION_MS =
+  SENSITIVE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+export const REDACTED_MESSAGE_BODY = "[Expired by 90-day retention policy]";
+
+const DEFAULT_RETENTION_CLEANUP_LIMIT = 100;
+const MAX_RETENTION_CLEANUP_LIMIT = 200;
+
+type CleanupArgs = {
+  nowIso: string;
+  limit: number;
+};
+
+type CleanupCount = {
+  scanned: number;
+  deleted: number;
+  scrubbed: number;
+};
+
+type RetentionCleanupSummary = {
+  nowIso: string;
+  messages: CleanupCount;
+  transcripts: CleanupCount;
+  callRecordings: CleanupCount;
+  previewSessions: CleanupCount;
+  messageAttachmentDownloadTokens: CleanupCount;
+  callRecordingDownloadTokens: CleanupCount;
+};
+
+export function getSensitiveContentExpiresAt(nowMs: number = Date.now()): string {
+  return new Date(nowMs + SENSITIVE_CONTENT_RETENTION_MS).toISOString();
+}
+
+function normalizeLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_RETENTION_CLEANUP_LIMIT;
+  }
+  return Math.max(1, Math.min(Math.floor(limit), MAX_RETENTION_CLEANUP_LIMIT));
+}
+
+function isExpired(expiresAt: string | undefined, nowIso: string): expiresAt is string {
+  return typeof expiresAt === "string" && expiresAt.length > 0 && expiresAt <= nowIso;
+}
+
+function addStorageId(
+  storageIds: Set<Id<"_storage">>,
+  storageId: Id<"_storage"> | undefined,
+): void {
+  if (storageId !== undefined) {
+    storageIds.add(storageId);
+  }
+}
+
+async function deleteStorageIds(
+  ctx: MutationCtx,
+  storageIds: Set<Id<"_storage">>,
+): Promise<number> {
+  let deleted = 0;
+  for (const storageId of storageIds) {
+    await ctx.storage.delete(storageId);
+    deleted += 1;
+  }
+  return deleted;
+}
+
+async function deleteMessageAttachmentTokens(
+  ctx: MutationCtx,
+  messageId: Id<"messages">,
+): Promise<number> {
+  const tokens = await ctx.db
+    .query("message_attachment_download_tokens")
+    .withIndex("by_message_id", (q) => q.eq("messageId", messageId))
+    .take(MAX_RETENTION_CLEANUP_LIMIT);
+
+  for (const token of tokens) {
+    await ctx.db.delete(token._id);
+  }
+
+  return tokens.length;
+}
+
+async function deleteSentAttachmentUploads(
+  ctx: MutationCtx,
+  messageId: Id<"messages">,
+  storageIds: Set<Id<"_storage">>,
+): Promise<number> {
+  const uploads = await ctx.db
+    .query("message_attachment_uploads")
+    .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", messageId))
+    .take(MAX_RETENTION_CLEANUP_LIMIT);
+
+  for (const upload of uploads) {
+    addStorageId(storageIds, upload.storageId);
+    addStorageId(storageIds, upload.previewStorageId);
+    await ctx.db.delete(upload._id);
+  }
+
+  return uploads.length;
+}
+
+function collectMessageStorageIds(
+  message: Doc<"messages">,
+  storageIds: Set<Id<"_storage">>,
+): void {
+  for (const attachment of message.media ?? []) {
+    addStorageId(storageIds, attachment.storageId);
+    addStorageId(storageIds, attachment.previewStorageId);
+  }
+}
+
+async function deleteCallRecordingTokens(
+  ctx: MutationCtx,
+  callId: Id<"calls">,
+): Promise<number> {
+  const tokens = await ctx.db
+    .query("call_recording_download_tokens")
+    .withIndex("by_call_id", (q) => q.eq("callId", callId))
+    .take(MAX_RETENTION_CLEANUP_LIMIT);
+
+  for (const token of tokens) {
+    await ctx.db.delete(token._id);
+  }
+
+  return tokens.length;
+}
+
+export const scrubExpiredMessages = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
+        q
+          .eq("contentRetentionStatus", "active")
+          .gt("contentExpiresAt", "")
+          .lte("contentExpiresAt", args.nowIso),
+      )
+      .take(limit);
+
+    let scrubbed = 0;
+    for (const message of messages) {
+      if (!isExpired(message.contentExpiresAt, args.nowIso)) {
+        continue;
+      }
+
+      const storageIds = new Set<Id<"_storage">>();
+      collectMessageStorageIds(message, storageIds);
+      await deleteSentAttachmentUploads(ctx, message._id, storageIds);
+      await deleteMessageAttachmentTokens(ctx, message._id);
+      await deleteStorageIds(ctx, storageIds);
+
+      await ctx.db.patch(message._id, {
+        body: REDACTED_MESSAGE_BODY,
+        fromPhoneNumber: undefined,
+        media: undefined,
+        contentRetentionStatus: "expired",
+      });
+      scrubbed += 1;
+    }
+
+    return {
+      scanned: messages.length,
+      deleted: 0,
+      scrubbed,
+    };
+  },
+});
+
+export const deleteExpiredTranscripts = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const transcripts = await ctx.db
+      .query("transcripts")
+      .withIndex("by_expires_at", (q) => q.gt("expiresAt", "").lte("expiresAt", args.nowIso))
+      .take(limit);
+
+    let deleted = 0;
+    for (const transcript of transcripts) {
+      if (!isExpired(transcript.expiresAt, args.nowIso)) {
+        continue;
+      }
+      await ctx.db.delete(transcript._id);
+      deleted += 1;
+    }
+
+    return {
+      scanned: transcripts.length,
+      deleted,
+      scrubbed: 0,
+    };
+  },
+});
+
+export const scrubExpiredCallRecordings = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const calls = await ctx.db
+      .query("calls")
+      .withIndex("by_recording_retention_status_and_recording_expires_at", (q) =>
+        q
+          .eq("recordingRetentionStatus", "active")
+          .gt("recordingExpiresAt", "")
+          .lte("recordingExpiresAt", args.nowIso),
+      )
+      .take(limit);
+
+    let scrubbed = 0;
+    for (const call of calls) {
+      if (!isExpired(call.recordingExpiresAt, args.nowIso)) {
+        continue;
+      }
+
+      const storageIds = new Set<Id<"_storage">>();
+      addStorageId(storageIds, call.recordingStorageId);
+      await deleteCallRecordingTokens(ctx, call._id);
+      await deleteStorageIds(ctx, storageIds);
+
+      await ctx.db.patch(call._id, {
+        recordingStorageId: undefined,
+        recordingContentType: undefined,
+        recordingByteLength: undefined,
+        recordingDurationMs: undefined,
+        recordingRetentionStatus: "expired",
+      });
+      scrubbed += 1;
+    }
+
+    return {
+      scanned: calls.length,
+      deleted: 0,
+      scrubbed,
+    };
+  },
+});
+
+export const deleteExpiredPreviewSessions = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const sessions = await ctx.db
+      .query("preview_sessions")
+      .withIndex("by_expires_at", (q) => q.gt("expiresAt", "").lte("expiresAt", args.nowIso))
+      .take(limit);
+
+    let deleted = 0;
+    for (const session of sessions) {
+      if (!isExpired(session.expiresAt, args.nowIso)) {
+        continue;
+      }
+      await ctx.db.delete(session._id);
+      deleted += 1;
+    }
+
+    return {
+      scanned: sessions.length,
+      deleted,
+      scrubbed: 0,
+    };
+  },
+});
+
+export const deleteExpiredMessageAttachmentDownloadTokens = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const tokens = await ctx.db
+      .query("message_attachment_download_tokens")
+      .withIndex("by_expires_at", (q) => q.gt("expiresAt", "").lte("expiresAt", args.nowIso))
+      .take(limit);
+
+    for (const token of tokens) {
+      await ctx.db.delete(token._id);
+    }
+
+    return {
+      scanned: tokens.length,
+      deleted: tokens.length,
+      scrubbed: 0,
+    };
+  },
+});
+
+export const deleteExpiredCallRecordingDownloadTokens = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const tokens = await ctx.db
+      .query("call_recording_download_tokens")
+      .withIndex("by_expires_at", (q) => q.gt("expiresAt", "").lte("expiresAt", args.nowIso))
+      .take(limit);
+
+    for (const token of tokens) {
+      await ctx.db.delete(token._id);
+    }
+
+    return {
+      scanned: tokens.length,
+      deleted: tokens.length,
+      scrubbed: 0,
+    };
+  },
+});
+
+export const runMvpRetentionCleanup = internalAction({
+  args: {
+    nowIso: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<RetentionCleanupSummary> => {
+    const nowIso = args.nowIso ?? new Date().toISOString();
+    const limit = normalizeLimit(args.limit ?? DEFAULT_RETENTION_CLEANUP_LIMIT);
+
+    const messages: CleanupCount = await ctx.runMutation(
+      internal.privacy.retention.scrubExpiredMessages,
+      { nowIso, limit },
+    );
+    const transcripts: CleanupCount = await ctx.runMutation(
+      internal.privacy.retention.deleteExpiredTranscripts,
+      { nowIso, limit },
+    );
+    const callRecordings: CleanupCount = await ctx.runMutation(
+      internal.privacy.retention.scrubExpiredCallRecordings,
+      { nowIso, limit },
+    );
+    const previewSessions: CleanupCount = await ctx.runMutation(
+      internal.privacy.retention.deleteExpiredPreviewSessions,
+      { nowIso, limit },
+    );
+    const messageAttachmentDownloadTokens: CleanupCount = await ctx.runMutation(
+      internal.privacy.retention.deleteExpiredMessageAttachmentDownloadTokens,
+      { nowIso, limit },
+    );
+    const callRecordingDownloadTokens: CleanupCount = await ctx.runMutation(
+      internal.privacy.retention.deleteExpiredCallRecordingDownloadTokens,
+      { nowIso, limit },
+    );
+
+    return {
+      nowIso,
+      messages,
+      transcripts,
+      callRecordings,
+      previewSessions,
+      messageAttachmentDownloadTokens,
+      callRecordingDownloadTokens,
+    };
+  },
+});

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -49,6 +49,8 @@ type RetentionCleanupSummary = {
   transcripts: CleanupCount;
   callRecordings: CleanupCount;
   previewSessions: CleanupCount;
+  inboxItems: CleanupCount;
+  operatorNotificationDeliveries: CleanupCount;
   messageAttachmentDownloadTokens: CleanupCount;
   callRecordingDownloadTokens: CleanupCount;
   abandonedMessageAttachmentUploads: CleanupCount;
@@ -104,6 +106,27 @@ export function isPreviewSessionExpired(
   nowMs: number = Date.now(),
 ): boolean {
   return isExpiredByTimestamp(session.expiresAt, nowMs);
+}
+
+export function isInboxItemContentExpired(
+  item: Doc<"inbox_items">,
+  nowMs: number = Date.now(),
+): boolean {
+  return (
+    item.contentRetentionStatus === "expired" ||
+    isExpiredByTimestamp(item.contentExpiresAt, nowMs)
+  );
+}
+
+export function getVisibleInboxItemTitle(item: Doc<"inbox_items">): string {
+  if (!isInboxItemContentExpired(item)) {
+    return item.title;
+  }
+  return item.kind === "voice_message" ? "Expired voice message" : "Expired item";
+}
+
+export function getVisibleInboxItemBody(item: Doc<"inbox_items">): string {
+  return isInboxItemContentExpired(item) ? REDACTED_MESSAGE_BODY : item.body;
 }
 
 export function getVisibleMessageBody(
@@ -201,6 +224,38 @@ export async function schedulePreviewSessionExpiration(
   );
 }
 
+export async function scheduleInboxItemContentExpiration(
+  ctx: MutationCtx,
+  inboxItemId: Id<"inbox_items">,
+  expiresAt: string,
+): Promise<void> {
+  const scheduledAt = parseScheduleTime(expiresAt);
+  if (scheduledAt === null) {
+    return;
+  }
+  await ctx.scheduler.runAt(
+    scheduledAt,
+    internal.privacy.retention.scrubInboxItemContentAtExpiry,
+    { inboxItemId, expiresAt },
+  );
+}
+
+export async function scheduleOperatorNotificationDeliveryContentExpiration(
+  ctx: MutationCtx,
+  deliveryId: Id<"operator_notification_deliveries">,
+  expiresAt: string,
+): Promise<void> {
+  const scheduledAt = parseScheduleTime(expiresAt);
+  if (scheduledAt === null) {
+    return;
+  }
+  await ctx.scheduler.runAt(
+    scheduledAt,
+    internal.privacy.retention.scrubOperatorNotificationDeliveryContentAtExpiry,
+    { deliveryId, expiresAt },
+  );
+}
+
 function normalizeLimit(limit: number): number {
   if (!Number.isFinite(limit)) {
     return DEFAULT_RETENTION_CLEANUP_LIMIT;
@@ -280,18 +335,25 @@ async function deleteSentAttachmentUploads(
   messageId: Id<"messages">,
   storageIds: Set<Id<"_storage">>,
 ): Promise<number> {
-  const uploads = await ctx.db
-    .query("message_attachment_uploads")
-    .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", messageId))
-    .take(MAX_RETENTION_CLEANUP_LIMIT);
+  let deleted = 0;
 
-  for (const upload of uploads) {
-    addStorageId(storageIds, upload.storageId);
-    addStorageId(storageIds, upload.previewStorageId);
-    await ctx.db.delete(upload._id);
+  while (true) {
+    const uploads = await ctx.db
+      .query("message_attachment_uploads")
+      .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", messageId))
+      .take(MAX_RETENTION_CLEANUP_LIMIT);
+
+    if (uploads.length === 0) {
+      return deleted;
+    }
+
+    for (const upload of uploads) {
+      addStorageId(storageIds, upload.storageId);
+      addStorageId(storageIds, upload.previewStorageId);
+      await ctx.db.delete(upload._id);
+      deleted += 1;
+    }
   }
-
-  return uploads.length;
 }
 
 function collectMessageStorageIds(
@@ -314,6 +376,7 @@ async function scrubMessageContent(
   await deleteMessageAttachmentTokens(ctx, message._id);
   await deleteStorageIds(ctx, storageIds);
   await scrubPausedSmsNotificationMirrors(ctx, message);
+  await scrubConversationSummaryMirrors(ctx, message);
   await scrubVoiceMessageMirrors(ctx, message);
   await deleteConversationAgentThread(ctx, message.conversationId);
 
@@ -348,6 +411,41 @@ async function deleteConversationAgentThread(
   }
   await ctx.db.delete(aiState._id);
   return 1;
+}
+
+function getExpiredDeliverySubject(
+  eventKind: Doc<"operator_notification_deliveries">["eventKind"],
+): string {
+  if (eventKind === "voiceMessage") {
+    return "Expired voice message";
+  }
+  if (eventKind === "pausedSms") {
+    return "Expired paused SMS message";
+  }
+  return "Expired notification content";
+}
+
+async function scrubOperatorNotificationDeliveryContent(
+  ctx: MutationCtx,
+  delivery: Doc<"operator_notification_deliveries">,
+  subject: string = getExpiredDeliverySubject(delivery.eventKind),
+): Promise<void> {
+  await ctx.db.patch(delivery._id, {
+    subject,
+    body: REDACTED_MESSAGE_BODY,
+    contentRetentionStatus: "expired",
+  });
+}
+
+async function scrubInboxItemContent(
+  ctx: MutationCtx,
+  item: Doc<"inbox_items">,
+): Promise<void> {
+  await ctx.db.patch(item._id, {
+    title: item.kind === "voice_message" ? "Expired voice message" : "Expired item",
+    body: REDACTED_MESSAGE_BODY,
+    contentRetentionStatus: "expired",
+  });
 }
 
 async function deletePreviewAgentThread(
@@ -402,9 +500,33 @@ async function scrubOperatorNotificationDeliveries(
     .take(MAX_RETENTION_CLEANUP_LIMIT);
 
   for (const delivery of deliveries) {
-    await ctx.db.patch(delivery._id, {
-      subject: input.subject,
-      body: REDACTED_MESSAGE_BODY,
+    await scrubOperatorNotificationDeliveryContent(ctx, delivery, input.subject);
+  }
+}
+
+async function scrubConversationSummaryMirrors(
+  ctx: MutationCtx,
+  message: Doc<"messages">,
+): Promise<void> {
+  const conversation = await ctx.db.get(message.conversationId);
+  if (conversation?.summary) {
+    await ctx.db.patch(conversation._id, {
+      summary: REDACTED_MESSAGE_BODY,
+    });
+  }
+
+  if (!message.conversationSessionId) {
+    return;
+  }
+
+  const session = await ctx.db.get(message.conversationSessionId);
+  const summary = session?.summary;
+  if (summary && "summary" in summary && summary.summary !== undefined) {
+    await ctx.db.patch(session._id, {
+      summary: {
+        ...summary,
+        summary: REDACTED_MESSAGE_BODY,
+      },
     });
   }
 }
@@ -433,31 +555,11 @@ async function scrubVoiceMessageMirrors(
     return;
   }
 
-  const conversation = await ctx.db.get(message.conversationId);
-  if (
-    conversation &&
-    (conversation.currentIntent === "message_taking" ||
-      conversation.summary?.includes(message.body))
-  ) {
-    await ctx.db.patch(conversation._id, {
-      summary: REDACTED_MESSAGE_BODY,
-    });
-  }
-
   const session = message.conversationSessionId
     ? await ctx.db.get(message.conversationSessionId)
     : null;
   if (!session || session.channel !== "voice") {
     return;
-  }
-
-  if (session.summary) {
-    await ctx.db.patch(session._id, {
-      summary: {
-        ...session.summary,
-        summary: REDACTED_MESSAGE_BODY,
-      },
-    });
   }
 
   if (!session.callId) {
@@ -477,10 +579,7 @@ async function scrubVoiceMessageMirrors(
       eventKey: `voiceMessage:${String(item._id)}`,
       subject: "Expired voice message",
     });
-    await ctx.db.patch(item._id, {
-      title: "Expired voice message",
-      body: REDACTED_MESSAGE_BODY,
-    });
+    await scrubInboxItemContent(ctx, item);
   }
 }
 
@@ -678,6 +777,82 @@ export const deletePreviewSessionAtExpiry = internalMutation({
   },
 });
 
+export const scrubInboxItemContentAtExpiry = internalMutation({
+  args: {
+    inboxItemId: v.id("inbox_items"),
+    expiresAt: v.string(),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const item = await ctx.db.get(args.inboxItemId);
+    if (
+      !item ||
+      item.contentRetentionStatus !== "active" ||
+      item.contentExpiresAt !== args.expiresAt
+    ) {
+      return {
+        scanned: item ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+    if (!isRetentionDue(args.expiresAt)) {
+      await scheduleInboxItemContentExpiration(ctx, item._id, args.expiresAt);
+      return {
+        scanned: 1,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    await scrubInboxItemContent(ctx, item);
+    return {
+      scanned: 1,
+      deleted: 0,
+      scrubbed: 1,
+    };
+  },
+});
+
+export const scrubOperatorNotificationDeliveryContentAtExpiry = internalMutation({
+  args: {
+    deliveryId: v.id("operator_notification_deliveries"),
+    expiresAt: v.string(),
+  },
+  handler: async (ctx, args): Promise<CleanupCount> => {
+    const delivery = await ctx.db.get(args.deliveryId);
+    if (
+      !delivery ||
+      delivery.contentRetentionStatus !== "active" ||
+      delivery.contentExpiresAt !== args.expiresAt
+    ) {
+      return {
+        scanned: delivery ? 1 : 0,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+    if (!isRetentionDue(args.expiresAt)) {
+      await scheduleOperatorNotificationDeliveryContentExpiration(
+        ctx,
+        delivery._id,
+        args.expiresAt,
+      );
+      return {
+        scanned: 1,
+        deleted: 0,
+        scrubbed: 0,
+      };
+    }
+
+    await scrubOperatorNotificationDeliveryContent(ctx, delivery);
+    return {
+      scanned: 1,
+      deleted: 0,
+      scrubbed: 1,
+    };
+  },
+});
+
 export const scrubExpiredMessages = internalMutation({
   args: {
     nowIso: v.string(),
@@ -802,6 +977,74 @@ export const deleteExpiredPreviewSessions = internalMutation({
       scanned: sessions.length,
       deleted,
       scrubbed: 0,
+    };
+  },
+});
+
+export const scrubExpiredInboxItems = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const items = await ctx.db
+      .query("inbox_items")
+      .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
+        q
+          .eq("contentRetentionStatus", "active")
+          .gt("contentExpiresAt", "")
+          .lte("contentExpiresAt", args.nowIso),
+      )
+      .take(limit);
+
+    let scrubbed = 0;
+    for (const item of items) {
+      if (!isExpired(item.contentExpiresAt, args.nowIso)) {
+        continue;
+      }
+      await scrubInboxItemContent(ctx, item);
+      scrubbed += 1;
+    }
+
+    return {
+      scanned: items.length,
+      deleted: 0,
+      scrubbed,
+    };
+  },
+});
+
+export const scrubExpiredOperatorNotificationDeliveries = internalMutation({
+  args: {
+    nowIso: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args: CleanupArgs): Promise<CleanupCount> => {
+    const limit = normalizeLimit(args.limit);
+    const deliveries = await ctx.db
+      .query("operator_notification_deliveries")
+      .withIndex("by_content_retention_status_and_content_expires_at", (q) =>
+        q
+          .eq("contentRetentionStatus", "active")
+          .gt("contentExpiresAt", "")
+          .lte("contentExpiresAt", args.nowIso),
+      )
+      .take(limit);
+
+    let scrubbed = 0;
+    for (const delivery of deliveries) {
+      if (!isExpired(delivery.contentExpiresAt, args.nowIso)) {
+        continue;
+      }
+      await scrubOperatorNotificationDeliveryContent(ctx, delivery);
+      scrubbed += 1;
+    }
+
+    return {
+      scanned: deliveries.length,
+      deleted: 0,
+      scrubbed,
     };
   },
 });
@@ -946,6 +1189,22 @@ export const runMvpRetentionCleanup = internalAction({
         }),
       limit,
     );
+    const inboxItems = await drainCleanup(
+      async () =>
+        await ctx.runMutation(internal.privacy.retention.scrubExpiredInboxItems, {
+          nowIso,
+          limit,
+        }),
+      limit,
+    );
+    const operatorNotificationDeliveries = await drainCleanup(
+      async () =>
+        await ctx.runMutation(
+          internal.privacy.retention.scrubExpiredOperatorNotificationDeliveries,
+          { nowIso, limit },
+        ),
+      limit,
+    );
     const messageAttachmentDownloadTokens = await drainCleanup(
       async () =>
         await ctx.runMutation(
@@ -977,6 +1236,8 @@ export const runMvpRetentionCleanup = internalAction({
       transcripts,
       callRecordings,
       previewSessions,
+      inboxItems,
+      operatorNotificationDeliveries,
       messageAttachmentDownloadTokens,
       callRecordingDownloadTokens,
       abandonedMessageAttachmentUploads,

--- a/convex/privacy/retention.ts
+++ b/convex/privacy/retention.ts
@@ -61,6 +61,53 @@ export function getMessageContentExpiresAt(nowMs: number = Date.now()): string {
   return new Date(nowMs + MESSAGE_CONTENT_RETENTION_MS).toISOString();
 }
 
+export function isMessageContentExpired(
+  message: Doc<"messages">,
+  nowMs: number = Date.now(),
+): boolean {
+  if (message.contentRetentionStatus === "expired") {
+    return true;
+  }
+  return (
+    typeof message.contentExpiresAt === "string" &&
+    Date.parse(message.contentExpiresAt) <= nowMs
+  );
+}
+
+export function isCallRecordingExpired(
+  call: Doc<"calls">,
+  nowMs: number = Date.now(),
+): boolean {
+  if (call.recordingRetentionStatus === "expired") {
+    return true;
+  }
+  return (
+    typeof call.recordingExpiresAt === "string" &&
+    Date.parse(call.recordingExpiresAt) <= nowMs
+  );
+}
+
+export function isTranscriptExpired(
+  transcript: Doc<"transcripts">,
+  nowMs: number = Date.now(),
+): boolean {
+  return typeof transcript.expiresAt === "string" && Date.parse(transcript.expiresAt) <= nowMs;
+}
+
+export function isPreviewSessionExpired(
+  session: Doc<"preview_sessions">,
+  nowMs: number = Date.now(),
+): boolean {
+  return typeof session.expiresAt === "string" && Date.parse(session.expiresAt) <= nowMs;
+}
+
+export function getVisibleMessageBody(
+  message: Doc<"messages">,
+  nowMs: number = Date.now(),
+): string {
+  return isMessageContentExpired(message, nowMs) ? REDACTED_MESSAGE_BODY : message.body;
+}
+
 function normalizeLimit(limit: number): number {
   if (!Number.isFinite(limit)) {
     return DEFAULT_RETENTION_CLEANUP_LIMIT;
@@ -162,6 +209,26 @@ function collectMessageStorageIds(
     addStorageId(storageIds, attachment.storageId);
     addStorageId(storageIds, attachment.previewStorageId);
   }
+}
+
+async function scrubMessageContent(
+  ctx: MutationCtx,
+  message: Doc<"messages">,
+): Promise<void> {
+  const storageIds = new Set<Id<"_storage">>();
+  collectMessageStorageIds(message, storageIds);
+  await deleteSentAttachmentUploads(ctx, message._id, storageIds);
+  await deleteMessageAttachmentTokens(ctx, message._id);
+  await deleteStorageIds(ctx, storageIds);
+  await scrubVoiceMessageMirrors(ctx, message);
+  await deleteConversationAgentThread(ctx, message.conversationId);
+
+  await ctx.db.patch(message._id, {
+    body: REDACTED_MESSAGE_BODY,
+    fromPhoneNumber: undefined,
+    media: undefined,
+    contentRetentionStatus: "expired",
+  });
 }
 
 async function deleteConversationAgentThread(
@@ -334,6 +401,24 @@ async function deleteCallRecordingTokens(
   return tokens.length;
 }
 
+async function scrubCallRecordingContent(
+  ctx: MutationCtx,
+  call: Doc<"calls">,
+): Promise<void> {
+  const storageIds = new Set<Id<"_storage">>();
+  addStorageId(storageIds, call.recordingStorageId);
+  await deleteCallRecordingTokens(ctx, call._id);
+  await deleteStorageIds(ctx, storageIds);
+
+  await ctx.db.patch(call._id, {
+    recordingStorageId: undefined,
+    recordingContentType: undefined,
+    recordingByteLength: undefined,
+    recordingDurationMs: undefined,
+    recordingRetentionStatus: "expired",
+  });
+}
+
 export const scrubExpiredMessages = internalMutation({
   args: {
     nowIso: v.string(),
@@ -356,21 +441,7 @@ export const scrubExpiredMessages = internalMutation({
       if (!isExpired(message.contentExpiresAt, args.nowIso)) {
         continue;
       }
-
-      const storageIds = new Set<Id<"_storage">>();
-      collectMessageStorageIds(message, storageIds);
-      await deleteSentAttachmentUploads(ctx, message._id, storageIds);
-      await deleteMessageAttachmentTokens(ctx, message._id);
-      await deleteStorageIds(ctx, storageIds);
-      await scrubVoiceMessageMirrors(ctx, message);
-      await deleteConversationAgentThread(ctx, message.conversationId);
-
-      await ctx.db.patch(message._id, {
-        body: REDACTED_MESSAGE_BODY,
-        fromPhoneNumber: undefined,
-        media: undefined,
-        contentRetentionStatus: "expired",
-      });
+      await scrubMessageContent(ctx, message);
       scrubbed += 1;
     }
 
@@ -433,19 +504,7 @@ export const scrubExpiredCallRecordings = internalMutation({
       if (!isExpired(call.recordingExpiresAt, args.nowIso)) {
         continue;
       }
-
-      const storageIds = new Set<Id<"_storage">>();
-      addStorageId(storageIds, call.recordingStorageId);
-      await deleteCallRecordingTokens(ctx, call._id);
-      await deleteStorageIds(ctx, storageIds);
-
-      await ctx.db.patch(call._id, {
-        recordingStorageId: undefined,
-        recordingContentType: undefined,
-        recordingByteLength: undefined,
-        recordingDurationMs: undefined,
-        recordingRetentionStatus: "expired",
-      });
+      await scrubCallRecordingContent(ctx, call);
       scrubbed += 1;
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -914,6 +914,8 @@ export default defineSchema({
     providerNumSegments: v.optional(v.number()),
     senderRole: v.optional(smsSenderRoleValidator),
     digestForDate: v.optional(v.string()),
+    contentRetentionStatus: v.optional(retentionStatusValidator),
+    contentExpiresAt: v.optional(v.string()),
     createdAt: v.string(),
   })
     .index("by_user_id_and_channel_and_event_key", ["userId", "channel", "eventKey"])
@@ -929,6 +931,10 @@ export default defineSchema({
       "eventKind",
       "channel",
       "digestForDate",
+    ])
+    .index("by_content_retention_status_and_content_expires_at", [
+      "contentRetentionStatus",
+      "contentExpiresAt",
     ])
     .index("by_status_and_scheduled_for", ["status", "scheduledFor"]),
 
@@ -1001,10 +1007,16 @@ export default defineSchema({
     body: v.string(),
     relatedId: v.optional(v.string()),
     status: v.string(),
+    contentRetentionStatus: v.optional(retentionStatusValidator),
+    contentExpiresAt: v.optional(v.string()),
   })
     .index("by_business_id_and_status", ["businessId", "status"])
     .index("by_business_id_and_kind", ["businessId", "kind"])
     .index("by_business_id_and_kind_and_status", ["businessId", "kind", "status"])
+    .index("by_content_retention_status_and_content_expires_at", [
+      "contentRetentionStatus",
+      "contentExpiresAt",
+    ])
     .index("by_kind_and_related_id", ["kind", "relatedId"])
     .index("by_related_id", ["relatedId"]),
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -674,10 +674,12 @@ export default defineSchema({
     previewByteLength: v.optional(v.number()),
     deliveryMode: v.string(),
     status: v.string(),
+    expiresAt: v.optional(v.string()),
     sentMessageId: v.optional(v.id("messages")),
   })
     .index("by_business_id_and_conversation_id", ["businessId", "conversationId"])
     .index("by_uploader_user_id_and_conversation_id", ["uploaderUserId", "conversationId"])
+    .index("by_status_and_expires_at", ["status", "expiresAt"])
     .index("by_sent_message_id", ["sentMessageId"]),
 
   message_attachment_download_tokens: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -917,6 +917,11 @@ export default defineSchema({
     .index("by_user_id_and_channel_and_event_key", ["userId", "channel", "eventKey"])
     .index("by_provider_message_id", ["providerMessageId"])
     .index("by_business_id_and_event_kind", ["businessId", "eventKind"])
+    .index("by_business_id_and_event_kind_and_event_key", [
+      "businessId",
+      "eventKind",
+      "eventKey",
+    ])
     .index("by_business_id_and_event_kind_and_channel_and_digest_for_date", [
       "businessId",
       "eventKind",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -65,6 +65,8 @@ const messageMediaValidator = v.object({
   deliveryMode: v.optional(v.string()),
 });
 
+const retentionStatusValidator = v.union(v.literal("active"), v.literal("expired"));
+
 const conversationSessionSummaryKindValidator = v.union(
   v.literal("booked"),
   v.literal("booking_in_progress"),
@@ -628,12 +630,18 @@ export default defineSchema({
     providerRawDlrDoneDate: v.optional(v.string()),
     senderRole: v.optional(smsSenderRoleValidator),
     aiGenerated: v.boolean(),
+    contentRetentionStatus: v.optional(retentionStatusValidator),
+    contentExpiresAt: v.optional(v.string()),
   })
     .index("by_business_id", ["businessId"])
     .index("by_business_id_and_provider_updated_at", ["businessId", "providerUpdatedAt"])
     .index("by_conversation_id", ["conversationId"])
     .index("by_conversation_session_id", ["conversationSessionId"])
-    .index("by_provider_message_sid", ["providerMessageSid"]),
+    .index("by_provider_message_sid", ["providerMessageSid"])
+    .index("by_content_retention_status_and_content_expires_at", [
+      "contentRetentionStatus",
+      "contentExpiresAt",
+    ]),
 
   conversation_sessions: defineTable({
     businessId: v.id("businesses"),
@@ -722,10 +730,16 @@ export default defineSchema({
     recordingContentType: v.optional(v.string()),
     recordingByteLength: v.optional(v.number()),
     recordingDurationMs: v.optional(v.number()),
+    recordingRetentionStatus: v.optional(retentionStatusValidator),
+    recordingExpiresAt: v.optional(v.string()),
   })
     .index("by_twilio_call_sid", ["twilioCallSid"])
     .index("by_business_id_and_started_at", ["businessId", "startedAt"])
-    .index("by_conversation_id", ["conversationId"]),
+    .index("by_conversation_id", ["conversationId"])
+    .index("by_recording_retention_status_and_recording_expires_at", [
+      "recordingRetentionStatus",
+      "recordingExpiresAt",
+    ]),
 
   transcripts: defineTable({
     businessId: v.id("businesses"),
@@ -735,7 +749,10 @@ export default defineSchema({
     text: v.string(),
     confidence: v.optional(v.number()),
     final: v.boolean(),
-  }).index("by_call_id_and_sequence", ["callId", "sequence"]),
+    expiresAt: v.optional(v.string()),
+  })
+    .index("by_call_id_and_sequence", ["callId", "sequence"])
+    .index("by_expires_at", ["expiresAt"]),
 
   appointments: defineTable({
     businessId: v.id("businesses"),
@@ -1037,10 +1054,12 @@ export default defineSchema({
     streamId: v.string(),
     threadId: v.optional(v.string()),
     response: v.optional(v.string()),
+    expiresAt: v.optional(v.string()),
   })
     .index("by_business_id_and_user_id", ["businessId", "userId"])
     .index("by_user_id", ["userId"])
-    .index("by_stream_id", ["streamId"]),
+    .index("by_stream_id", ["streamId"])
+    .index("by_expires_at", ["expiresAt"]),
 
   billing_accounts: defineTable({
     businessId: v.id("businesses"),

--- a/convex/test.setup.ts
+++ b/convex/test.setup.ts
@@ -3,4 +3,5 @@ export const modules = import.meta.glob([
   "./**/*.js",
   "!./**/*.test.ts",
   "!./**/*.test.js",
+  "!./vitest.setup.ts",
 ]);

--- a/convex/tests/dashboardHomeSummary.test.ts
+++ b/convex/tests/dashboardHomeSummary.test.ts
@@ -548,6 +548,50 @@ describe("Dashboard home summary", () => {
     ).toBe(true);
   });
 
+  it("uses the conversation summary for attachment-only handoff messages", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, authed } = await seedBusinessMember(
+      t,
+      "dashboard-home-attachment-handoff",
+    );
+
+    await t.run(async (ctx) => {
+      const contactId = await insertContact(ctx, businessId, {
+        name: "Attachment Sender",
+        phone: "+14165550999",
+      });
+      const conversationId = await ctx.db.insert("conversations", {
+        businessId,
+        contactId,
+        channel: "sms",
+        status: "open",
+        automationState: "human_handoff",
+        summary: "Customer sent an attachment while automation was paused.",
+      });
+      await ctx.db.insert("messages", {
+        businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        body: "",
+        status: "received",
+        aiGenerated: false,
+      });
+    });
+
+    const summary = await authed.query(api.dashboard.overview.getHomeSummary, {
+      businessId,
+      locale: HOME_SUMMARY_LOCALE,
+    });
+
+    const handoffTask = summary.actionRequired.find(
+      (item) => item.kind === "human_handoff",
+    );
+    expect(handoffTask?.body).toBe(
+      "Customer sent an attachment while automation was paused.",
+    );
+  });
+
   it("filters upcoming appointments by timestamp instead of lexical ISO ordering", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId, authed } = await seedBusinessMember(

--- a/convex/tests/dashboardSmsReply.test.ts
+++ b/convex/tests/dashboardSmsReply.test.ts
@@ -118,6 +118,7 @@ async function storeAttachment(
     businessId: Id<"businesses">;
     conversationId: Id<"conversations">;
     userId: Id<"users">;
+    expiresAt?: string;
   },
 ): Promise<Id<"message_attachment_uploads">> {
   const storageId = await ctx.storage.store(
@@ -139,6 +140,7 @@ async function storeAttachment(
         ? "mms"
         : "link",
     status: "staged",
+    ...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
   });
 }
 
@@ -992,6 +994,59 @@ describe("Dashboard SMS replies", () => {
       byteLength: "pdf-file".length,
       previewUrl: null,
     });
+  });
+
+  it("hides and rejects expired staged attachments when cleanup is late", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId, conversationId, userId } = await seedSmsConversation(t, {
+      subject: "dashboard-sms-reply-expired-staged",
+    });
+
+    const { expiredAttachmentId } = await t.run(async (ctx) => {
+      const expiredAttachmentId = await storeAttachment(ctx, {
+        content: "old-pdf-file",
+        contentType: "application/pdf",
+        fileName: "old-details.pdf",
+        businessId,
+        conversationId,
+        userId,
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      });
+      await storeAttachment(ctx, {
+        content: "fresh-pdf-file",
+        contentType: "application/pdf",
+        fileName: "fresh-details.pdf",
+        businessId,
+        conversationId,
+        userId,
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      });
+      return { expiredAttachmentId };
+    });
+
+    const stagedAttachments = await authed.query(api.dashboard.messages.listStagedAttachments, {
+      businessId,
+      conversationId,
+    });
+
+    expect(stagedAttachments).toHaveLength(1);
+    expect(stagedAttachments[0]?.fileName).toBe("fresh-details.pdf");
+    await expect(
+      t.query(internal.dashboard.messages.getSmsReplyContext, {
+        businessId,
+        conversationId,
+        userId,
+        attachmentIds: [expiredAttachmentId],
+      }),
+    ).rejects.toThrow("Attachment is no longer available.");
+    await expect(
+      t.mutation(internal.dashboard.messages.claimStagedAttachmentsForSend, {
+        businessId,
+        conversationId,
+        userId,
+        attachmentIds: [expiredAttachmentId],
+      }),
+    ).rejects.toThrow("Attachment is no longer available.");
   });
 
   it("hydrates legacy media messages in the dashboard thread without a migration", async () => {

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -131,6 +131,10 @@ describe("MVP privacy retention", () => {
 
     const seeded = await t.run(async (ctx: TestRunCtx) => {
       const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
+      await ctx.db.patch(conversationId, {
+        automationState: "human_handoff",
+        summary: "Leaky handoff summary before cron",
+      });
       const messageStorageId = await storeTestBlob(ctx, "expired visible attachment");
       const messageId = await ctx.db.insert("messages", {
         businessId: owner.businessId,
@@ -227,8 +231,21 @@ describe("MVP privacy retention", () => {
       callId: seeded.callId,
     });
     expect(call?.recordingUrl).toBeNull();
+    expect(
+      call && "recordingStorageId" in call ? call.recordingStorageId : undefined,
+    ).toBeUndefined();
+    expect(call?.recordingRetentionStatus).toBe("expired");
     expect(call?.transcriptReady).toBe(false);
     expect(call?.transcriptPreview).toBeNull();
+
+    const homeSummary = await owner.authed.query(api.dashboard.overview.getHomeSummary, {
+      businessId: owner.businessId,
+      locale: "en",
+    });
+    const handoffTask = homeSummary.actionRequired.find(
+      (item) => item.kind === "human_handoff",
+    );
+    expect(handoffTask?.body).toBe(REDACTED_MESSAGE_BODY);
 
     await expect(
       owner.authed.query(api.voice.runtime.getCallTranscript, {
@@ -285,6 +302,18 @@ describe("MVP privacy retention", () => {
         ],
         contentRetentionStatus: "active",
         contentExpiresAt: EXPIRED_ISO,
+      });
+      const pausedSmsDeliveryId = await ctx.db.insert("operator_notification_deliveries", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        eventKind: "pausedSms",
+        eventKey: `pausedSms:${String(expiredMessageId)}`,
+        channel: "sms",
+        status: "sent",
+        subject: "New message in paused SMS conversation",
+        body: "A customer sent a new SMS while automation is paused.\n\nFrom: +14165550001\n\nold sensitive SMS body",
+        sentAt: "2026-05-01T12:00:00.000Z",
+        createdAt: "2026-05-01T12:00:00.000Z",
       });
       await ctx.db.insert("message_attachment_uploads", {
         businessId: owner.businessId,
@@ -354,6 +383,7 @@ describe("MVP privacy retention", () => {
         expiredStorageId,
         expiredPreviewStorageId,
         expiredTokenId,
+        pausedSmsDeliveryId,
         conversationAiStateId,
         freshMessageId,
         freshStorageId,
@@ -380,6 +410,10 @@ describe("MVP privacy retention", () => {
       expect(expiredMessage?.fromPhoneNumber).toBeUndefined();
       expect(await ctx.db.get(seeded.expiredTokenId)).toBeNull();
       expect(await ctx.db.get(seeded.conversationAiStateId)).toBeNull();
+      expect(await ctx.db.get(seeded.pausedSmsDeliveryId)).toMatchObject({
+        subject: "Expired paused SMS message",
+        body: REDACTED_MESSAGE_BODY,
+      });
       expect(await ctx.storage.get(seeded.expiredStorageId)).toBeNull();
       expect(await ctx.storage.get(seeded.expiredPreviewStorageId)).toBeNull();
       expect(

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -165,6 +165,11 @@ describe("MVP privacy retention", () => {
         nonce: "expired-message-token",
         expiresAt: FRESH_ISO,
       });
+      const conversationAiStateId = await ctx.db.insert("conversation_ai_state", {
+        businessId: owner.businessId,
+        conversationId,
+        threadId: "thread-with-expired-sms-copy",
+      });
 
       const freshMessageId = await ctx.db.insert("messages", {
         businessId: owner.businessId,
@@ -202,6 +207,7 @@ describe("MVP privacy retention", () => {
         expiredStorageId,
         expiredPreviewStorageId,
         expiredTokenId,
+        conversationAiStateId,
         freshMessageId,
         freshStorageId,
         legacyMessageId,
@@ -226,6 +232,7 @@ describe("MVP privacy retention", () => {
       expect(expiredMessage?.media).toBeUndefined();
       expect(expiredMessage?.fromPhoneNumber).toBeUndefined();
       expect(await ctx.db.get(seeded.expiredTokenId)).toBeNull();
+      expect(await ctx.db.get(seeded.conversationAiStateId)).toBeNull();
       expect(await ctx.storage.get(seeded.expiredStorageId)).toBeNull();
       expect(await ctx.storage.get(seeded.expiredPreviewStorageId)).toBeNull();
       expect(
@@ -350,6 +357,8 @@ describe("MVP privacy retention", () => {
         userId: owner.userId,
         prompt: "old preview",
         streamId: "stream-old",
+        threadId: "thread-old-preview",
+        response: "old generated preview answer",
         expiresAt: EXPIRED_ISO,
       });
       const freshPreviewSessionId = await ctx.db.insert("preview_sessions", {
@@ -415,6 +424,163 @@ describe("MVP privacy retention", () => {
       expect(await ctx.db.get(seeded.expiredPreviewSessionId)).toBeNull();
       expect(await ctx.db.get(seeded.freshPreviewSessionId)).not.toBeNull();
       expect(await ctx.db.get(seeded.legacyPreviewSessionId)).not.toBeNull();
+    });
+  });
+
+  it("scrubs voice-message mirror fields when the retained message expires", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-voice-mirrors-owner",
+      slug: "mvp-retention-voice-mirrors",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
+      const callId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-retention-voice-mirrors",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+      });
+      const sessionId = await ctx.db.insert("conversation_sessions", {
+        businessId: owner.businessId,
+        conversationId,
+        channel: "voice",
+        callId,
+        status: "closed",
+        startedAt: 1,
+        lastMessageAt: 2,
+        summaryGeneratedAt: 3,
+        summaryKind: "message_taking",
+        summary: {
+          kind: "message_taking",
+          summary: "Callback: +14165551212\n\nold voice message body",
+        },
+      });
+      const inboxItemId = await ctx.db.insert("inbox_items", {
+        businessId: owner.businessId,
+        kind: "voice_message",
+        title: "Voice message from Taylor Customer",
+        body: "Callback: +14165551212\n\nold voice message body",
+        relatedId: String(callId),
+        status: "open",
+      });
+      await ctx.db.patch(conversationId, {
+        currentIntent: "message_taking",
+        summary: "Callback: +14165551212\n\nold voice message body",
+      });
+      const messageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        conversationSessionId: sessionId,
+        direction: "inbound",
+        channel: "voice",
+        body: "old voice message body",
+        status: "captured",
+        aiGenerated: false,
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+
+      return {
+        conversationId,
+        inboxItemId,
+        messageId,
+        sessionId,
+      };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.messages.scrubbed).toBe(1);
+    await t.run(async (ctx: TestRunCtx) => {
+      const message = await ctx.db.get(seeded.messageId);
+      const conversation = await ctx.db.get(seeded.conversationId);
+      const session = await ctx.db.get(seeded.sessionId);
+      const inboxItem = await ctx.db.get(seeded.inboxItemId);
+
+      expect(message?.body).toBe(REDACTED_MESSAGE_BODY);
+      expect(conversation?.summary).toBe(REDACTED_MESSAGE_BODY);
+      expect(session?.summary?.summary).toBe(REDACTED_MESSAGE_BODY);
+      expect(inboxItem?.title).toBe("Expired voice message");
+      expect(inboxItem?.body).toBe(REDACTED_MESSAGE_BODY);
+    });
+  });
+
+  it("drains expired rows across multiple batches in one cleanup action", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-batch-owner",
+      slug: "mvp-retention-batch",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { conversationId } = await seedConversation(ctx, owner.businessId);
+      const messageIds: Array<Id<"messages">> = [];
+      for (let index = 0; index < 3; index += 1) {
+        messageIds.push(
+          await ctx.db.insert("messages", {
+            businessId: owner.businessId,
+            conversationId,
+            direction: "inbound",
+            channel: "sms",
+            body: `old batched SMS body ${index}`,
+            status: "received",
+            aiGenerated: false,
+            contentRetentionStatus: "active",
+            contentExpiresAt: EXPIRED_ISO,
+          }),
+        );
+      }
+      return { messageIds };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 2,
+    });
+
+    expect(summary.messages.scanned).toBe(3);
+    expect(summary.messages.scrubbed).toBe(3);
+    await t.run(async (ctx: TestRunCtx) => {
+      for (const messageId of seeded.messageIds) {
+        const message = await ctx.db.get(messageId);
+        expect(message?.body).toBe(REDACTED_MESSAGE_BODY);
+        expect(message?.contentRetentionStatus).toBe("expired");
+      }
+    });
+  });
+
+  it("records preview thread handles for later retention cleanup", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-preview-output-owner",
+      slug: "mvp-retention-preview-output",
+    });
+
+    const previewSessionId = await t.run(async (ctx: TestRunCtx) => {
+      return await ctx.db.insert("preview_sessions", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        prompt: "preview prompt",
+        streamId: "preview-output-stream",
+        expiresAt: FRESH_ISO,
+      });
+    });
+
+    await t.mutation(internal.ai.preview.stream.recordPreviewOutput, {
+      streamId: "preview-output-stream",
+      threadId: "preview-output-thread",
+    });
+
+    await t.run(async (ctx: TestRunCtx) => {
+      const previewSession = await ctx.db.get(previewSessionId);
+      expect(previewSession?.threadId).toBe("preview-output-thread");
     });
   });
 });

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -19,6 +19,8 @@ const convexModules = modules;
 const NOW_ISO = "2026-05-07T12:00:00.000Z";
 const EXPIRED_ISO = "2026-05-06T12:00:00.000Z";
 const FRESH_ISO = "2026-05-08T12:00:00.000Z";
+const RETENTION_MARKER = "__OPE_127_RETENTION_MARKER__";
+const FRESH_RETENTION_MARKER = "__OPE_127_FRESH_MARKER__";
 
 type ConvexHarness = TestConvex<typeof schema>;
 type TestRunCtx = Parameters<Parameters<ConvexHarness["run"]>[0]>[0];
@@ -181,6 +183,16 @@ describe("MVP privacy retention", () => {
         recordingRetentionStatus: "active",
         recordingExpiresAt: EXPIRED_ISO,
       });
+      const inboxItemId = await ctx.db.insert("inbox_items", {
+        businessId: owner.businessId,
+        kind: "voice_message",
+        title: "Expired voice follow-up before cron",
+        body: "expired voice follow-up before cron",
+        relatedId: String(callId),
+        status: "open",
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
       await ctx.db.insert("call_recording_download_tokens", {
         businessId: owner.businessId,
         callId,
@@ -210,6 +222,7 @@ describe("MVP privacy retention", () => {
       return {
         callId,
         conversationId,
+        inboxItemId,
         messageId,
         previewSessionId,
         transcriptId,
@@ -240,6 +253,8 @@ describe("MVP privacy retention", () => {
     expect(call?.recordingRetentionStatus).toBe("expired");
     expect(call?.transcriptReady).toBe(false);
     expect(call?.transcriptPreview).toBeNull();
+    expect(call?.followUpTask?.title).toBe("Expired voice message");
+    expect(call?.followUpTask?.body).toBe(REDACTED_MESSAGE_BODY);
 
     const homeSummary = await owner.authed.query(api.dashboard.overview.getHomeSummary, {
       businessId: owner.businessId,
@@ -249,6 +264,14 @@ describe("MVP privacy retention", () => {
       (item) => item.kind === "human_handoff",
     );
     expect(handoffTask?.body).toBe(REDACTED_MESSAGE_BODY);
+    const voiceTask = homeSummary.actionRequired.find(
+      (item) =>
+        item.kind === "voice_message" &&
+        "taskId" in item &&
+        item.taskId === seeded.inboxItemId,
+    );
+    expect(voiceTask?.title).toBe("Expired voice message");
+    expect(voiceTask?.body).toBe(REDACTED_MESSAGE_BODY);
 
     await expect(
       owner.authed.query(api.voice.runtime.getCallTranscript, {
@@ -318,6 +341,16 @@ describe("MVP privacy retention", () => {
       recordingContentType: "audio/wav",
       recordingByteLength: 19,
     });
+    await t.mutation(internal.operatorNotifications.reserveDelivery, {
+      businessId: owner.businessId,
+      userId: owner.userId,
+      eventKind: "voiceMessage",
+      eventKey: "voiceMessage:scheduled-retention",
+      channel: "email",
+      subject: "Voice message scheduled for retention",
+      body: "operator delivery scheduled for retention",
+      contentExpiresAt: FRESH_ISO,
+    });
 
     const scheduledNames = await t.run(async (ctx: TestRunCtx) => {
       const jobs = await ctx.db.system.query("_scheduled_functions").collect();
@@ -327,6 +360,9 @@ describe("MVP privacy retention", () => {
     expect(scheduledNames).toContain("privacy/retention:scrubMessageContentAtExpiry");
     expect(scheduledNames).toContain("privacy/retention:deleteTranscriptAtExpiry");
     expect(scheduledNames).toContain("privacy/retention:scrubCallRecordingAtExpiry");
+    expect(scheduledNames).toContain(
+      "privacy/retention:scrubOperatorNotificationDeliveryContentAtExpiry",
+    );
   });
 
   it("scrubs expired message content and attachment storage while preserving fresh and legacy rows", async () => {
@@ -1024,6 +1060,411 @@ describe("MVP privacy retention", () => {
       expect(inboxItem?.body).toBe(REDACTED_MESSAGE_BODY);
       expect(delivery?.subject).toBe("Expired voice message");
       expect(delivery?.body).toBe(REDACTED_MESSAGE_BODY);
+    });
+  });
+
+  it("removes a sensitive marker from retained first-party communication mirrors", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-marker-owner",
+      slug: "mvp-retention-marker",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const sms = await seedConversation(ctx, owner.businessId);
+      const smsSessionId = await ctx.db.insert("conversation_sessions", {
+        businessId: owner.businessId,
+        conversationId: sms.conversationId,
+        channel: "sms",
+        status: "closed",
+        startedAt: 1,
+        lastMessageAt: 2,
+        closedAt: 2,
+        summaryGeneratedAt: 3,
+        summaryKind: "summary",
+        summary: {
+          kind: "summary",
+          summary: `SMS session ${RETENTION_MARKER}`,
+        },
+      });
+      await ctx.db.patch(sms.conversationId, {
+        summary: `SMS conversation ${RETENTION_MARKER}`,
+      });
+      const smsStorageId = await storeTestBlob(ctx, `sms storage ${RETENTION_MARKER}`);
+      const smsPreviewStorageId = await storeTestBlob(
+        ctx,
+        `sms preview ${RETENTION_MARKER}`,
+        "image/png",
+      );
+      const smsMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId: sms.conversationId,
+        conversationSessionId: smsSessionId,
+        direction: "inbound",
+        channel: "sms",
+        fromPhoneNumber: "+14165559999",
+        body: `expired sms ${RETENTION_MARKER}`,
+        status: "received",
+        aiGenerated: false,
+        media: [
+          {
+            storageId: smsStorageId,
+            fileName: `sms-${RETENTION_MARKER}.txt`,
+            contentType: "text/plain",
+            byteLength: 12,
+            previewStorageId: smsPreviewStorageId,
+            previewFileName: `sms-${RETENTION_MARKER}.png`,
+            previewContentType: "image/png",
+            previewByteLength: 10,
+            deliveryMode: "link",
+          },
+        ],
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      const smsUploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId: sms.conversationId,
+        uploaderUserId: owner.userId,
+        storageId: smsStorageId,
+        fileName: `sent-${RETENTION_MARKER}.txt`,
+        contentType: "text/plain",
+        byteLength: 12,
+        previewStorageId: smsPreviewStorageId,
+        previewFileName: `sent-${RETENTION_MARKER}.png`,
+        previewContentType: "image/png",
+        previewByteLength: 10,
+        deliveryMode: "link",
+        status: "sent",
+        sentMessageId: smsMessageId,
+      });
+      const smsTokenId = await ctx.db.insert("message_attachment_download_tokens", {
+        businessId: owner.businessId,
+        messageId: smsMessageId,
+        storageId: smsStorageId,
+        fileName: `token-${RETENTION_MARKER}.txt`,
+        contentType: "text/plain",
+        disposition: "attachment",
+        nonce: `nonce-${RETENTION_MARKER}`,
+        expiresAt: FRESH_ISO,
+      });
+      const pausedDeliveryId = await ctx.db.insert("operator_notification_deliveries", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        eventKind: "pausedSms",
+        eventKey: `pausedSms:${String(smsMessageId)}`,
+        channel: "email",
+        status: "sent",
+        subject: `Paused ${RETENTION_MARKER}`,
+        body: `Paused body ${RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+        sentAt: "2026-05-01T12:00:00.000Z",
+        createdAt: "2026-05-01T12:00:00.000Z",
+      });
+
+      const voice = await seedConversation(ctx, owner.businessId);
+      const voiceCallId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId: voice.conversationId,
+        contactId: voice.contactId,
+        twilioCallSid: "CA-marker-voice",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+      });
+      const voiceSessionId = await ctx.db.insert("conversation_sessions", {
+        businessId: owner.businessId,
+        conversationId: voice.conversationId,
+        channel: "voice",
+        callId: voiceCallId,
+        status: "closed",
+        startedAt: 1,
+        lastMessageAt: 2,
+        closedAt: 2,
+        summaryGeneratedAt: 3,
+        summaryKind: "summary",
+        summary: {
+          kind: "summary",
+          summary: `Voice session abstract ${RETENTION_MARKER}`,
+        },
+      });
+      await ctx.db.patch(voice.conversationId, {
+        currentIntent: "summary",
+        summary: `Voice conversation abstract ${RETENTION_MARKER}`,
+      });
+      const voiceMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId: voice.conversationId,
+        conversationSessionId: voiceSessionId,
+        direction: "inbound",
+        channel: "voice",
+        body: `voice note ${RETENTION_MARKER}`,
+        status: "captured",
+        aiGenerated: false,
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      const voiceInboxItemId = await ctx.db.insert("inbox_items", {
+        businessId: owner.businessId,
+        kind: "voice_message",
+        title: `Voice title ${RETENTION_MARKER}`,
+        body: `Voice body ${RETENTION_MARKER}`,
+        relatedId: String(voiceCallId),
+        status: "open",
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      const voiceDeliveryId = await ctx.db.insert("operator_notification_deliveries", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        eventKind: "voiceMessage",
+        eventKey: `voiceMessage:${String(voiceInboxItemId)}`,
+        channel: "email",
+        status: "sent",
+        subject: `Voice delivery ${RETENTION_MARKER}`,
+        body: `Voice delivery body ${RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+        sentAt: "2026-05-01T12:00:00.000Z",
+        createdAt: "2026-05-01T12:00:00.000Z",
+      });
+
+      const orphanCallId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        twilioCallSid: "CA-marker-orphan-voice",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+      });
+      const orphanInboxItemId = await ctx.db.insert("inbox_items", {
+        businessId: owner.businessId,
+        kind: "voice_message",
+        title: `Orphan voice title ${RETENTION_MARKER}`,
+        body: `Orphan voice body ${RETENTION_MARKER}`,
+        relatedId: String(orphanCallId),
+        status: "open",
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      const orphanDeliveryId = await ctx.db.insert("operator_notification_deliveries", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        eventKind: "voiceMessage",
+        eventKey: `voiceMessage:${String(orphanInboxItemId)}`,
+        channel: "sms",
+        status: "sent",
+        subject: `Orphan delivery ${RETENTION_MARKER}`,
+        body: `Orphan delivery body ${RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+        sentAt: "2026-05-01T12:00:00.000Z",
+        createdAt: "2026-05-01T12:00:00.000Z",
+      });
+
+      const recordingStorageId = await storeTestBlob(
+        ctx,
+        `recording ${RETENTION_MARKER}`,
+        "audio/wav",
+      );
+      const recordingCallId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        twilioCallSid: "CA-marker-recording",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+        recordingStorageId,
+        recordingContentType: "audio/wav",
+        recordingByteLength: 12,
+        recordingRetentionStatus: "active",
+        recordingExpiresAt: EXPIRED_ISO,
+      });
+      const recordingTokenId = await ctx.db.insert("call_recording_download_tokens", {
+        businessId: owner.businessId,
+        callId: recordingCallId,
+        storageId: recordingStorageId,
+        fileName: `recording-${RETENTION_MARKER}.wav`,
+        contentType: "audio/wav",
+        nonce: `recording-${RETENTION_MARKER}`,
+        expiresAt: FRESH_ISO,
+      });
+      const transcriptId = await ctx.db.insert("transcripts", {
+        businessId: owner.businessId,
+        callId: recordingCallId,
+        sequence: 1,
+        speaker: "caller",
+        text: `transcript ${RETENTION_MARKER}`,
+        final: true,
+        expiresAt: EXPIRED_ISO,
+      });
+
+      const previewSessionId = await ctx.db.insert("preview_sessions", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        prompt: `preview prompt ${RETENTION_MARKER}`,
+        streamId: "marker-preview-stream",
+        threadId: "marker-preview-thread",
+        response: `preview response ${RETENTION_MARKER}`,
+        expiresAt: EXPIRED_ISO,
+      });
+      const stagedStorageId = await storeTestBlob(ctx, `staged ${RETENTION_MARKER}`);
+      const stagedUploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId: sms.conversationId,
+        uploaderUserId: owner.userId,
+        storageId: stagedStorageId,
+        fileName: `staged-${RETENTION_MARKER}.txt`,
+        contentType: "text/plain",
+        byteLength: 12,
+        deliveryMode: "link",
+        status: "staged",
+        expiresAt: EXPIRED_ISO,
+      });
+
+      const fresh = await seedConversation(ctx, owner.businessId);
+      const freshMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId: fresh.conversationId,
+        direction: "inbound",
+        channel: "sms",
+        body: `fresh ${FRESH_RETENTION_MARKER}`,
+        status: "received",
+        aiGenerated: false,
+        contentRetentionStatus: "active",
+        contentExpiresAt: FRESH_ISO,
+      });
+      const freshInboxItemId = await ctx.db.insert("inbox_items", {
+        businessId: owner.businessId,
+        kind: "voice_message",
+        title: `Fresh title ${FRESH_RETENTION_MARKER}`,
+        body: `Fresh body ${FRESH_RETENTION_MARKER}`,
+        relatedId: "fresh-call",
+        status: "open",
+        contentRetentionStatus: "active",
+        contentExpiresAt: FRESH_ISO,
+      });
+      const freshDeliveryId = await ctx.db.insert("operator_notification_deliveries", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        eventKind: "pausedSms",
+        eventKey: "pausedSms:fresh-marker",
+        channel: "email",
+        status: "sent",
+        subject: `Fresh subject ${FRESH_RETENTION_MARKER}`,
+        body: `Fresh delivery ${FRESH_RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+        contentExpiresAt: FRESH_ISO,
+        sentAt: "2026-05-01T12:00:00.000Z",
+        createdAt: "2026-05-01T12:00:00.000Z",
+      });
+
+      return {
+        freshDeliveryId,
+        freshInboxItemId,
+        freshMessageId,
+        orphanDeliveryId,
+        orphanInboxItemId,
+        pausedDeliveryId,
+        previewSessionId,
+        recordingStorageId,
+        recordingTokenId,
+        smsMessageId,
+        smsPreviewStorageId,
+        smsSessionId,
+        smsStorageId,
+        smsTokenId,
+        smsUploadId,
+        stagedStorageId,
+        stagedUploadId,
+        transcriptId,
+        voiceDeliveryId,
+        voiceInboxItemId,
+        voiceMessageId,
+        voiceSessionId,
+      };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.messages.scrubbed).toBe(2);
+    expect(summary.inboxItems.scrubbed).toBe(1);
+    expect(summary.operatorNotificationDeliveries.scrubbed).toBe(1);
+    expect(summary.transcripts.deleted).toBe(1);
+    expect(summary.callRecordings.scrubbed).toBe(1);
+    expect(summary.previewSessions.deleted).toBe(1);
+    expect(summary.abandonedMessageAttachmentUploads.deleted).toBe(1);
+
+    await t.run(async (ctx: TestRunCtx) => {
+      expect(await ctx.db.get(seeded.smsTokenId)).toBeNull();
+      expect(await ctx.db.get(seeded.smsUploadId)).toBeNull();
+      expect(await ctx.db.get(seeded.recordingTokenId)).toBeNull();
+      expect(await ctx.db.get(seeded.transcriptId)).toBeNull();
+      expect(await ctx.db.get(seeded.previewSessionId)).toBeNull();
+      expect(await ctx.db.get(seeded.stagedUploadId)).toBeNull();
+      expect(await ctx.storage.get(seeded.smsStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.smsPreviewStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.recordingStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.stagedStorageId)).toBeNull();
+
+      expect(await ctx.db.get(seeded.smsMessageId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(await ctx.db.get(seeded.voiceMessageId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(await ctx.db.get(seeded.pausedDeliveryId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(await ctx.db.get(seeded.voiceDeliveryId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(await ctx.db.get(seeded.orphanDeliveryId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(await ctx.db.get(seeded.voiceInboxItemId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(await ctx.db.get(seeded.orphanInboxItemId)).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+
+      expect(await ctx.db.get(seeded.freshMessageId)).toMatchObject({
+        body: `fresh ${FRESH_RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+      });
+      expect(await ctx.db.get(seeded.freshInboxItemId)).toMatchObject({
+        body: `Fresh body ${FRESH_RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+      });
+      expect(await ctx.db.get(seeded.freshDeliveryId)).toMatchObject({
+        body: `Fresh delivery ${FRESH_RETENTION_MARKER}`,
+        contentRetentionStatus: "active",
+      });
+
+      const remainingRows = [
+        ...(await ctx.db.query("messages").collect()),
+        ...(await ctx.db.query("conversations").collect()),
+        ...(await ctx.db.query("conversation_sessions").collect()),
+        ...(await ctx.db.query("inbox_items").collect()),
+        ...(await ctx.db.query("operator_notification_deliveries").collect()),
+        ...(await ctx.db.query("calls").collect()),
+        ...(await ctx.db.query("transcripts").collect()),
+        ...(await ctx.db.query("preview_sessions").collect()),
+        ...(await ctx.db.query("message_attachment_uploads").collect()),
+        ...(await ctx.db.query("message_attachment_download_tokens").collect()),
+        ...(await ctx.db.query("call_recording_download_tokens").collect()),
+      ];
+      for (const row of remainingRows) {
+        expect(JSON.stringify(row)).not.toContain(RETENTION_MARKER);
+      }
+      expect(JSON.stringify(remainingRows)).toContain(FRESH_RETENTION_MARKER);
     });
   });
 

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -1,5 +1,5 @@
 import { convexTest, type TestConvex } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
@@ -24,6 +24,16 @@ const FRESH_RETENTION_MARKER = "__OPE_127_FRESH_MARKER__";
 
 type ConvexHarness = TestConvex<typeof schema>;
 type TestRunCtx = Parameters<Parameters<ConvexHarness["run"]>[0]>[0];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW_ISO));
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
 
 type WorkspaceSeed = {
   authed: ReturnType<ConvexHarness["withIdentity"]>;
@@ -352,17 +362,37 @@ describe("MVP privacy retention", () => {
       contentExpiresAt: FRESH_ISO,
     });
 
-    const scheduledNames = await t.run(async (ctx: TestRunCtx) => {
+    const scheduled = await t.run(async (ctx: TestRunCtx) => {
+      const message = await ctx.db
+        .query("messages")
+        .withIndex("by_business_id", (q) => q.eq("businessId", owner.businessId))
+        .filter((q) => q.eq(q.field("body"), "message scheduled for retention"))
+        .first();
       const jobs = await ctx.db.system.query("_scheduled_functions").collect();
-      return jobs.map((job) => String(job.name));
+      return {
+        messageExpiresAt: message?.contentExpiresAt ?? null,
+        jobs: jobs.map((job) => ({
+          name: String(job.name),
+          scheduledTime: job.scheduledTime,
+        })),
+      };
     });
 
+    const scheduledNames = scheduled.jobs.map((job) => job.name);
     expect(scheduledNames).toContain("privacy/retention:scrubMessageContentAtExpiry");
     expect(scheduledNames).toContain("privacy/retention:deleteTranscriptAtExpiry");
     expect(scheduledNames).toContain("privacy/retention:scrubCallRecordingAtExpiry");
     expect(scheduledNames).toContain(
       "privacy/retention:scrubOperatorNotificationDeliveryContentAtExpiry",
     );
+
+    if (scheduled.messageExpiresAt === null) {
+      throw new Error("Expected scheduled message to have contentExpiresAt");
+    }
+    const messageRetentionJob = scheduled.jobs.find(
+      (job) => job.name === "privacy/retention:scrubMessageContentAtExpiry",
+    );
+    expect(messageRetentionJob?.scheduledTime).toBe(Date.parse(scheduled.messageExpiresAt));
   });
 
   it("scrubs expired message content and attachment storage while preserving fresh and legacy rows", async () => {
@@ -477,6 +507,17 @@ describe("MVP privacy retention", () => {
         status: "received",
         aiGenerated: false,
       });
+      const statuslessExpiredMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        fromPhoneNumber: "+14165550003",
+        body: "statusless expired body",
+        status: "received",
+        aiGenerated: false,
+        contentExpiresAt: EXPIRED_ISO,
+      });
 
       return {
         expiredMessageId,
@@ -488,6 +529,7 @@ describe("MVP privacy retention", () => {
         freshMessageId,
         freshStorageId,
         legacyMessageId,
+        statuslessExpiredMessageId,
       };
     });
 
@@ -496,11 +538,12 @@ describe("MVP privacy retention", () => {
       limit: 100,
     });
 
-    expect(summary.messages.scrubbed).toBe(1);
+    expect(summary.messages.scrubbed).toBe(2);
     await t.run(async (ctx: TestRunCtx) => {
       const expiredMessage = await ctx.db.get(seeded.expiredMessageId);
       const freshMessage = await ctx.db.get(seeded.freshMessageId);
       const legacyMessage = await ctx.db.get(seeded.legacyMessageId);
+      const statuslessExpiredMessage = await ctx.db.get(seeded.statuslessExpiredMessageId);
 
       expect(expiredMessage).toMatchObject({
         body: REDACTED_MESSAGE_BODY,
@@ -529,6 +572,11 @@ describe("MVP privacy retention", () => {
       expect(freshMessage?.media).toHaveLength(1);
       expect(await ctx.storage.get(seeded.freshStorageId)).not.toBeNull();
       expect(legacyMessage?.body).toBe("legacy body without retention fields");
+      expect(statuslessExpiredMessage).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(statuslessExpiredMessage?.fromPhoneNumber).toBeUndefined();
     });
   });
 
@@ -615,6 +663,86 @@ describe("MVP privacy retention", () => {
       expect(await ctx.db.get(seeded.uploadId)).toBeNull();
       expect(await ctx.storage.get(seeded.sentStorageId)).toBeNull();
       expect(await ctx.storage.get(seeded.sentPreviewStorageId)).toBeNull();
+    });
+  });
+
+  it("scrubs expired messages before draining very large linked attachment upload batches", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-large-upload-owner",
+      slug: "mvp-retention-large-upload",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { conversationId } = await seedConversation(ctx, owner.businessId);
+      const storageId = await storeTestBlob(ctx, "large linked upload");
+      const messageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "outbound",
+        channel: "sms",
+        body: "old outbound attachment body with many upload rows",
+        status: "sent",
+        aiGenerated: false,
+        media: [
+          {
+            storageId,
+            fileName: "large.txt",
+            contentType: "text/plain",
+            byteLength: 19,
+            deliveryMode: "link",
+          },
+        ],
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+
+      for (let index = 0; index < 201; index += 1) {
+        await ctx.db.insert("message_attachment_uploads", {
+          businessId: owner.businessId,
+          conversationId,
+          uploaderUserId: owner.userId,
+          storageId,
+          fileName: `large-${index}.txt`,
+          contentType: "text/plain",
+          byteLength: 19,
+          deliveryMode: "link",
+          status: "consumed",
+          sentMessageId: messageId,
+        });
+      }
+
+      return { messageId, storageId };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.messages.scrubbed).toBe(1);
+    await t.run(async (ctx: TestRunCtx) => {
+      const message = await ctx.db.get(seeded.messageId);
+      const remainingUploads = await ctx.db
+        .query("message_attachment_uploads")
+        .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", seeded.messageId))
+        .collect();
+
+      expect(message?.body).toBe(REDACTED_MESSAGE_BODY);
+      expect(message?.contentRetentionStatus).toBe("expired");
+      expect(remainingUploads).toHaveLength(1);
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+
+    await t.run(async (ctx: TestRunCtx) => {
+      expect(
+        await ctx.db
+          .query("message_attachment_uploads")
+          .withIndex("by_sent_message_id", (q) => q.eq("sentMessageId", seeded.messageId))
+          .collect(),
+      ).toHaveLength(0);
+      expect(await ctx.storage.get(seeded.storageId)).toBeNull();
     });
   });
 
@@ -796,6 +924,11 @@ describe("MVP privacy retention", () => {
     const seeded = await t.run(async (ctx: TestRunCtx) => {
       const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
       const expiredRecordingStorageId = await storeTestBlob(ctx, "expired recording", "audio/wav");
+      const statuslessExpiredRecordingStorageId = await storeTestBlob(
+        ctx,
+        "statusless expired recording",
+        "audio/wav",
+      );
       const freshRecordingStorageId = await storeTestBlob(ctx, "fresh recording", "audio/wav");
       const expiredCallId = await ctx.db.insert("calls", {
         businessId: owner.businessId,
@@ -809,6 +942,19 @@ describe("MVP privacy retention", () => {
         recordingByteLength: 17,
         recordingDurationMs: 12000,
         recordingRetentionStatus: "active",
+        recordingExpiresAt: EXPIRED_ISO,
+      });
+      const statuslessExpiredCallId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-retention-statusless-expired",
+        status: "completed",
+        startedAt: "2026-01-02T12:00:00.000Z",
+        recordingStorageId: statuslessExpiredRecordingStorageId,
+        recordingContentType: "audio/wav",
+        recordingByteLength: 29,
+        recordingDurationMs: 9000,
         recordingExpiresAt: EXPIRED_ISO,
       });
       const freshCallId = await ctx.db.insert("calls", {
@@ -912,8 +1058,10 @@ describe("MVP privacy retention", () => {
 
       return {
         expiredCallId,
+        statuslessExpiredCallId,
         freshCallId,
         expiredRecordingStorageId,
+        statuslessExpiredRecordingStorageId,
         freshRecordingStorageId,
         expiredRecordingTokenId,
         standaloneMessageTokenId,
@@ -933,11 +1081,12 @@ describe("MVP privacy retention", () => {
     });
 
     expect(summary.transcripts.deleted).toBe(1);
-    expect(summary.callRecordings.scrubbed).toBe(1);
+    expect(summary.callRecordings.scrubbed).toBe(2);
     expect(summary.previewSessions.deleted).toBe(1);
     expect(summary.messageAttachmentDownloadTokens.deleted).toBe(1);
     await t.run(async (ctx: TestRunCtx) => {
       const expiredCall = await ctx.db.get(seeded.expiredCallId);
+      const statuslessExpiredCall = await ctx.db.get(seeded.statuslessExpiredCallId);
       const freshCall = await ctx.db.get(seeded.freshCallId);
 
       expect(expiredCall?.recordingRetentionStatus).toBe("expired");
@@ -947,6 +1096,12 @@ describe("MVP privacy retention", () => {
       expect(expiredCall?.recordingDurationMs).toBeUndefined();
       expect(await ctx.storage.get(seeded.expiredRecordingStorageId)).toBeNull();
       expect(await ctx.db.get(seeded.expiredRecordingTokenId)).toBeNull();
+      expect(statuslessExpiredCall?.recordingRetentionStatus).toBe("expired");
+      expect(statuslessExpiredCall?.recordingStorageId).toBeUndefined();
+      expect(statuslessExpiredCall?.recordingContentType).toBeUndefined();
+      expect(statuslessExpiredCall?.recordingByteLength).toBeUndefined();
+      expect(statuslessExpiredCall?.recordingDurationMs).toBeUndefined();
+      expect(await ctx.storage.get(seeded.statuslessExpiredRecordingStorageId)).toBeNull();
 
       expect(freshCall?.recordingStorageId).toBe(seeded.freshRecordingStorageId);
       expect(await ctx.storage.get(seeded.freshRecordingStorageId)).not.toBeNull();

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -4,7 +4,14 @@ import { describe, expect, it } from "vitest";
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { getBillingKey } from "../lib/billing";
-import { REDACTED_MESSAGE_BODY } from "../privacy/retention";
+import {
+  CALL_RECORDING_RETENTION_DAYS,
+  MESSAGE_CONTENT_RETENTION_DAYS,
+  REDACTED_MESSAGE_BODY,
+  getCallRecordingExpiresAt,
+  getMessageContentExpiresAt,
+  getSensitiveContentExpiresAt,
+} from "../privacy/retention";
 import schema from "../schema";
 import { modules } from "../test.setup";
 
@@ -101,6 +108,20 @@ async function storeTestBlob(
 }
 
 describe("MVP privacy retention", () => {
+  it("uses 365 days for message content and 90 days for raw sensitive artifacts", () => {
+    const nowMs = Date.parse(NOW_ISO);
+
+    expect(Date.parse(getMessageContentExpiresAt(nowMs)) - nowMs).toBe(
+      MESSAGE_CONTENT_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    );
+    expect(Date.parse(getCallRecordingExpiresAt(nowMs)) - nowMs).toBe(
+      CALL_RECORDING_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    );
+    expect(Date.parse(getSensitiveContentExpiresAt(nowMs)) - nowMs).toBe(
+      CALL_RECORDING_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    );
+  });
+
   it("scrubs expired message content and attachment storage while preserving fresh and legacy rows", async () => {
     const t = convexTest(schema, convexModules);
     const owner = await seedWorkspace(t, {

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -693,7 +693,60 @@ describe("MVP privacy retention", () => {
       expect(await ctx.db.get(seeded.freshUploadId)).not.toBeNull();
       expect(await ctx.storage.get(seeded.freshStorageId)).not.toBeNull();
       expect(await ctx.db.get(seeded.linkedUploadId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.linkedUploadId)).toMatchObject({
+        status: "consumed",
+      });
       expect(await ctx.storage.get(seeded.linkedStorageId)).not.toBeNull();
+    });
+  });
+
+  it("does not loop on full batches of linked expired attachment uploads", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-linked-upload-owner",
+      slug: "mvp-retention-linked-upload",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { conversationId } = await seedConversation(ctx, owner.businessId);
+      const messageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "outbound",
+        channel: "sms",
+        body: "linked message body",
+        status: "sent",
+        aiGenerated: false,
+      });
+      const storageId = await storeTestBlob(ctx, "linked expired upload");
+      const uploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId,
+        fileName: "linked-expired.txt",
+        contentType: "text/plain",
+        byteLength: 21,
+        deliveryMode: "link",
+        status: "staged",
+        expiresAt: EXPIRED_ISO,
+        sentMessageId: messageId,
+      });
+      return { storageId, uploadId };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 1,
+    });
+
+    expect(summary.abandonedMessageAttachmentUploads.scanned).toBe(1);
+    expect(summary.abandonedMessageAttachmentUploads.deleted).toBe(0);
+    await t.run(async (ctx: TestRunCtx) => {
+      expect(await ctx.db.get(seeded.uploadId)).toMatchObject({
+        status: "consumed",
+      });
+      expect(await ctx.storage.get(seeded.storageId)).not.toBeNull();
     });
   });
 

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -582,6 +582,121 @@ describe("MVP privacy retention", () => {
     });
   });
 
+  it("deletes expired abandoned staged and sending attachment uploads", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-abandoned-upload-owner",
+      slug: "mvp-retention-abandoned-upload",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { conversationId } = await seedConversation(ctx, owner.businessId);
+      const expiredStagedStorageId = await storeTestBlob(ctx, "expired staged upload");
+      const expiredStagedPreviewStorageId = await storeTestBlob(
+        ctx,
+        "expired staged preview",
+        "image/png",
+      );
+      const expiredSendingStorageId = await storeTestBlob(ctx, "expired sending upload");
+      const freshStorageId = await storeTestBlob(ctx, "fresh staged upload");
+      const linkedStorageId = await storeTestBlob(ctx, "linked staged upload");
+      const linkedMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "outbound",
+        channel: "sms",
+        body: "linked message body",
+        status: "sent",
+        aiGenerated: false,
+      });
+
+      const expiredStagedUploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId: expiredStagedStorageId,
+        fileName: "expired-staged.txt",
+        contentType: "text/plain",
+        byteLength: 21,
+        previewStorageId: expiredStagedPreviewStorageId,
+        previewFileName: "expired-staged.png",
+        previewContentType: "image/png",
+        previewByteLength: 22,
+        deliveryMode: "link",
+        status: "staged",
+        expiresAt: EXPIRED_ISO,
+      });
+      const expiredSendingUploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId: expiredSendingStorageId,
+        fileName: "expired-sending.txt",
+        contentType: "text/plain",
+        byteLength: 22,
+        deliveryMode: "link",
+        status: "sending",
+        expiresAt: EXPIRED_ISO,
+      });
+      const freshUploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId: freshStorageId,
+        fileName: "fresh-staged.txt",
+        contentType: "text/plain",
+        byteLength: 18,
+        deliveryMode: "link",
+        status: "staged",
+        expiresAt: FRESH_ISO,
+      });
+      const linkedUploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId: linkedStorageId,
+        fileName: "linked-staged.txt",
+        contentType: "text/plain",
+        byteLength: 19,
+        deliveryMode: "link",
+        status: "staged",
+        expiresAt: EXPIRED_ISO,
+        sentMessageId: linkedMessageId,
+      });
+
+      return {
+        expiredSendingStorageId,
+        expiredSendingUploadId,
+        expiredStagedPreviewStorageId,
+        expiredStagedStorageId,
+        expiredStagedUploadId,
+        freshStorageId,
+        freshUploadId,
+        linkedStorageId,
+        linkedUploadId,
+      };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.abandonedMessageAttachmentUploads.deleted).toBe(2);
+    await t.run(async (ctx: TestRunCtx) => {
+      expect(await ctx.db.get(seeded.expiredStagedUploadId)).toBeNull();
+      expect(await ctx.db.get(seeded.expiredSendingUploadId)).toBeNull();
+      expect(await ctx.storage.get(seeded.expiredStagedStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.expiredStagedPreviewStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.expiredSendingStorageId)).toBeNull();
+
+      expect(await ctx.db.get(seeded.freshUploadId)).not.toBeNull();
+      expect(await ctx.storage.get(seeded.freshStorageId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.linkedUploadId)).not.toBeNull();
+      expect(await ctx.storage.get(seeded.linkedStorageId)).not.toBeNull();
+    });
+  });
+
   it("deletes expired transcripts, preview sessions, recordings, and standalone download tokens", async () => {
     const t = convexTest(schema, convexModules);
     const owner = await seedWorkspace(t, {

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -122,7 +122,7 @@ describe("MVP privacy retention", () => {
     );
   });
 
-  it("hides expired content from read paths before cleanup runs", async () => {
+  it("hides expired content after scheduled row-level retention runs", async () => {
     const t = convexTest(schema, convexModules);
     const owner = await seedWorkspace(t, {
       subject: "mvp-retention-read-guards-owner",
@@ -190,7 +190,7 @@ describe("MVP privacy retention", () => {
         nonce: "expired-read-guard-recording-token",
         expiresAt: FRESH_ISO,
       });
-      await ctx.db.insert("transcripts", {
+      const transcriptId = await ctx.db.insert("transcripts", {
         businessId: owner.businessId,
         callId,
         sequence: 1,
@@ -199,7 +199,7 @@ describe("MVP privacy retention", () => {
         final: true,
         expiresAt: EXPIRED_ISO,
       });
-      await ctx.db.insert("preview_sessions", {
+      const previewSessionId = await ctx.db.insert("preview_sessions", {
         businessId: owner.businessId,
         userId: owner.userId,
         prompt: "expired preview before cron",
@@ -210,7 +210,27 @@ describe("MVP privacy retention", () => {
       return {
         callId,
         conversationId,
+        messageId,
+        previewSessionId,
+        transcriptId,
       };
+    });
+
+    await t.mutation(internal.privacy.retention.scrubMessageContentAtExpiry, {
+      messageId: seeded.messageId,
+      expiresAt: EXPIRED_ISO,
+    });
+    await t.mutation(internal.privacy.retention.scrubCallRecordingAtExpiry, {
+      callId: seeded.callId,
+      expiresAt: EXPIRED_ISO,
+    });
+    await t.mutation(internal.privacy.retention.deleteTranscriptAtExpiry, {
+      transcriptId: seeded.transcriptId,
+      expiresAt: EXPIRED_ISO,
+    });
+    await t.mutation(internal.privacy.retention.deletePreviewSessionAtExpiry, {
+      previewSessionId: seeded.previewSessionId,
+      expiresAt: EXPIRED_ISO,
     });
 
     const thread = await owner.authed.query(api.dashboard.messages.getConversationThread, {
@@ -263,6 +283,58 @@ describe("MVP privacy retention", () => {
         streamId: "expired-read-guard-preview-stream",
       }),
     ).rejects.toThrow("Preview session not found.");
+  });
+
+  it("schedules row-level retention mutations when sensitive content is created", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-schedule-owner",
+      slug: "mvp-retention-schedule",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
+      const callId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-retention-schedule",
+        status: "completed",
+        startedAt: NOW_ISO,
+      });
+      const recordingStorageId = await storeTestBlob(ctx, "scheduled recording", "audio/wav");
+      return { callId, contactId, recordingStorageId };
+    });
+
+    await t.mutation(internal.conversations.webhooks.storeInboundMessage, {
+      businessId: owner.businessId,
+      contactId: seeded.contactId,
+      channel: "sms",
+      body: "message scheduled for retention",
+    });
+    await t.mutation(internal.voice.runtime.appendTranscriptSegment, {
+      businessId: owner.businessId,
+      callId: seeded.callId,
+      sequence: 1,
+      speaker: "caller",
+      text: "transcript scheduled for retention",
+      final: true,
+    });
+    await t.mutation(internal.voice.runtime.attachCallRecording, {
+      callId: seeded.callId,
+      recordingStorageId: seeded.recordingStorageId,
+      recordingContentType: "audio/wav",
+      recordingByteLength: 19,
+    });
+
+    const scheduledNames = await t.run(async (ctx: TestRunCtx) => {
+      const jobs = await ctx.db.system.query("_scheduled_functions").collect();
+      return jobs.map((job) => String(job.name));
+    });
+
+    expect(scheduledNames).toContain("privacy/retention:scrubMessageContentAtExpiry");
+    expect(scheduledNames).toContain("privacy/retention:deleteTranscriptAtExpiry");
+    expect(scheduledNames).toContain("privacy/retention:scrubCallRecordingAtExpiry");
   });
 
   it("scrubs expired message content and attachment storage while preserving fresh and legacy rows", async () => {

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -122,6 +122,132 @@ describe("MVP privacy retention", () => {
     );
   });
 
+  it("hides expired content from read paths before cleanup runs", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-read-guards-owner",
+      slug: "mvp-retention-read-guards",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
+      const messageStorageId = await storeTestBlob(ctx, "expired visible attachment");
+      const messageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        body: "expired body before cron",
+        status: "received",
+        aiGenerated: false,
+        media: [
+          {
+            storageId: messageStorageId,
+            fileName: "expired.txt",
+            contentType: "text/plain",
+            byteLength: 25,
+            deliveryMode: "link",
+          },
+        ],
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      await ctx.db.insert("message_attachment_download_tokens", {
+        businessId: owner.businessId,
+        messageId,
+        storageId: messageStorageId,
+        fileName: "expired.txt",
+        contentType: "text/plain",
+        disposition: "attachment",
+        nonce: "expired-read-guard-message-token",
+        expiresAt: FRESH_ISO,
+      });
+
+      const recordingStorageId = await storeTestBlob(ctx, "expired recording", "audio/wav");
+      const callId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-retention-read-guards",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+        recordingStorageId,
+        recordingContentType: "audio/wav",
+        recordingByteLength: 17,
+        recordingRetentionStatus: "active",
+        recordingExpiresAt: EXPIRED_ISO,
+      });
+      await ctx.db.insert("call_recording_download_tokens", {
+        businessId: owner.businessId,
+        callId,
+        storageId: recordingStorageId,
+        fileName: "expired-recording.wav",
+        contentType: "audio/wav",
+        nonce: "expired-read-guard-recording-token",
+        expiresAt: FRESH_ISO,
+      });
+      await ctx.db.insert("transcripts", {
+        businessId: owner.businessId,
+        callId,
+        sequence: 1,
+        speaker: "caller",
+        text: "expired transcript before cron",
+        final: true,
+        expiresAt: EXPIRED_ISO,
+      });
+      await ctx.db.insert("preview_sessions", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        prompt: "expired preview before cron",
+        streamId: "expired-read-guard-preview-stream",
+        expiresAt: EXPIRED_ISO,
+      });
+
+      return {
+        callId,
+        conversationId,
+      };
+    });
+
+    const thread = await owner.authed.query(api.dashboard.messages.getConversationThread, {
+      businessId: owner.businessId,
+      conversationId: seeded.conversationId,
+    });
+    expect(thread.messages[0]?.body).toBe(REDACTED_MESSAGE_BODY);
+    expect(thread.messages[0]?.attachments).toEqual([]);
+
+    await expect(
+      t.query(internal.dashboard.messages.getMessageAttachmentDownloadToken, {
+        token: "expired-read-guard-message-token",
+      }),
+    ).resolves.toBeNull();
+
+    const call = await owner.authed.query(api.voice.runtime.getCallForDashboard, {
+      businessId: owner.businessId,
+      callId: seeded.callId,
+    });
+    expect(call?.recordingUrl).toBeNull();
+    expect(call?.transcriptReady).toBe(false);
+    expect(call?.transcriptPreview).toBeNull();
+
+    await expect(
+      owner.authed.query(api.voice.runtime.getCallTranscript, {
+        businessId: owner.businessId,
+        callId: seeded.callId,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      t.query(internal.voice.runtime.getCallRecordingDownloadToken, {
+        token: "expired-read-guard-recording-token",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      owner.authed.query(api.ai.preview.stream.getPreviewBody, {
+        streamId: "expired-read-guard-preview-stream",
+      }),
+    ).rejects.toThrow("Preview session not found.");
+  });
+
   it("scrubs expired message content and attachment storage while preserving fresh and legacy rows", async () => {
     const t = convexTest(schema, convexModules);
     const owner = await seedWorkspace(t, {

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -122,7 +122,7 @@ describe("MVP privacy retention", () => {
     );
   });
 
-  it("hides expired content after scheduled row-level retention runs", async () => {
+  it("hides expired content from fresh reads when scheduled cleanup is late", async () => {
     const t = convexTest(schema, convexModules);
     const owner = await seedWorkspace(t, {
       subject: "mvp-retention-read-guards-owner",
@@ -216,23 +216,6 @@ describe("MVP privacy retention", () => {
       };
     });
 
-    await t.mutation(internal.privacy.retention.scrubMessageContentAtExpiry, {
-      messageId: seeded.messageId,
-      expiresAt: EXPIRED_ISO,
-    });
-    await t.mutation(internal.privacy.retention.scrubCallRecordingAtExpiry, {
-      callId: seeded.callId,
-      expiresAt: EXPIRED_ISO,
-    });
-    await t.mutation(internal.privacy.retention.deleteTranscriptAtExpiry, {
-      transcriptId: seeded.transcriptId,
-      expiresAt: EXPIRED_ISO,
-    });
-    await t.mutation(internal.privacy.retention.deletePreviewSessionAtExpiry, {
-      previewSessionId: seeded.previewSessionId,
-      expiresAt: EXPIRED_ISO,
-    });
-
     const thread = await owner.authed.query(api.dashboard.messages.getConversationThread, {
       businessId: owner.businessId,
       conversationId: seeded.conversationId,
@@ -283,6 +266,15 @@ describe("MVP privacy retention", () => {
         streamId: "expired-read-guard-preview-stream",
       }),
     ).rejects.toThrow("Preview session not found.");
+
+    await t.run(async (ctx: TestRunCtx) => {
+      const message = await ctx.db.get(seeded.messageId);
+      const call = await ctx.db.get(seeded.callId);
+      expect(message?.contentRetentionStatus).toBe("active");
+      expect(call?.recordingRetentionStatus).toBe("active");
+      expect(await ctx.db.get(seeded.transcriptId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.previewSessionId)).not.toBeNull();
+    });
   });
 
   it("schedules row-level retention mutations when sensitive content is created", async () => {

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -1,0 +1,564 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { getBillingKey } from "../lib/billing";
+import { REDACTED_MESSAGE_BODY } from "../privacy/retention";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+const convexModules = modules;
+const NOW_ISO = "2026-05-07T12:00:00.000Z";
+const EXPIRED_ISO = "2026-05-06T12:00:00.000Z";
+const FRESH_ISO = "2026-05-08T12:00:00.000Z";
+
+type ConvexHarness = TestConvex<typeof schema>;
+type TestRunCtx = Parameters<Parameters<ConvexHarness["run"]>[0]>[0];
+
+type WorkspaceSeed = {
+  authed: ReturnType<ConvexHarness["withIdentity"]>;
+  businessId: Id<"businesses">;
+  userId: Id<"users">;
+};
+
+async function seedWorkspace(
+  t: ConvexHarness,
+  input: {
+    subject: string;
+    slug: string;
+    role?: "business_owner" | "business_admin" | "scheduler" | "viewer";
+  },
+): Promise<WorkspaceSeed> {
+  const { businessId, userId } = await t.run(async (ctx: TestRunCtx) => {
+    const businessId = await ctx.db.insert("businesses", {
+      slug: input.slug,
+      name: "MVP Privacy Test Business",
+      timezone: "America/Toronto",
+      businessType: "clinic",
+      defaultLocale: "en",
+      deploymentMode: "cloud",
+      status: "active",
+    });
+    const userId = await ctx.db.insert("users", {
+      authSubject: input.subject,
+      email: `${input.subject}@example.com`,
+      displayName: "MVP Privacy Tester",
+    });
+    await ctx.db.insert("business_memberships", {
+      businessId,
+      userId,
+      role: input.role ?? "business_owner",
+      status: "active",
+    });
+
+    return { businessId, userId };
+  });
+
+  return {
+    authed: t.withIdentity({ subject: input.subject }),
+    businessId,
+    userId,
+  };
+}
+
+async function seedUserWithoutMembership(
+  t: ConvexHarness,
+  subject: string,
+): Promise<ReturnType<ConvexHarness["withIdentity"]>> {
+  await t.run(async (ctx: TestRunCtx) => {
+    await ctx.db.insert("users", {
+      authSubject: subject,
+      email: `${subject}@example.com`,
+      displayName: "Outside User",
+    });
+  });
+  return t.withIdentity({ subject });
+}
+
+async function seedConversation(ctx: TestRunCtx, businessId: Id<"businesses">) {
+  const contactId = await ctx.db.insert("contacts", {
+    businessId,
+    phone: "+14165550111",
+    name: "Taylor Customer",
+  });
+  const conversationId = await ctx.db.insert("conversations", {
+    businessId,
+    contactId,
+    channel: "sms",
+    status: "open",
+  });
+
+  return { contactId, conversationId };
+}
+
+async function storeTestBlob(
+  ctx: TestRunCtx,
+  contents: string,
+  contentType: string = "text/plain",
+): Promise<Id<"_storage">> {
+  return await ctx.storage.store(new Blob([contents], { type: contentType }));
+}
+
+describe("MVP privacy retention", () => {
+  it("scrubs expired message content and attachment storage while preserving fresh and legacy rows", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-messages-owner",
+      slug: "mvp-retention-messages",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { conversationId } = await seedConversation(ctx, owner.businessId);
+      const expiredStorageId = await storeTestBlob(ctx, "expired attachment", "text/plain");
+      const expiredPreviewStorageId = await storeTestBlob(ctx, "expired preview", "image/png");
+      const freshStorageId = await storeTestBlob(ctx, "fresh attachment", "text/plain");
+
+      const expiredMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        fromPhoneNumber: "+14165550001",
+        body: "old sensitive SMS body",
+        status: "received",
+        aiGenerated: false,
+        media: [
+          {
+            storageId: expiredStorageId,
+            fileName: "expired.txt",
+            contentType: "text/plain",
+            byteLength: 18,
+            previewStorageId: expiredPreviewStorageId,
+            previewFileName: "expired.png",
+            previewContentType: "image/png",
+            previewByteLength: 15,
+            deliveryMode: "link",
+          },
+        ],
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId: expiredStorageId,
+        fileName: "expired.txt",
+        contentType: "text/plain",
+        byteLength: 18,
+        previewStorageId: expiredPreviewStorageId,
+        previewFileName: "expired.png",
+        previewContentType: "image/png",
+        previewByteLength: 15,
+        deliveryMode: "link",
+        status: "sent",
+        sentMessageId: expiredMessageId,
+      });
+      const expiredTokenId = await ctx.db.insert("message_attachment_download_tokens", {
+        businessId: owner.businessId,
+        messageId: expiredMessageId,
+        storageId: expiredStorageId,
+        fileName: "expired.txt",
+        contentType: "text/plain",
+        disposition: "attachment",
+        nonce: "expired-message-token",
+        expiresAt: FRESH_ISO,
+      });
+
+      const freshMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        fromPhoneNumber: "+14165550002",
+        body: "fresh SMS body",
+        status: "received",
+        aiGenerated: false,
+        media: [
+          {
+            storageId: freshStorageId,
+            fileName: "fresh.txt",
+            contentType: "text/plain",
+            byteLength: 16,
+            deliveryMode: "link",
+          },
+        ],
+        contentRetentionStatus: "active",
+        contentExpiresAt: FRESH_ISO,
+      });
+      const legacyMessageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        body: "legacy body without retention fields",
+        status: "received",
+        aiGenerated: false,
+      });
+
+      return {
+        expiredMessageId,
+        expiredStorageId,
+        expiredPreviewStorageId,
+        expiredTokenId,
+        freshMessageId,
+        freshStorageId,
+        legacyMessageId,
+      };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.messages.scrubbed).toBe(1);
+    await t.run(async (ctx: TestRunCtx) => {
+      const expiredMessage = await ctx.db.get(seeded.expiredMessageId);
+      const freshMessage = await ctx.db.get(seeded.freshMessageId);
+      const legacyMessage = await ctx.db.get(seeded.legacyMessageId);
+
+      expect(expiredMessage).toMatchObject({
+        body: REDACTED_MESSAGE_BODY,
+        contentRetentionStatus: "expired",
+      });
+      expect(expiredMessage?.media).toBeUndefined();
+      expect(expiredMessage?.fromPhoneNumber).toBeUndefined();
+      expect(await ctx.db.get(seeded.expiredTokenId)).toBeNull();
+      expect(await ctx.storage.get(seeded.expiredStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.expiredPreviewStorageId)).toBeNull();
+      expect(
+        await ctx.db
+          .query("message_attachment_uploads")
+          .withIndex("by_sent_message_id", (q) =>
+            q.eq("sentMessageId", seeded.expiredMessageId),
+          )
+          .take(1),
+      ).toHaveLength(0);
+
+      expect(freshMessage?.body).toBe("fresh SMS body");
+      expect(freshMessage?.media).toHaveLength(1);
+      expect(await ctx.storage.get(seeded.freshStorageId)).not.toBeNull();
+      expect(legacyMessage?.body).toBe("legacy body without retention fields");
+    });
+  });
+
+  it("deletes expired transcripts, preview sessions, recordings, and standalone download tokens", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-voice-owner",
+      slug: "mvp-retention-voice",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
+      const expiredRecordingStorageId = await storeTestBlob(ctx, "expired recording", "audio/wav");
+      const freshRecordingStorageId = await storeTestBlob(ctx, "fresh recording", "audio/wav");
+      const expiredCallId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-retention-expired",
+        status: "completed",
+        startedAt: "2026-01-01T12:00:00.000Z",
+        recordingStorageId: expiredRecordingStorageId,
+        recordingContentType: "audio/wav",
+        recordingByteLength: 17,
+        recordingDurationMs: 12000,
+        recordingRetentionStatus: "active",
+        recordingExpiresAt: EXPIRED_ISO,
+      });
+      const freshCallId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-retention-fresh",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+        recordingStorageId: freshRecordingStorageId,
+        recordingContentType: "audio/wav",
+        recordingByteLength: 15,
+        recordingDurationMs: 8000,
+        recordingRetentionStatus: "active",
+        recordingExpiresAt: FRESH_ISO,
+      });
+      const expiredRecordingTokenId = await ctx.db.insert("call_recording_download_tokens", {
+        businessId: owner.businessId,
+        callId: expiredCallId,
+        storageId: expiredRecordingStorageId,
+        fileName: "expired.wav",
+        contentType: "audio/wav",
+        nonce: "expired-recording-token",
+        expiresAt: FRESH_ISO,
+      });
+      const standaloneMessageTokenId = await ctx.db.insert("message_attachment_download_tokens", {
+        businessId: owner.businessId,
+        messageId: await ctx.db.insert("messages", {
+          businessId: owner.businessId,
+          conversationId,
+          direction: "inbound",
+          channel: "sms",
+          body: "token owner",
+          status: "received",
+          aiGenerated: false,
+        }),
+        storageId: await storeTestBlob(ctx, "standalone token storage"),
+        fileName: "standalone.txt",
+        contentType: "text/plain",
+        disposition: "attachment",
+        nonce: "standalone-message-token",
+        expiresAt: EXPIRED_ISO,
+      });
+      const standaloneRecordingTokenId = await ctx.db.insert("call_recording_download_tokens", {
+        businessId: owner.businessId,
+        callId: freshCallId,
+        storageId: freshRecordingStorageId,
+        fileName: "standalone-recording.wav",
+        contentType: "audio/wav",
+        nonce: "standalone-recording-token",
+        expiresAt: EXPIRED_ISO,
+      });
+      const expiredTranscriptId = await ctx.db.insert("transcripts", {
+        businessId: owner.businessId,
+        callId: expiredCallId,
+        sequence: 1,
+        speaker: "caller",
+        text: "old transcript",
+        final: true,
+        expiresAt: EXPIRED_ISO,
+      });
+      const freshTranscriptId = await ctx.db.insert("transcripts", {
+        businessId: owner.businessId,
+        callId: freshCallId,
+        sequence: 1,
+        speaker: "caller",
+        text: "fresh transcript",
+        final: true,
+        expiresAt: FRESH_ISO,
+      });
+      const legacyTranscriptId = await ctx.db.insert("transcripts", {
+        businessId: owner.businessId,
+        callId: freshCallId,
+        sequence: 2,
+        speaker: "agent",
+        text: "legacy transcript",
+        final: true,
+      });
+      const expiredPreviewSessionId = await ctx.db.insert("preview_sessions", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        prompt: "old preview",
+        streamId: "stream-old",
+        expiresAt: EXPIRED_ISO,
+      });
+      const freshPreviewSessionId = await ctx.db.insert("preview_sessions", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        prompt: "fresh preview",
+        streamId: "stream-fresh",
+        expiresAt: FRESH_ISO,
+      });
+      const legacyPreviewSessionId = await ctx.db.insert("preview_sessions", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        prompt: "legacy preview",
+        streamId: "stream-legacy",
+      });
+
+      return {
+        expiredCallId,
+        freshCallId,
+        expiredRecordingStorageId,
+        freshRecordingStorageId,
+        expiredRecordingTokenId,
+        standaloneMessageTokenId,
+        standaloneRecordingTokenId,
+        expiredTranscriptId,
+        freshTranscriptId,
+        legacyTranscriptId,
+        expiredPreviewSessionId,
+        freshPreviewSessionId,
+        legacyPreviewSessionId,
+      };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.transcripts.deleted).toBe(1);
+    expect(summary.callRecordings.scrubbed).toBe(1);
+    expect(summary.previewSessions.deleted).toBe(1);
+    expect(summary.messageAttachmentDownloadTokens.deleted).toBe(1);
+    await t.run(async (ctx: TestRunCtx) => {
+      const expiredCall = await ctx.db.get(seeded.expiredCallId);
+      const freshCall = await ctx.db.get(seeded.freshCallId);
+
+      expect(expiredCall?.recordingRetentionStatus).toBe("expired");
+      expect(expiredCall?.recordingStorageId).toBeUndefined();
+      expect(expiredCall?.recordingContentType).toBeUndefined();
+      expect(expiredCall?.recordingByteLength).toBeUndefined();
+      expect(expiredCall?.recordingDurationMs).toBeUndefined();
+      expect(await ctx.storage.get(seeded.expiredRecordingStorageId)).toBeNull();
+      expect(await ctx.db.get(seeded.expiredRecordingTokenId)).toBeNull();
+
+      expect(freshCall?.recordingStorageId).toBe(seeded.freshRecordingStorageId);
+      expect(await ctx.storage.get(seeded.freshRecordingStorageId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.standaloneMessageTokenId)).toBeNull();
+      expect(await ctx.db.get(seeded.standaloneRecordingTokenId)).toBeNull();
+
+      expect(await ctx.db.get(seeded.expiredTranscriptId)).toBeNull();
+      expect(await ctx.db.get(seeded.freshTranscriptId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.legacyTranscriptId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.expiredPreviewSessionId)).toBeNull();
+      expect(await ctx.db.get(seeded.freshPreviewSessionId)).not.toBeNull();
+      expect(await ctx.db.get(seeded.legacyPreviewSessionId)).not.toBeNull();
+    });
+  });
+});
+
+describe("MVP tenant access boundaries", () => {
+  it("rejects non-members across high-risk public business data functions", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-access-owner",
+      slug: "mvp-access-owner",
+    });
+    const outsider = await seedUserWithoutMembership(t, "mvp-access-outsider");
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { contactId, conversationId } = await seedConversation(ctx, owner.businessId);
+      await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "inbound",
+        channel: "sms",
+        body: "tenant-private message",
+        status: "received",
+        aiGenerated: false,
+      });
+      const callId = await ctx.db.insert("calls", {
+        businessId: owner.businessId,
+        conversationId,
+        contactId,
+        twilioCallSid: "CA-mvp-access",
+        status: "completed",
+        startedAt: "2026-05-01T12:00:00.000Z",
+      });
+      await ctx.db.insert("transcripts", {
+        businessId: owner.businessId,
+        callId,
+        sequence: 1,
+        speaker: "caller",
+        text: "tenant-private transcript",
+        final: true,
+      });
+      await ctx.db.insert("knowledge_documents", {
+        businessId: owner.businessId,
+        sourceType: "manual",
+        title: "Tenant-private policy",
+        textContent: "Private knowledge",
+        status: "ready",
+        tags: [],
+        importance: 75,
+      });
+      await ctx.db.insert("knowledge_snippets", {
+        businessId: owner.businessId,
+        title: "Tenant-private snippet",
+        content: "Private snippet",
+        tags: [],
+        priority: 10,
+        active: true,
+      });
+      await ctx.db.insert("calendar_connections", {
+        businessId: owner.businessId,
+        provider: "google",
+        ownerUserId: owner.userId,
+        externalAccountId: "google-account",
+        externalAccountEmail: "calendar@example.com",
+        selectedCalendarId: "primary",
+        selectedCalendarSummary: "Primary",
+        status: "connected",
+      });
+      await ctx.db.insert("billing_accounts", {
+        businessId: owner.businessId,
+        billingKey: getBillingKey(owner.businessId),
+        currentPlan: "pro",
+        activeAddons: ["ai_sms"],
+        subscriptionState: "active",
+        billingContactEmail: "owner@example.com",
+        billingContactName: "Owner",
+        lastSyncedAt: NOW_ISO,
+      });
+
+      return { contactId, conversationId, callId };
+    });
+
+    await expect(
+      owner.authed.query(api.dashboard.messages.getConversationThread, {
+        businessId: owner.businessId,
+        conversationId: seeded.conversationId,
+      }),
+    ).resolves.toMatchObject({
+      conversation: expect.objectContaining({ id: seeded.conversationId }),
+    });
+
+    const denied = "You do not have access to this business.";
+    await expect(
+      outsider.query(api.dashboard.overview.getHomeSummary, {
+        businessId: owner.businessId,
+        locale: "en",
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.dashboard.messages.listConversationSummaries, {
+        businessId: owner.businessId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.dashboard.messages.getConversationThread, {
+        businessId: owner.businessId,
+        conversationId: seeded.conversationId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.dashboard.contacts.listContacts, {
+        businessId: owner.businessId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.dashboard.contacts.getContactDetail, {
+        businessId: owner.businessId,
+        contactId: seeded.contactId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.voice.runtime.listRecentCalls, {
+        businessId: owner.businessId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.voice.runtime.getCallTranscript, {
+        businessId: owner.businessId,
+        callId: seeded.callId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.ai.context.knowledge.listKnowledge, {
+        businessId: owner.businessId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.integrations.calendar.listCalendarConnections, {
+        businessId: owner.businessId,
+      }),
+    ).rejects.toThrow(denied);
+    await expect(
+      outsider.query(api.billing.getStatus, {
+        businessId: owner.businessId,
+      }),
+    ).rejects.toThrow(denied);
+  });
+});

--- a/convex/tests/mvpPrivacyRetention.test.ts
+++ b/convex/tests/mvpPrivacyRetention.test.ts
@@ -251,6 +251,92 @@ describe("MVP privacy retention", () => {
     });
   });
 
+  it("scrubs expired attachment messages when consumed upload blobs are already gone", async () => {
+    const t = convexTest(schema, convexModules);
+    const owner = await seedWorkspace(t, {
+      subject: "mvp-retention-consumed-upload-owner",
+      slug: "mvp-retention-consumed-upload",
+    });
+
+    const seeded = await t.run(async (ctx: TestRunCtx) => {
+      const { conversationId } = await seedConversation(ctx, owner.businessId);
+      const sentStorageId = await storeTestBlob(ctx, "sent attachment clone");
+      const sentPreviewStorageId = await storeTestBlob(ctx, "sent preview clone", "image/png");
+      const consumedStorageId = await storeTestBlob(ctx, "already deleted upload");
+      const consumedPreviewStorageId = await storeTestBlob(
+        ctx,
+        "already deleted preview",
+        "image/png",
+      );
+      await ctx.storage.delete(consumedStorageId);
+      await ctx.storage.delete(consumedPreviewStorageId);
+
+      const messageId = await ctx.db.insert("messages", {
+        businessId: owner.businessId,
+        conversationId,
+        direction: "outbound",
+        channel: "sms",
+        body: "old outbound attachment body",
+        status: "sent",
+        aiGenerated: false,
+        media: [
+          {
+            storageId: sentStorageId,
+            fileName: "sent.txt",
+            contentType: "text/plain",
+            byteLength: 21,
+            previewStorageId: sentPreviewStorageId,
+            previewFileName: "sent.png",
+            previewContentType: "image/png",
+            previewByteLength: 18,
+            deliveryMode: "link",
+          },
+        ],
+        contentRetentionStatus: "active",
+        contentExpiresAt: EXPIRED_ISO,
+      });
+      const uploadId = await ctx.db.insert("message_attachment_uploads", {
+        businessId: owner.businessId,
+        conversationId,
+        uploaderUserId: owner.userId,
+        storageId: consumedStorageId,
+        fileName: "original.txt",
+        contentType: "text/plain",
+        byteLength: 22,
+        previewStorageId: consumedPreviewStorageId,
+        previewFileName: "original.png",
+        previewContentType: "image/png",
+        previewByteLength: 21,
+        deliveryMode: "link",
+        status: "consumed",
+        sentMessageId: messageId,
+      });
+
+      return {
+        messageId,
+        sentPreviewStorageId,
+        sentStorageId,
+        uploadId,
+      };
+    });
+
+    const summary = await t.action(internal.privacy.retention.runMvpRetentionCleanup, {
+      nowIso: NOW_ISO,
+      limit: 100,
+    });
+
+    expect(summary.messages.scrubbed).toBe(1);
+    await t.run(async (ctx: TestRunCtx) => {
+      const message = await ctx.db.get(seeded.messageId);
+      expect(message?.body).toBe(REDACTED_MESSAGE_BODY);
+      expect(message?.contentRetentionStatus).toBe("expired");
+      expect(message?.media).toBeUndefined();
+      expect(await ctx.db.get(seeded.uploadId)).toBeNull();
+      expect(await ctx.storage.get(seeded.sentStorageId)).toBeNull();
+      expect(await ctx.storage.get(seeded.sentPreviewStorageId)).toBeNull();
+    });
+  });
+
   it("deletes expired transcripts, preview sessions, recordings, and standalone download tokens", async () => {
     const t = convexTest(schema, convexModules);
     const owner = await seedWorkspace(t, {
@@ -467,6 +553,18 @@ describe("MVP privacy retention", () => {
         relatedId: String(callId),
         status: "open",
       });
+      const deliveryId = await ctx.db.insert("operator_notification_deliveries", {
+        businessId: owner.businessId,
+        userId: owner.userId,
+        eventKind: "voiceMessage",
+        eventKey: `voiceMessage:${String(inboxItemId)}`,
+        channel: "sms",
+        status: "sent",
+        subject: "Voice message from Taylor Customer",
+        body: "Callback: +14165551212\n\nold voice message body",
+        sentAt: "2026-05-01T12:00:00.000Z",
+        createdAt: "2026-05-01T12:00:00.000Z",
+      });
       await ctx.db.patch(conversationId, {
         currentIntent: "message_taking",
         summary: "Callback: +14165551212\n\nold voice message body",
@@ -486,6 +584,7 @@ describe("MVP privacy retention", () => {
 
       return {
         conversationId,
+        deliveryId,
         inboxItemId,
         messageId,
         sessionId,
@@ -501,6 +600,7 @@ describe("MVP privacy retention", () => {
     await t.run(async (ctx: TestRunCtx) => {
       const message = await ctx.db.get(seeded.messageId);
       const conversation = await ctx.db.get(seeded.conversationId);
+      const delivery = await ctx.db.get(seeded.deliveryId);
       const session = await ctx.db.get(seeded.sessionId);
       const inboxItem = await ctx.db.get(seeded.inboxItemId);
 
@@ -509,6 +609,8 @@ describe("MVP privacy retention", () => {
       expect(session?.summary?.summary).toBe(REDACTED_MESSAGE_BODY);
       expect(inboxItem?.title).toBe("Expired voice message");
       expect(inboxItem?.body).toBe(REDACTED_MESSAGE_BODY);
+      expect(delivery?.subject).toBe("Expired voice message");
+      expect(delivery?.body).toBe(REDACTED_MESSAGE_BODY);
     });
   });
 

--- a/convex/vitest.config.ts
+++ b/convex/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
     environment: "edge-runtime",
     include: ["**/*.test.ts"],
     exclude: ["dist/**", "**/dist/**", "node_modules/**"],
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/convex/vitest.setup.ts
+++ b/convex/vitest.setup.ts
@@ -1,0 +1,34 @@
+import { afterAll } from "vitest";
+
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
+const nativeSetTimeout = globalThis.setTimeout;
+const nativeClearTimeout = globalThis.clearTimeout;
+const syntheticLongTimerIds = new Set<number>();
+let nextSyntheticLongTimerId = -1;
+
+// Convex can schedule functions years out, but convex-test uses Node timers.
+// Leave those long scheduled functions pending in tests instead of overflowing.
+globalThis.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+  const [, timeout] = args;
+  if (typeof timeout === "number" && timeout > MAX_NODE_TIMER_DELAY_MS) {
+    const timerId = nextSyntheticLongTimerId;
+    nextSyntheticLongTimerId -= 1;
+    syntheticLongTimerIds.add(timerId);
+    return timerId as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  return nativeSetTimeout(...args);
+}) as typeof setTimeout;
+
+globalThis.clearTimeout = ((timerId?: Parameters<typeof clearTimeout>[0]) => {
+  if (typeof timerId === "number" && syntheticLongTimerIds.delete(timerId)) {
+    return;
+  }
+
+  return nativeClearTimeout(timerId);
+}) as typeof clearTimeout;
+
+afterAll(() => {
+  globalThis.setTimeout = nativeSetTimeout;
+  globalThis.clearTimeout = nativeClearTimeout;
+});

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -45,7 +45,9 @@ import {
   getMessageContentExpiresAt,
   getSensitiveContentExpiresAt,
   isCallRecordingExpired,
-  isTranscriptExpired,
+  scheduleCallRecordingExpiration,
+  scheduleMessageContentExpiration,
+  scheduleTranscriptExpiration,
 } from "../privacy/retention";
 
 import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
@@ -382,9 +384,7 @@ async function hydrateDashboardCallRow(
         };
       })()
     : call;
-  const visibleTranscriptPreview = transcriptPreview.find(
-    (transcript) => !isTranscriptExpired(transcript),
-  );
+  const visibleTranscriptPreview = transcriptPreview[0];
 
   return {
     ...callForDashboard,
@@ -746,17 +746,22 @@ export const appendTranscriptSegment = internalMutation({
       .unique();
 
     if (existing) {
+      const expiresAt = existing.expiresAt ?? getSensitiveContentExpiresAt();
       await ctx.db.patch(existing._id, {
         speaker: args.speaker,
         text: args.text,
         final: args.final,
         ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
-        expiresAt: existing.expiresAt ?? getSensitiveContentExpiresAt(),
+        expiresAt,
       });
+      if (!existing.expiresAt) {
+        await scheduleTranscriptExpiration(ctx, existing._id, expiresAt);
+      }
       return existing._id;
     }
 
-    return await ctx.db.insert("transcripts", {
+    const expiresAt = getSensitiveContentExpiresAt();
+    const transcriptId = await ctx.db.insert("transcripts", {
       businessId: args.businessId,
       callId: args.callId,
       sequence: args.sequence,
@@ -764,8 +769,10 @@ export const appendTranscriptSegment = internalMutation({
       text: args.text,
       final: args.final,
       ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
-      expiresAt: getSensitiveContentExpiresAt(),
+      expiresAt,
     });
+    await scheduleTranscriptExpiration(ctx, transcriptId, expiresAt);
+    return transcriptId;
   },
 });
 
@@ -971,6 +978,7 @@ export const takeMessageForVoice = internalMutation({
     });
 
     if (args.conversationId) {
+      const contentExpiresAt = getMessageContentExpiresAt();
       const messageId = await ctx.db.insert("messages", {
         businessId: args.businessId,
         conversationId: args.conversationId,
@@ -980,8 +988,9 @@ export const takeMessageForVoice = internalMutation({
         status: "captured",
         aiGenerated: false,
         contentRetentionStatus: "active",
-        contentExpiresAt: getMessageContentExpiresAt(),
+        contentExpiresAt,
       });
+      await scheduleMessageContentExpiration(ctx, messageId, contentExpiresAt);
       await ensureSessionForStoredMessage(ctx, {
         businessId: args.businessId,
         conversationId: args.conversationId,
@@ -1030,6 +1039,7 @@ export const attachCallRecording = internalMutation({
       await ctx.db.delete(token._id);
     }
 
+    const recordingExpiresAt = getCallRecordingExpiresAt();
     await ctx.db.patch(args.callId, {
       recordingStorageId: args.recordingStorageId,
       recordingContentType: args.recordingContentType,
@@ -1038,8 +1048,9 @@ export const attachCallRecording = internalMutation({
         ? { recordingDurationMs: args.recordingDurationMs }
         : {}),
       recordingRetentionStatus: "active",
-      recordingExpiresAt: getCallRecordingExpiresAt(),
+      recordingExpiresAt,
     });
+    await scheduleCallRecordingExpiration(ctx, args.callId, recordingExpiresAt);
 
     await ctx.db.insert("call_recording_download_tokens", {
       businessId: call.businessId,
@@ -1864,6 +1875,6 @@ export const getCallTranscript = query({
       .withIndex("by_call_id_and_sequence", (q) => q.eq("callId", args.callId))
       .order("asc")
       .collect();
-    return transcripts.filter((transcript) => !isTranscriptExpired(transcript));
+    return transcripts;
   },
 });

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -40,6 +40,7 @@ import {
   ensureVoiceSessionForCall,
   finalizeVoiceSessionForCall,
 } from "../conversations/sessions";
+import { getSensitiveContentExpiresAt } from "../privacy/retention";
 
 import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 type BusinessIdArgs = { businessId: Id<"businesses"> };
@@ -730,6 +731,7 @@ export const appendTranscriptSegment = internalMutation({
         text: args.text,
         final: args.final,
         ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
+        expiresAt: existing.expiresAt ?? getSensitiveContentExpiresAt(),
       });
       return existing._id;
     }
@@ -742,6 +744,7 @@ export const appendTranscriptSegment = internalMutation({
       text: args.text,
       final: args.final,
       ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
+      expiresAt: getSensitiveContentExpiresAt(),
     });
   },
 });
@@ -956,6 +959,8 @@ export const takeMessageForVoice = internalMutation({
         body: args.message,
         status: "captured",
         aiGenerated: false,
+        contentRetentionStatus: "active",
+        contentExpiresAt: getSensitiveContentExpiresAt(),
       });
       await ensureSessionForStoredMessage(ctx, {
         businessId: args.businessId,
@@ -1012,6 +1017,8 @@ export const attachCallRecording = internalMutation({
       ...(args.recordingDurationMs !== undefined
         ? { recordingDurationMs: args.recordingDurationMs }
         : {}),
+      recordingRetentionStatus: "active",
+      recordingExpiresAt: getSensitiveContentExpiresAt(),
     });
 
     await ctx.db.insert("call_recording_download_tokens", {

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -45,6 +45,7 @@ import {
   getMessageContentExpiresAt,
   getSensitiveContentExpiresAt,
   isCallRecordingExpired,
+  isTranscriptExpired,
   scheduleCallRecordingExpiration,
   scheduleMessageContentExpiration,
   scheduleTranscriptExpiration,
@@ -384,7 +385,9 @@ async function hydrateDashboardCallRow(
         };
       })()
     : call;
-  const visibleTranscriptPreview = transcriptPreview[0];
+  const visibleTranscriptPreview = transcriptPreview.find(
+    (transcript) => !isTranscriptExpired(transcript),
+  );
 
   return {
     ...callForDashboard,
@@ -1875,6 +1878,6 @@ export const getCallTranscript = query({
       .withIndex("by_call_id_and_sequence", (q) => q.eq("callId", args.callId))
       .order("asc")
       .collect();
-    return transcripts;
+    return transcripts.filter((transcript) => !isTranscriptExpired(transcript));
   },
 });

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -44,9 +44,12 @@ import {
   getCallRecordingExpiresAt,
   getMessageContentExpiresAt,
   getSensitiveContentExpiresAt,
+  getVisibleInboxItemBody,
+  getVisibleInboxItemTitle,
   isCallRecordingExpired,
   isTranscriptExpired,
   scheduleCallRecordingExpiration,
+  scheduleInboxItemContentExpiration,
   scheduleMessageContentExpiration,
   scheduleTranscriptExpiration,
 } from "../privacy/retention";
@@ -403,8 +406,8 @@ async function hydrateDashboardCallRow(
     followUpTask: followUpTask
       ? {
           id: followUpTask._id,
-          title: followUpTask.title,
-          body: followUpTask.body,
+          title: getVisibleInboxItemTitle(followUpTask),
+          body: getVisibleInboxItemBody(followUpTask),
           createdAt: new Date(followUpTask._creationTime).toISOString(),
         }
       : null,
@@ -970,6 +973,7 @@ export const takeMessageForVoice = internalMutation({
     ]
       .filter((line): line is string => Boolean(line))
       .join("\n");
+    const contentExpiresAt = getMessageContentExpiresAt();
 
     const inboxItemId = await ctx.db.insert("inbox_items", {
       businessId: args.businessId,
@@ -978,10 +982,12 @@ export const takeMessageForVoice = internalMutation({
       body,
       relatedId: String(args.callId),
       status: "open",
+      contentRetentionStatus: "active",
+      contentExpiresAt,
     });
+    await scheduleInboxItemContentExpiration(ctx, inboxItemId, contentExpiresAt);
 
     if (args.conversationId) {
-      const contentExpiresAt = getMessageContentExpiresAt();
       const messageId = await ctx.db.insert("messages", {
         businessId: args.businessId,
         conversationId: args.conversationId,
@@ -1805,8 +1811,8 @@ export const getVoiceFollowUpTaskForDashboard = query({
 
     return {
       id: inboxItem._id,
-      title: inboxItem.title,
-      body: inboxItem.body,
+      title: getVisibleInboxItemTitle(inboxItem),
+      body: getVisibleInboxItemBody(inboxItem),
       createdAt: new Date(inboxItem._creationTime).toISOString(),
       callId: inboxItem.relatedId ? (inboxItem.relatedId as Id<"calls">) : null,
     };

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -371,14 +371,23 @@ async function hydrateDashboardCallRow(
   )[0] ?? null;
   const hasActiveRecordingToken =
     recordingToken !== null && Date.parse(recordingToken.expiresAt) >= Date.now();
-  const recordingAvailable =
-    call.recordingStorageId !== undefined && !isCallRecordingExpired(call);
+  const recordingExpired = isCallRecordingExpired(call);
+  const recordingAvailable = call.recordingStorageId !== undefined && !recordingExpired;
+  const callForDashboard = recordingExpired
+    ? (() => {
+        const { recordingStorageId: _recordingStorageId, ...rest } = call;
+        return {
+          ...rest,
+          recordingRetentionStatus: "expired" as const,
+        };
+      })()
+    : call;
   const visibleTranscriptPreview = transcriptPreview.find(
     (transcript) => !isTranscriptExpired(transcript),
   );
 
   return {
-    ...call,
+    ...callForDashboard,
     recordingUrl: recordingAvailable
       ? hasActiveRecordingToken
         ? buildCallRecordingDownloadUrl(recordingToken.nonce)

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -44,6 +44,8 @@ import {
   getCallRecordingExpiresAt,
   getMessageContentExpiresAt,
   getSensitiveContentExpiresAt,
+  isCallRecordingExpired,
+  isTranscriptExpired,
 } from "../privacy/retention";
 
 import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
@@ -369,16 +371,21 @@ async function hydrateDashboardCallRow(
   )[0] ?? null;
   const hasActiveRecordingToken =
     recordingToken !== null && Date.parse(recordingToken.expiresAt) >= Date.now();
+  const recordingAvailable =
+    call.recordingStorageId !== undefined && !isCallRecordingExpired(call);
+  const visibleTranscriptPreview = transcriptPreview.find(
+    (transcript) => !isTranscriptExpired(transcript),
+  );
 
   return {
     ...call,
-    recordingUrl: call.recordingStorageId
+    recordingUrl: recordingAvailable
       ? hasActiveRecordingToken
         ? buildCallRecordingDownloadUrl(recordingToken.nonce)
-        : await ctx.storage.getUrl(call.recordingStorageId)
+        : await ctx.storage.getUrl(call.recordingStorageId!)
       : null,
-    transcriptReady: transcriptPreview.length > 0,
-    transcriptPreview: transcriptPreview[0]?.text ?? null,
+    transcriptReady: visibleTranscriptPreview !== undefined,
+    transcriptPreview: visibleTranscriptPreview?.text ?? null,
     contactName: contact?.name ?? null,
     contactPhone: contact?.phone ?? null,
     followUpTask: followUpTask
@@ -1044,10 +1051,20 @@ export const getCallRecordingDownloadToken = internalQuery({
     token: v.string(),
   },
   handler: async (ctx: QueryCtx, args) => {
-    return await ctx.db
+    const token = await ctx.db
       .query("call_recording_download_tokens")
       .withIndex("by_nonce", (q) => q.eq("nonce", args.token))
       .unique();
+    if (!token) {
+      return null;
+    }
+
+    const call = await ctx.db.get(token.callId);
+    if (!call || isCallRecordingExpired(call)) {
+      return null;
+    }
+
+    return token;
   },
 });
 
@@ -1833,10 +1850,11 @@ export const getCallTranscript = query({
       throw new Error("Call not found.");
     }
 
-    return await ctx.db
+    const transcripts = await ctx.db
       .query("transcripts")
       .withIndex("by_call_id_and_sequence", (q) => q.eq("callId", args.callId))
       .order("asc")
       .collect();
+    return transcripts.filter((transcript) => !isTranscriptExpired(transcript));
   },
 });

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -381,7 +381,13 @@ async function hydrateDashboardCallRow(
   const recordingAvailable = call.recordingStorageId !== undefined && !recordingExpired;
   const callForDashboard = recordingExpired
     ? (() => {
-        const { recordingStorageId: _recordingStorageId, ...rest } = call;
+        const {
+          recordingStorageId: _recordingStorageId,
+          recordingContentType: _recordingContentType,
+          recordingByteLength: _recordingByteLength,
+          recordingDurationMs: _recordingDurationMs,
+          ...rest
+        } = call;
         return {
           ...rest,
           recordingRetentionStatus: "expired" as const,

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -40,7 +40,11 @@ import {
   ensureVoiceSessionForCall,
   finalizeVoiceSessionForCall,
 } from "../conversations/sessions";
-import { getSensitiveContentExpiresAt } from "../privacy/retention";
+import {
+  getCallRecordingExpiresAt,
+  getMessageContentExpiresAt,
+  getSensitiveContentExpiresAt,
+} from "../privacy/retention";
 
 import { observedInternalAction as internalAction } from "../telemetry/observedFunctions";
 type BusinessIdArgs = { businessId: Id<"businesses"> };
@@ -960,7 +964,7 @@ export const takeMessageForVoice = internalMutation({
         status: "captured",
         aiGenerated: false,
         contentRetentionStatus: "active",
-        contentExpiresAt: getSensitiveContentExpiresAt(),
+        contentExpiresAt: getMessageContentExpiresAt(),
       });
       await ensureSessionForStoredMessage(ctx, {
         businessId: args.businessId,
@@ -1018,7 +1022,7 @@ export const attachCallRecording = internalMutation({
         ? { recordingDurationMs: args.recordingDurationMs }
         : {}),
       recordingRetentionStatus: "active",
-      recordingExpiresAt: getSensitiveContentExpiresAt(),
+      recordingExpiresAt: getCallRecordingExpiresAt(),
     });
 
     await ctx.db.insert("call_recording_download_tokens", {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "overrides": {
       "@hono/node-server": "1.19.13",
       "@xmldom/xmldom": "0.8.13",
-      "axios": "1.15.0",
+      "axios": "1.15.2",
       "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
       "dompurify": "3.4.0",
       "follow-redirects": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@convex-dev/agent": "latest",
     "@convex-dev/auth": "latest",
     "@convex-dev/crons": "latest",
-    "@convex-dev/persistent-text-streaming": "latest",
+    "@convex-dev/persistent-text-streaming": "0.3.2",
     "@convex-dev/polar": "^0.9.0",
     "@convex-dev/rag": "latest",
     "@convex-dev/rate-limiter": "^0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: latest
         version: 0.2.0(convex@1.34.1(react@19.2.4))
       '@convex-dev/persistent-text-streaming':
-        specifier: latest
-        version: 0.3.0(convex@1.34.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.3.2
+        version: 0.3.2(@standard-schema/spec@1.1.0)(convex@1.34.1(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       '@convex-dev/polar':
         specifier: ^0.9.0
         version: 0.9.0(@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@polar-sh/sdk@0.47.0)(@standard-schema/spec@1.1.0)(convex@1.34.1(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
@@ -202,8 +202,8 @@ importers:
         specifier: latest
         version: 0.0.91(@auth/core@0.37.4)(convex@1.34.1(react@19.2.4))(react@19.2.4)
       '@convex-dev/persistent-text-streaming':
-        specifier: latest
-        version: 0.3.0(convex@1.34.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.3.2
+        version: 0.3.2(@standard-schema/spec@1.1.0)(convex@1.34.1(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -660,10 +660,10 @@ packages:
     peerDependencies:
       convex: ^1.24.8
 
-  '@convex-dev/persistent-text-streaming@0.3.0':
-    resolution: {integrity: sha512-y7CteewFHrBKhVSoLxTMEwWPEmc/3J+BTJ+x+8pvh5DCUlwN80eWmfojpmGOQr7xSc6UC/c7DxlZXQPN7dVlKg==}
+  '@convex-dev/persistent-text-streaming@0.3.2':
+    resolution: {integrity: sha512-lTLcrwB5AcT+Y9LBuOf6CFZKkfN2XuiuWzs9ZHmYcivAn9R9l/AT0X3RxkByxkO01+gsk/s1o4yc3qPD/qi4fg==}
     peerDependencies:
-      convex: ^1.24.8
+      convex: ^1.32.0
       react: ~18.3.1 || ^19.0.0
       react-dom: ~18.3.1 || ^19.0.0
 
@@ -8413,11 +8413,17 @@ snapshots:
       convex: 1.34.1(react@19.2.4)
       cron-parser: 4.9.0
 
-  '@convex-dev/persistent-text-streaming@0.3.0(convex@1.34.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@convex-dev/persistent-text-streaming@0.3.2(@standard-schema/spec@1.1.0)(convex@1.34.1(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       convex: 1.34.1(react@19.2.4)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.34.1(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@standard-schema/spec'
+      - hono
+      - typescript
+      - zod
 
   '@convex-dev/polar@0.9.0(@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@polar-sh/sdk@0.47.0)(@standard-schema/spec@1.1.0)(convex@1.34.1(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@hono/node-server': 1.19.13
   '@xmldom/xmldom': 0.8.13
-  axios: 1.15.0
+  axios: 1.15.2
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
   dompurify: 3.4.0
   follow-redirects: 1.16.0
@@ -3534,8 +3534,8 @@ packages:
   axios-proxy-builder@0.1.2:
     resolution: {integrity: sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -9632,14 +9632,14 @@ snapshots:
 
   '@mintlify/models@0.0.255':
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       openapi-types: 12.1.3
     transitivePeerDependencies:
       - debug
 
   '@mintlify/models@0.0.297':
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       openapi-types: 12.1.3
     transitivePeerDependencies:
       - debug
@@ -10222,7 +10222,7 @@ snapshots:
 
   '@posthog/cli@0.7.5':
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       axios-proxy-builder: 0.1.2
       console.table: 0.10.0
       detect-libc: 2.1.2
@@ -11789,7 +11789,7 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -13023,7 +13023,7 @@ snapshots:
 
   firecrawl@4.20.1:
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       typescript-event-target: 1.1.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
@@ -16825,7 +16825,7 @@ snapshots:
 
   twilio@5.12.2:
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       dayjs: 1.11.19
       https-proxy-agent: 5.0.1
       jsonwebtoken: 9.0.3


### PR DESCRIPTION
## Summary
- Introduce a new Convex retention module to schedule and clean up expired sensitive content across messages, recordings, transcripts, preview sessions, inbox items, and notification deliveries.
- Redact expired content at read time in dashboard, voice, AI preview, and SMS reply flows so late cleanup never leaks old body text or attachments.
- Add retention-aware schema fields, cron wiring, and tests covering cleanup, late-read guards, and attachment expiration behavior.

## Testing
- Added and updated Convex unit/integration tests for retention scheduling, batch cleanup, expired-content redaction, and dashboard/voice visibility rules.
- Verified the Convex test suite and typecheck pass locally.