### PR TITLE
Add role-aware tenant admin authorization coverage

### DIFF
--- a/apps/web/public/locales/en/onboarding.json
+++ b/apps/web/public/locales/en/onboarding.json
@@ -7,6 +7,15 @@
   "errors": {
     "tooManyBusinesses": "Too many setup attempts. Please wait a bit and try again."
   },
+  "adminRequired": {
+    "eyebrow": "Workspace setup",
+    "title": "Setup is waiting on an admin",
+    "description": "This workspace is still being configured. Ask a business owner or admin to finish setup before you use it.",
+    "descriptionWithBusiness": "{{businessName}} is still being configured. Ask a business owner or admin to finish setup before you use it.",
+    "statusTitle": "Your access is active",
+    "statusDescription": "You will be able to use the workspace once an admin completes onboarding. Setup changes are limited to business owners and admins.",
+    "goToWorkspace": "Go to workspace"
+  },
   "businessName": {
     "title": "First, what is the name of your business?",
     "description": "",

--- a/apps/web/public/locales/fr/onboarding.json
+++ b/apps/web/public/locales/fr/onboarding.json
@@ -7,6 +7,15 @@
   "errors": {
     "tooManyBusinesses": "Trop de tentatives de configuration. Attendez un peu, puis réessayez."
   },
+  "adminRequired": {
+    "eyebrow": "Configuration de l'espace de travail",
+    "title": "La configuration attend un administrateur",
+    "description": "Cet espace de travail est encore en configuration. Demandez à un propriétaire ou à un administrateur de terminer la configuration avant de l'utiliser.",
+    "descriptionWithBusiness": "{{businessName}} est encore en configuration. Demandez à un propriétaire ou à un administrateur de terminer la configuration avant de l'utiliser.",
+    "statusTitle": "Votre accès est actif",
+    "statusDescription": "Vous pourrez utiliser l'espace de travail dès qu'un administrateur aura terminé l'accueil. Les changements de configuration sont réservés aux propriétaires et aux administrateurs.",
+    "goToWorkspace": "Aller à l'espace de travail"
+  },
   "businessName": {
     "title": "D'abord, quel est le nom de votre entreprise ?",
     "description": "",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { useConvexAuth, useQuery } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useTranslation } from "react-i18next";
 
 import { api } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
@@ -13,6 +14,7 @@ import {
 } from "@/components/app-route-skeletons";
 import { useObservedAction } from "@/lib/observed-convex";
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout";
+import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Main } from "@/components/layout/main";
 import {
@@ -53,6 +55,7 @@ import { OnboardingPlanPage } from "@/features/onboarding/OnboardingPlanPage";
 import { OnboardingVerifyPhoneCodePage } from "@/features/onboarding/OnboardingVerifyPhoneCodePage";
 import { OnboardingVerifyPhonePage } from "@/features/onboarding/OnboardingVerifyPhonePage";
 import { OnboardingWebsitePage } from "@/features/onboarding/OnboardingWebsitePage";
+import { OnboardingShell } from "@/features/onboarding/components/OnboardingShell";
 import {
   captureAnalyticsEvent,
   identifyOperator,
@@ -201,6 +204,96 @@ function isPhoneVerificationStage(stage: string | undefined): boolean {
   return stage === "verify_phone" || stage === "verify_phone_code";
 }
 
+function WorkspaceSetupPendingPage(props: { businessName?: string }) {
+  const { t } = useTranslation("onboarding");
+
+  return (
+    <div className="mx-auto flex min-h-[420px] w-full max-w-2xl flex-col justify-center py-16">
+      <div className="space-y-4">
+        <p className="text-sm font-medium text-muted-foreground">
+          {t("adminRequired.eyebrow")}
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          {t("adminRequired.title")}
+        </h1>
+        <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+          {props.businessName
+            ? t("adminRequired.descriptionWithBusiness", {
+                businessName: props.businessName,
+              })
+            : t("adminRequired.description")}
+        </p>
+      </div>
+
+      <div className="mt-8 rounded-xl border bg-muted/30 p-6">
+        <p className="text-sm font-medium text-foreground">
+          {t("adminRequired.statusTitle")}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {t("adminRequired.statusDescription")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function OnboardingSetupPendingPage(props: {
+  businessName?: string;
+  onSignOut: () => void;
+}) {
+  const { t } = useTranslation("onboarding");
+  const navigate = useNavigate();
+
+  return (
+    <OnboardingShell
+      description={
+        props.businessName
+          ? t("adminRequired.descriptionWithBusiness", {
+              businessName: props.businessName,
+            })
+          : t("adminRequired.description")
+      }
+      eyebrow={t("adminRequired.eyebrow")}
+      onSignOut={props.onSignOut}
+      progress={null}
+      title={t("adminRequired.title")}
+    >
+      <div className="rounded-xl border bg-muted/30 p-6 text-left">
+        <p className="text-sm font-medium text-foreground">
+          {t("adminRequired.statusTitle")}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {t("adminRequired.statusDescription")}
+        </p>
+      </div>
+      <Button className="mt-6 h-11 w-full" onClick={() => navigate("/")} type="button">
+        {t("adminRequired.goToWorkspace")}
+      </Button>
+    </OnboardingShell>
+  );
+}
+
+function getNonAdminOnboardingElement(
+  activeBusiness: ActiveBusiness,
+  canManageTenant: boolean,
+  onSignOut: () => void,
+): ReactNode | null {
+  if (canManageTenant) {
+    return null;
+  }
+
+  if (!onboardingRouteForStage(activeBusiness.onboardingStage)) {
+    return <Navigate replace to="/" />;
+  }
+
+  return (
+    <OnboardingSetupPendingPage
+      businessName={activeBusiness.name}
+      onSignOut={onSignOut}
+    />
+  );
+}
+
 function WorkspaceShell() {
   const { signOut } = useAuthActions();
   const location = useLocation();
@@ -220,6 +313,11 @@ function WorkspaceShell() {
     billingStatus?.hasCheckoutAccess === true &&
     billingStatus.availableCheckoutPlans.includes("pro") &&
     billingStatus.plan === "free_cloud";
+  const onboardingTarget = activeBusiness
+    ? onboardingRouteForStage(activeBusiness.onboardingStage)
+    : null;
+  const shouldShowSetupPending =
+    !isBootstrapLoading && Boolean(activeBusiness && onboardingTarget && !canManageTenant);
 
   async function handleSignOut(): Promise<void> {
     resetAnalyticsIdentity();
@@ -283,14 +381,13 @@ function WorkspaceShell() {
 
   // Honour the server-side onboarding stage. If the active business hasn't
   // completed onboarding, redirect to the right step.
-  if (!isBootstrapLoading && activeBusiness) {
-    const target = onboardingRouteForStage(activeBusiness.onboardingStage);
+  if (!isBootstrapLoading && activeBusiness && onboardingTarget && canManageTenant) {
     const isNumberClaimPlanBridge =
       location.pathname === "/onboarding/plan" &&
       hasJustClaimedPhoneNumberState(location.state) &&
       isPhoneNumberClaimBridgeStage(activeBusiness.onboardingStage);
-    if (target && location.pathname !== target && !isNumberClaimPlanBridge) {
-      return <Navigate replace to={target} />;
+    if (location.pathname !== onboardingTarget && !isNumberClaimPlanBridge) {
+      return <Navigate replace to={onboardingTarget} />;
     }
   }
 
@@ -314,6 +411,10 @@ function WorkspaceShell() {
       <Main className="flex flex-1 flex-col" fixed={usesFixedMain}>
         {isBootstrapLoading ? (
           <WorkspaceRouteSkeleton pathname={location.pathname} />
+        ) : shouldShowSetupPending ? (
+          <WorkspaceSetupPendingPage
+            {...(activeBusiness?.name ? { businessName: activeBusiness.name } : {})}
+          />
         ) : (
           <Routes>
             <Route element={<HomePage {...(businessId ? { businessId } : {})} />} path="/" />
@@ -513,6 +614,7 @@ function useOnboardingContext() {
   const businesses = useQuery(api.businesses.admin.listForCurrentUser, {});
   const activeBusinessEntry = selectActiveBusinessEntry(currentUser, businesses);
   const activeBusiness = activeBusinessEntry?.business ?? null;
+  const canManageTenant = hasTenantAdminAccess(activeBusinessEntry?.membership.role);
   const businessId = activeBusiness?._id;
 
   useEffect(() => {
@@ -538,6 +640,7 @@ function useOnboardingContext() {
     currentUser,
     businesses,
     activeBusiness,
+    canManageTenant,
     isLoading: businesses === undefined || currentUser === undefined,
     onSignOut: () => void handleSignOut(),
     navigate,
@@ -552,6 +655,15 @@ function OnboardingBusinessRoute() {
   }
 
   if (ctx.activeBusiness) {
+    const nonAdminElement = getNonAdminOnboardingElement(
+      ctx.activeBusiness,
+      ctx.canManageTenant,
+      ctx.onSignOut,
+    );
+    if (nonAdminElement) {
+      return nonAdminElement;
+    }
+
     const stage = ctx.activeBusiness.onboardingStage;
     if (stage && !canVisitOnboardingStage(stage, "create_business")) {
       const target = onboardingRouteForStage(stage) ?? "/";
@@ -586,6 +698,15 @@ function OnboardingWebsiteRoute() {
     return <Navigate replace to="/onboarding/business" />;
   }
 
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
+  }
+
   if (!canVisitOnboardingStage(ctx.activeBusiness.onboardingStage, "website")) {
     return <Navigate replace to={onboardingRouteForStage(ctx.activeBusiness.onboardingStage) ?? "/"} />;
   }
@@ -613,6 +734,15 @@ function OnboardingKnowledgeRoute() {
     return <Navigate replace to="/onboarding/business" />;
   }
 
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
+  }
+
   if (!canVisitOnboardingStage(ctx.activeBusiness.onboardingStage, "knowledge")) {
     return <Navigate replace to={onboardingRouteForStage(ctx.activeBusiness.onboardingStage) ?? "/"} />;
   }
@@ -635,6 +765,15 @@ function OnboardingGreetingRoute() {
 
   if (!ctx.activeBusiness) {
     return <Navigate replace to="/onboarding/business" />;
+  }
+
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
   }
 
   if (!canVisitOnboardingStage(ctx.activeBusiness.onboardingStage, "greeting")) {
@@ -667,6 +806,7 @@ function OnboardingVerifyPhoneRoute() {
     if (
       ctx.isLoading ||
       !ctx.activeBusiness ||
+      !ctx.canManageTenant ||
       ctx.activeBusiness.onboardingStage !== "verify_phone" ||
       !hasReusableVerifiedPhone ||
       hasAttemptedAutoSkip ||
@@ -698,6 +838,7 @@ function OnboardingVerifyPhoneRoute() {
   }, [
     ctx.isLoading,
     ctx.activeBusiness,
+    ctx.canManageTenant,
     hasReusableVerifiedPhone,
     hasAttemptedAutoSkip,
     isSkipping,
@@ -711,6 +852,15 @@ function OnboardingVerifyPhoneRoute() {
 
   if (!ctx.activeBusiness) {
     return <Navigate replace to="/onboarding/business" />;
+  }
+
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
   }
 
   if (!isPhoneVerificationStage(ctx.activeBusiness.onboardingStage)) {
@@ -744,6 +894,15 @@ function OnboardingVerifyPhoneCodeRoute() {
 
   if (!ctx.activeBusiness) {
     return <Navigate replace to="/onboarding/business" />;
+  }
+
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
   }
 
   if (!isPhoneVerificationStage(ctx.activeBusiness.onboardingStage)) {
@@ -785,6 +944,15 @@ function OnboardingNumberRoute() {
 
   if (!ctx.activeBusiness) {
     return <Navigate replace to="/onboarding/business" />;
+  }
+
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
   }
 
   const canVisitNumber = canVisitOnboardingStage(
@@ -830,6 +998,15 @@ function OnboardingPlanRoute() {
     return <Navigate replace to="/onboarding/business" />;
   }
 
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
+  }
+
   const canUseNumberClaimBridge =
     hasJustClaimedPhoneNumberState(location.state) &&
     isPhoneNumberClaimBridgeStage(ctx.activeBusiness.onboardingStage);
@@ -859,6 +1036,15 @@ function OnboardingAttributionRoute() {
 
   if (!ctx.activeBusiness) {
     return <Navigate replace to="/onboarding/business" />;
+  }
+
+  const nonAdminElement = getNonAdminOnboardingElement(
+    ctx.activeBusiness,
+    ctx.canManageTenant,
+    ctx.onSignOut,
+  );
+  if (nonAdminElement) {
+    return nonAdminElement;
   }
 
   if (!canVisitOnboardingStage(ctx.activeBusiness.onboardingStage, "attribution")) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,6 +69,19 @@ type ActiveBusiness = {
   websiteUrl?: string;
 };
 
+type ActiveBusinessEntry = {
+  business: ActiveBusiness;
+  membership: {
+    role: string;
+  };
+};
+
+const TENANT_ADMIN_ROLES = new Set(["business_owner", "business_admin", "owner"]);
+
+function hasTenantAdminAccess(role: string | undefined): boolean {
+  return role !== undefined && TENANT_ADMIN_ROLES.has(role);
+}
+
 function RequireAuth(props: { children: ReactNode }) {
   const auth = useConvexAuth();
 
@@ -97,22 +110,18 @@ function PublicOnly(props: { children: ReactNode }) {
   return props.children;
 }
 
-function selectActiveBusiness(
+function selectActiveBusinessEntry(
   currentUser: { activeBusinessId?: Id<"businesses"> } | undefined | null,
-  businesses:
-    | Array<{
-        business: ActiveBusiness;
-      }>
-    | undefined,
-): ActiveBusiness | null {
+  businesses: Array<ActiveBusinessEntry> | undefined,
+): ActiveBusinessEntry | null {
   const activeBusinessId = currentUser?.activeBusinessId;
   if (!businesses || businesses.length === 0) {
     return null;
   }
 
   return (
-    businesses.find((entry) => entry.business._id === activeBusinessId)?.business ??
-    businesses[0]?.business ??
+    businesses.find((entry) => entry.business._id === activeBusinessId) ??
+    businesses[0] ??
     null
   );
 }
@@ -197,7 +206,9 @@ function WorkspaceShell() {
   const location = useLocation();
   const currentUser = useQuery(api.users.current, {});
   const businesses = useQuery(api.businesses.admin.listForCurrentUser, {});
-  const activeBusiness = selectActiveBusiness(currentUser, businesses);
+  const activeBusinessEntry = selectActiveBusinessEntry(currentUser, businesses);
+  const activeBusiness = activeBusinessEntry?.business ?? null;
+  const canManageTenant = hasTenantAdminAccess(activeBusinessEntry?.membership.role);
   const businessId = activeBusiness?._id;
   const billingStatus = useQuery(
     api.billing.getStatus,
@@ -320,13 +331,21 @@ function WorkspaceShell() {
               path="/analytics"
             />
             <Route
-              element={<AgentLayout {...(businessId ? { businessId } : {})} />}
+              element={
+                <AgentLayout
+                  {...(businessId ? { businessId } : {})}
+                  canManageTenant={canManageTenant}
+                />
+              }
               path="/agent/*"
             >
               <Route
                 element={
                   businessId ? (
-                    <AgentBasicSettingsPage businessId={businessId} />
+                    <AgentBasicSettingsPage
+                      businessId={businessId}
+                      canManageTenant={canManageTenant}
+                    />
                   ) : (
                     <Navigate replace to="/agent" />
                   )
@@ -336,7 +355,10 @@ function WorkspaceShell() {
               <Route
                 element={
                   businessId ? (
-                    <AgentBasicSettingsPage businessId={businessId} />
+                    <AgentBasicSettingsPage
+                      businessId={businessId}
+                      canManageTenant={canManageTenant}
+                    />
                   ) : (
                     <Navigate replace to="/agent" />
                   )
@@ -346,7 +368,11 @@ function WorkspaceShell() {
               <Route
                 element={
                   businessId ? (
-                    <AgentKnowledgePage businessId={businessId} section="knowledge" />
+                    <AgentKnowledgePage
+                      businessId={businessId}
+                      canManageTenant={canManageTenant}
+                      section="knowledge"
+                    />
                   ) : (
                     <Navigate replace to="/agent" />
                   )
@@ -356,7 +382,10 @@ function WorkspaceShell() {
               <Route
                 element={
                   businessId ? (
-                    <AgentServicesPage businessId={businessId} />
+                    <AgentServicesPage
+                      businessId={businessId}
+                      canManageTenant={canManageTenant}
+                    />
                   ) : (
                     <Navigate replace to="/agent" />
                   )
@@ -366,7 +395,10 @@ function WorkspaceShell() {
               <Route
                 element={
                   businessId ? (
-                    <AgentRulesPage businessId={businessId} />
+                    <AgentRulesPage
+                      businessId={businessId}
+                      canManageTenant={canManageTenant}
+                    />
                   ) : (
                     <Navigate replace to="/agent" />
                   )
@@ -399,7 +431,10 @@ function WorkspaceShell() {
               <Route
                 element={
                   businessId ? (
-                    <SettingsBusinessPage businessId={businessId} />
+                    <SettingsBusinessPage
+                      businessId={businessId}
+                      canManageTenant={canManageTenant}
+                    />
                   ) : (
                     <Navigate replace to="/settings/usage" />
                   )
@@ -476,7 +511,8 @@ function useOnboardingContext() {
   const navigate = useNavigate();
   const currentUser = useQuery(api.users.current, {});
   const businesses = useQuery(api.businesses.admin.listForCurrentUser, {});
-  const activeBusiness = selectActiveBusiness(currentUser, businesses);
+  const activeBusinessEntry = selectActiveBusinessEntry(currentUser, businesses);
+  const activeBusiness = activeBusinessEntry?.business ?? null;
   const businessId = activeBusiness?._id;
 
   useEffect(() => {

--- a/apps/web/src/features/agent/AgentBasicSettingsPage.tsx
+++ b/apps/web/src/features/agent/AgentBasicSettingsPage.tsx
@@ -25,6 +25,7 @@ import { captureAnalyticsEvent } from "@/lib/analytics";
 
 type AgentBasicSettingsPageProps = {
   businessId: Id<"businesses">;
+  canManageTenant: boolean;
 };
 
 export function resolveTransferNumberForSave({
@@ -69,7 +70,10 @@ export function buildAppointmentChangePolicyForSave({
   };
 }
 
-export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPageProps) {
+export function AgentBasicSettingsPage({
+  businessId,
+  canManageTenant,
+}: AgentBasicSettingsPageProps) {
   const { i18n, t } = useTranslation(["agent", "common"]);
   const configuration = useQuery(api.businesses.catalog.getAgentBasicSettings, {
     businessId,
@@ -149,7 +153,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
   }, [appointmentChangeStatus, greetingStatus, localeStatus, transferStatus]);
 
   async function saveGreeting(): Promise<void> {
-    if (!persistedProfile) {
+    if (!canManageTenant || !persistedProfile) {
       return;
     }
 
@@ -183,7 +187,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
   }
 
   async function saveTransferNumber(): Promise<void> {
-    if (!persistedProfile) {
+    if (!canManageTenant || !persistedProfile) {
       return;
     }
 
@@ -226,7 +230,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
     allowReschedule?: boolean;
     requireOtp?: boolean;
   } = {}): Promise<void> {
-    if (!persistedProfile) {
+    if (!canManageTenant || !persistedProfile) {
       return;
     }
 
@@ -285,13 +289,14 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
                   ) : (
                     <Input
                       className="w-full sm:max-w-md"
+                      disabled={!canManageTenant}
                       id="agent-greeting"
-                      placeholder={t("agent:fields.greeting.placeholder")}
-                      value={greeting}
                       onChange={(event) => {
                         setGreeting(event.target.value);
                         setGreetingStatus(null);
                       }}
+                      placeholder={t("agent:fields.greeting.placeholder")}
+                      value={greeting}
                     />
                   )}
                 </div>
@@ -299,7 +304,12 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
               </ItemContent>
               <ItemActions className="w-full justify-end self-center sm:w-auto">
                 <Button
-                  disabled={isLoadingConfiguration || isGreetingSaving || !persistedProfile}
+                  disabled={
+                    isLoadingConfiguration ||
+                    isGreetingSaving ||
+                    !persistedProfile ||
+                    !canManageTenant
+                  }
                   onClick={() => void saveGreeting()}
                   size="sm"
                   type="button"
@@ -331,13 +341,14 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
                   <NativeSelect
                     aria-label={t("agent:fields.defaultLocale.label")}
                     className="w-full sm:w-[9.5ch]"
+                    disabled={!canManageTenant}
                     id="agent-default-language"
                     onChange={(event) => {
                       const nextLocale = ((event.target.value as RuntimeLocale | "") || "en");
                       setDefaultLocale(nextLocale);
                       setLocaleStatus(null);
                       void (async () => {
-                        if (!persistedProfile) {
+                        if (!canManageTenant || !persistedProfile) {
                           return;
                         }
 
@@ -396,20 +407,21 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
                     <PhoneInput
                       className="w-full min-w-0 sm:w-[12ch]"
                       containerClassName="w-full sm:w-fit"
+                      disabled={!canManageTenant}
                       id="agent-transfer-number"
                       locale={i18n.language}
                       maxLength={18}
+                      onChange={(nextValue) => {
+                        setTransferNumber(nextValue ?? "");
+                        setTransferStatus(null);
+                        setTransferStatusTone("success");
+                      }}
                       onRawValueChange={(nextRawValue) => {
                         setTransferNumberInputValue(nextRawValue);
                         setTransferStatus(null);
                         setTransferStatusTone("success");
                       }}
                       value={transferNumber || undefined}
-                      onChange={(nextValue) => {
-                        setTransferNumber(nextValue ?? "");
-                        setTransferStatus(null);
-                        setTransferStatusTone("success");
-                      }}
                     />
                   )}
                 </div>
@@ -423,7 +435,12 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
               </ItemContent>
               <ItemActions className="w-full justify-end self-center sm:w-auto">
                 <Button
-                  disabled={isLoadingConfiguration || isTransferSaving || !persistedProfile}
+                  disabled={
+                    isLoadingConfiguration ||
+                    isTransferSaving ||
+                    !persistedProfile ||
+                    !canManageTenant
+                  }
                   onClick={() => void saveTransferNumber()}
                   size="sm"
                   type="button"
@@ -458,7 +475,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
                   <Switch
                     aria-label={t("agent:appointmentChanges.allowCancel.label")}
                     checked={allowAppointmentCancel}
-                    disabled={isAppointmentChangeSaving || !persistedProfile}
+                    disabled={isAppointmentChangeSaving || !persistedProfile || !canManageTenant}
                     onCheckedChange={(checked) => {
                       setAllowAppointmentCancel(checked);
                       setAppointmentChangeStatus(null);
@@ -486,7 +503,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
                   <Switch
                     aria-label={t("agent:appointmentChanges.allowReschedule.label")}
                     checked={allowAppointmentReschedule}
-                    disabled={isAppointmentChangeSaving || !persistedProfile}
+                    disabled={isAppointmentChangeSaving || !persistedProfile || !canManageTenant}
                     onCheckedChange={(checked) => {
                       setAllowAppointmentReschedule(checked);
                       setAppointmentChangeStatus(null);
@@ -517,7 +534,7 @@ export function AgentBasicSettingsPage({ businessId }: AgentBasicSettingsPagePro
                   <Switch
                     aria-label={t("agent:appointmentChanges.requireOtp.label")}
                     checked={requireAppointmentChangeOtp}
-                    disabled={isAppointmentChangeSaving || !persistedProfile}
+                    disabled={isAppointmentChangeSaving || !persistedProfile || !canManageTenant}
                     onCheckedChange={(checked) => {
                       setRequireAppointmentChangeOtp(checked);
                       setAppointmentChangeStatus(null);

--- a/apps/web/src/features/agent/AgentKnowledgePage.test.tsx
+++ b/apps/web/src/features/agent/AgentKnowledgePage.test.tsx
@@ -312,7 +312,7 @@ describe("AgentKnowledgePage", () => {
         },
       });
 
-      render(<AgentKnowledgePage businessId={"business-1" as never} section={section} />);
+      render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section={section} />);
 
       expect(screen.getByPlaceholderText("agent:table.searchPlaceholder")).toBeTruthy();
       expect(screen.getByText("agent:table.title")).toBeTruthy();
@@ -335,7 +335,7 @@ describe("AgentKnowledgePage", () => {
     });
     upsertKnowledgeSnippetMock.mockResolvedValue({ snippetId: "snippet-1" });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByLabelText("agent:sections.knowledge.textBadge")).toBeTruthy();
 
@@ -373,6 +373,40 @@ describe("AgentKnowledgePage", () => {
     });
   });
 
+  it("hides tenant-admin knowledge controls for non-admin operators", async () => {
+    mockAgentKnowledgeQueries({
+      knowledge: {
+        documents: [createDocument()],
+        snippets: [createSnippet()],
+      },
+      websiteJobs: [
+        createWebsiteIngestionJob({
+          _id: "website-job-active",
+          status: "crawling",
+        }),
+      ],
+    });
+
+    render(
+      <AgentKnowledgePage
+        businessId={"business-1" as never}
+        canManageTenant={false}
+        section="knowledge"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "actions.moreOptions" })).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Hours"));
+
+    expect(screen.queryByText("agent:sections.knowledge.editKnowledge")).toBeNull();
+    expect(deleteKnowledgeEntryMock).not.toHaveBeenCalled();
+    expect(setKnowledgeEntryActiveMock).not.toHaveBeenCalled();
+    expect(cancelWebsiteIngestionJobMock).not.toHaveBeenCalled();
+    expect(deleteWebsiteIngestionJobMock).not.toHaveBeenCalled();
+  });
+
   it("toggles snippet activity from the row actions menu", async () => {
     mockAgentKnowledgeQueries({
       knowledge: {
@@ -382,7 +416,7 @@ describe("AgentKnowledgePage", () => {
     });
     setKnowledgeEntryActiveMock.mockResolvedValue(null);
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "actions.moreOptions" }));
@@ -406,7 +440,7 @@ describe("AgentKnowledgePage", () => {
     });
     deleteKnowledgeEntryMock.mockResolvedValue(null);
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "actions.moreOptions" }));
@@ -446,7 +480,7 @@ describe("AgentKnowledgePage", () => {
       text: async () => "Full document text loaded",
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     const user = userEvent.setup();
     await user.click(screen.getByText("Clinic Policies"));
@@ -483,7 +517,7 @@ describe("AgentKnowledgePage", () => {
         text: async () => "Full document text loaded",
       });
 
-      render(<AgentKnowledgePage businessId={"business-1" as never} section={section} />);
+      render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section={section} />);
 
       const user = userEvent.setup();
       await user.click(screen.getByText("Clinic Policies"));
@@ -508,7 +542,7 @@ describe("AgentKnowledgePage", () => {
       ],
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("example.com/team")).toBeTruthy();
     expect(
@@ -536,7 +570,7 @@ describe("AgentKnowledgePage", () => {
       ],
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("99%")).toBeTruthy();
     expect(screen.queryByText("100%")).toBeNull();
@@ -558,7 +592,7 @@ describe("AgentKnowledgePage", () => {
     });
 
     const { rerender } = render(
-      <AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />,
+      <AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />,
     );
 
     expect(screen.getByText("50%")).toBeTruthy();
@@ -577,7 +611,7 @@ describe("AgentKnowledgePage", () => {
       ],
     });
 
-    rerender(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    rerender(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("50%")).toBeTruthy();
     expect(screen.queryByText("30%")).toBeNull();
@@ -598,7 +632,7 @@ describe("AgentKnowledgePage", () => {
     });
     cancelWebsiteIngestionJobMock.mockResolvedValue(null);
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "actions.moreOptions" }));
@@ -628,7 +662,7 @@ describe("AgentKnowledgePage", () => {
       },
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("Clinic Policies")).toBeTruthy();
     expect(screen.getByLabelText("agent:sections.knowledge.documentBadge")).toBeTruthy();
@@ -652,7 +686,7 @@ describe("AgentKnowledgePage", () => {
       },
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("Existing document content remains visible.")).toBeTruthy();
     expect(screen.getByText("agent:sections.knowledge.status.indexing")).toBeTruthy();
@@ -674,7 +708,7 @@ describe("AgentKnowledgePage", () => {
       },
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.queryByText(/!\[CallRail logo\]/)).toBeNull();
     expect(
@@ -699,7 +733,7 @@ describe("AgentKnowledgePage", () => {
       },
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("Imported website page content is already available.")).toBeTruthy();
     expect(screen.getByLabelText("agent:sections.knowledge.websiteImport.badge")).toBeTruthy();
@@ -716,7 +750,7 @@ describe("AgentKnowledgePage", () => {
     });
     setKnowledgeEntryActiveMock.mockResolvedValue(null);
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "actions.moreOptions" }));
@@ -745,7 +779,7 @@ describe("AgentKnowledgePage", () => {
       },
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("Changelog")).toBeTruthy();
     expect(screen.getByLabelText("agent:sections.knowledge.websiteImport.badge")).toBeTruthy();
@@ -779,7 +813,7 @@ describe("AgentKnowledgePage", () => {
       },
     });
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section={section} />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section={section} />);
 
     expect(screen.getByText(title)).toBeTruthy();
     expect(screen.queryByLabelText(`agent:sections.${section}.textBadge`)).toBeNull();
@@ -802,7 +836,7 @@ describe("AgentKnowledgePage", () => {
     });
     deleteWebsiteIngestionJobMock.mockResolvedValue(null);
 
-    render(<AgentKnowledgePage businessId={"business-1" as never} section="knowledge" />);
+    render(<AgentKnowledgePage businessId={"business-1" as never} canManageTenant={true} section="knowledge" />);
 
     expect(screen.getByText("agent:sections.knowledge.websiteImport.previewFailed")).toBeTruthy();
     expect(screen.queryByText("Firecrawl request failed")).toBeNull();

--- a/apps/web/src/features/agent/AgentKnowledgePage.tsx
+++ b/apps/web/src/features/agent/AgentKnowledgePage.tsx
@@ -56,6 +56,7 @@ import { cn } from "@/lib/utils";
 
 type AgentKnowledgePageProps = {
   businessId: Id<"businesses">;
+  canManageTenant: boolean;
   section: KnowledgeSection;
 };
 
@@ -283,7 +284,11 @@ function RowActionsMenu({
   );
 }
 
-export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePageProps) {
+export function AgentKnowledgePage({
+  businessId,
+  canManageTenant,
+  section,
+}: AgentKnowledgePageProps) {
   const { i18n, t } = useTranslation(["agent", "knowledge"]);
   const outletContext = useOutletContext<AgentLayoutOutletContext | null>();
   const headerActions = outletContext?.headerActions;
@@ -810,19 +815,19 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
 
           return (
             <DataTableRowActions>
-              {!isWebsiteIngestionJobRow(rowData) || rowData.status !== "completed" ? (
+              {canManageTenant && (!isWebsiteIngestionJobRow(rowData) || rowData.status !== "completed") ? (
                 <RowActionsMenu
                   deleting={deletingEntryId === String(rowData._id)}
                   {...(toggleableRow
                     ? {
-                      onToggleActive: () => {
-                        void handleSetEntryActive(toggleableRow, !isKnowledgeEntryActive(toggleableRow));
-                      },
-                      toggleActiveDisabled: togglingEntryIds.includes(String(rowData._id)),
-                      toggleActiveLabel: getEntryToggleActionLabel(toggleableRow),
-                      toggleActiveVariant: isKnowledgeEntryActive(toggleableRow) ? "disable" : "enable",
-                    }
-                  : {})}
+                        onToggleActive: () => {
+                          void handleSetEntryActive(toggleableRow, !isKnowledgeEntryActive(toggleableRow));
+                        },
+                        toggleActiveDisabled: togglingEntryIds.includes(String(rowData._id)),
+                        toggleActiveLabel: getEntryToggleActionLabel(toggleableRow),
+                        toggleActiveVariant: isKnowledgeEntryActive(toggleableRow) ? "disable" : "enable",
+                      }
+                    : {})}
                   {...(isWebsiteIngestionJobRow(rowData) && rowData.status !== "failed"
                     ? { actionLabel: t("agent:actions.cancelImport") }
                     : {})}
@@ -841,6 +846,7 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
     ],
     [
       businessId,
+      canManageTenant,
       deletingEntryId,
       locale,
       section,
@@ -874,10 +880,15 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
   }, [expandedDocumentId, filteredRows]);
 
   useEffect(() => {
+    if (!canManageTenant && editingSnippet) {
+      setEditingSnippet(null);
+      return;
+    }
+
     if (editingSnippet && !filteredRows.some((row) => row.entryType === "snippet" && row._id === editingSnippet._id)) {
       setEditingSnippet(null);
     }
-  }, [editingSnippet, filteredRows]);
+  }, [canManageTenant, editingSnippet, filteredRows]);
 
   useEffect(() => {
     setPagination((current) => {
@@ -894,6 +905,10 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
   }, [filteredRows.length]);
 
   async function handleDelete(row: KnowledgeRow): Promise<void> {
+    if (!canManageTenant) {
+      return;
+    }
+
     const entryId = String(row._id);
     setDeletingEntryId(entryId);
     setOptimisticDeletedIds((current) => (current.includes(entryId) ? current : [...current, entryId]));
@@ -955,6 +970,10 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
     row: KnowledgeDocumentRow | KnowledgeSnippetRow,
     nextActive: boolean,
   ): Promise<void> {
+    if (!canManageTenant) {
+      return;
+    }
+
     const entryId = String(row._id);
     setTogglingEntryIds((current) => [...current, entryId]);
 
@@ -1159,7 +1178,8 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
                   const rowData = row.original;
                   const rowId = String(rowData._id);
                   const rowIsInteractive =
-                    rowData.entryType === "snippet" || rowData.entryType === "document";
+                    rowData.entryType === "document" ||
+                    (canManageTenant && rowData.entryType === "snippet");
                   const isSelected =
                     rowData.entryType === "snippet"
                       ? editingSnippet?._id === rowData._id
@@ -1180,6 +1200,9 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
                         data-state={isSelected ? "selected" : undefined}
                         onClick={() => {
                           if (rowData.entryType === "snippet") {
+                            if (!canManageTenant) {
+                              return;
+                            }
                             setExpandedDocumentId(null);
                             setEditingSnippet(rowData);
                             return;
@@ -1289,18 +1312,20 @@ export function AgentKnowledgePage({ businessId, section }: AgentKnowledgePagePr
         </>
       )}
 
-      <AddKnowledgeSheet
-        businessId={businessId}
-        mode="edit"
-        onOpenChange={(open) => {
-          if (!open) {
-            setEditingSnippet(null);
-          }
-        }}
-        open={editingSnippet !== null}
-        section={section}
-        snippet={editingSnippet}
-      />
+      {canManageTenant ? (
+        <AddKnowledgeSheet
+          businessId={businessId}
+          mode="edit"
+          onOpenChange={(open) => {
+            if (!open) {
+              setEditingSnippet(null);
+            }
+          }}
+          open={editingSnippet !== null}
+          section={section}
+          snippet={editingSnippet}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/agent/AgentLayout.tsx
+++ b/apps/web/src/features/agent/AgentLayout.tsx
@@ -10,13 +10,14 @@ import { getAgentSectionFromPathname } from "./sections";
 
 type AgentLayoutProps = {
   businessId?: Id<"businesses">;
+  canManageTenant: boolean;
 };
 
 type AgentLayoutOutletContext = {
   headerActions?: ReactNode;
 };
 
-export function AgentLayout({ businessId }: AgentLayoutProps) {
+export function AgentLayout({ businessId, canManageTenant }: AgentLayoutProps) {
   const { t } = useTranslation("agent");
   const location = useLocation();
   const section = getAgentSectionFromPathname(location.pathname);
@@ -56,7 +57,7 @@ export function AgentLayout({ businessId }: AgentLayoutProps) {
   }
 
   const headerActions =
-    !isBasicSettingsRoute && isKnowledgeRoute ? (
+    canManageTenant && !isBasicSettingsRoute && isKnowledgeRoute ? (
       <>
         {section === "knowledge" ? (
           <KnowledgeActionsMenu businessId={businessId} />

--- a/apps/web/src/features/agent/AgentRulesPage.tsx
+++ b/apps/web/src/features/agent/AgentRulesPage.tsx
@@ -1,6 +1,18 @@
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import { AgentKnowledgePage } from "./AgentKnowledgePage";
 
-export function AgentRulesPage({ businessId }: { businessId: Id<"businesses"> }) {
-  return <AgentKnowledgePage businessId={businessId} section="rules" />;
+export function AgentRulesPage({
+  businessId,
+  canManageTenant,
+}: {
+  businessId: Id<"businesses">;
+  canManageTenant: boolean;
+}) {
+  return (
+    <AgentKnowledgePage
+      businessId={businessId}
+      canManageTenant={canManageTenant}
+      section="rules"
+    />
+  );
 }

--- a/apps/web/src/features/agent/AgentServicesPage.tsx
+++ b/apps/web/src/features/agent/AgentServicesPage.tsx
@@ -1,6 +1,18 @@
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import { AgentKnowledgePage } from "./AgentKnowledgePage";
 
-export function AgentServicesPage({ businessId }: { businessId: Id<"businesses"> }) {
-  return <AgentKnowledgePage businessId={businessId} section="services" />;
+export function AgentServicesPage({
+  businessId,
+  canManageTenant,
+}: {
+  businessId: Id<"businesses">;
+  canManageTenant: boolean;
+}) {
+  return (
+    <AgentKnowledgePage
+      businessId={businessId}
+      canManageTenant={canManageTenant}
+      section="services"
+    />
+  );
 }

--- a/apps/web/src/features/settings/SettingsBusinessPage.tsx
+++ b/apps/web/src/features/settings/SettingsBusinessPage.tsx
@@ -33,6 +33,7 @@ import {
 
 type SettingsBusinessPageProps = {
   businessId: Id<"businesses">;
+  canManageTenant: boolean;
 };
 
 export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
@@ -70,6 +71,10 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
   }, [businessNameStatus]);
 
   async function handleBusinessNameSave(): Promise<void> {
+    if (!props.canManageTenant) {
+      return;
+    }
+
     setIsSavingBusinessName(true);
     setBusinessNameStatus(null);
 
@@ -103,58 +108,60 @@ export function SettingsBusinessPage(props: SettingsBusinessPageProps) {
               )}
               {businessNameStatus ? <ItemDescription>{businessNameStatus}</ItemDescription> : null}
             </ItemContent>
-            <ItemActions>
-              <Dialog
-                onOpenChange={(open) => {
-                  setIsBusinessNameDialogOpen(open);
-                  if (open) {
-                    setBusinessName(configuredBusinessName || businessName);
-                  }
-                }}
-                open={isBusinessNameDialogOpen}
-              >
-                <DialogTrigger
-                  render={<Button disabled={isLoadingBusinessName} size="sm" variant="outline" />}
+            {props.canManageTenant ? (
+              <ItemActions>
+                <Dialog
+                  onOpenChange={(open) => {
+                    setIsBusinessNameDialogOpen(open);
+                    if (open) {
+                      setBusinessName(configuredBusinessName || businessName);
+                    }
+                  }}
+                  open={isBusinessNameDialogOpen}
                 >
-                  {t("account.actions.change")}
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>{t("account.businessName.label")}</DialogTitle>
-                    <DialogDescription>{t("account.businessName.description")}</DialogDescription>
-                  </DialogHeader>
+                  <DialogTrigger
+                    render={<Button disabled={isLoadingBusinessName} size="sm" variant="outline" />}
+                  >
+                    {t("account.actions.change")}
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>{t("account.businessName.label")}</DialogTitle>
+                      <DialogDescription>{t("account.businessName.description")}</DialogDescription>
+                    </DialogHeader>
 
-                  <FieldGroup>
-                    <Field>
-                      <FieldLabel htmlFor="profile-username">
-                        {t("account.businessName.label")}
-                      </FieldLabel>
-                      <Input
-                        id="profile-username"
-                        placeholder={t("account.businessName.placeholder")}
-                        value={businessName}
-                        onChange={(event) => {
-                          setBusinessName(event.target.value);
-                          setBusinessNameStatus(null);
-                        }}
-                      />
-                    </Field>
-                  </FieldGroup>
+                    <FieldGroup>
+                      <Field>
+                        <FieldLabel htmlFor="profile-username">
+                          {t("account.businessName.label")}
+                        </FieldLabel>
+                        <Input
+                          id="profile-username"
+                          onChange={(event) => {
+                            setBusinessName(event.target.value);
+                            setBusinessNameStatus(null);
+                          }}
+                          placeholder={t("account.businessName.placeholder")}
+                          value={businessName}
+                        />
+                      </Field>
+                    </FieldGroup>
 
-                  <DialogFooter>
-                    <Button
-                      disabled={isSavingBusinessName}
-                      type="button"
-                      onClick={() => void handleBusinessNameSave()}
-                    >
-                      {isSavingBusinessName
-                        ? t("account.businessName.saving")
-                        : t("account.businessName.save")}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </ItemActions>
+                    <DialogFooter>
+                      <Button
+                        disabled={isSavingBusinessName}
+                        onClick={() => void handleBusinessNameSave()}
+                        type="button"
+                      >
+                        {isSavingBusinessName
+                          ? t("account.businessName.saving")
+                          : t("account.businessName.save")}
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              </ItemActions>
+            ) : null}
           </Item>
         </ItemGroup>
       </div>

--- a/convex/ai/context/knowledge.ts
+++ b/convex/ai/context/knowledge.ts
@@ -16,7 +16,12 @@ import {
 } from "../../_generated/server";
 import { api, internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
-import { requireIdentity, requireMembership } from "../../lib/auth";
+import {
+  requireIdentity,
+  requireMembership,
+  requireTenantAdminAccess,
+  requireTenantAdminMembership,
+} from "../../lib/auth";
 import { getKnowledgeStorageLimitBytes } from "../../lib/billing";
 import {
   bulkWorkpool,
@@ -177,6 +182,10 @@ async function requireKnowledgeAccess(
   if (!membership) {
     throw new Error("Unauthorized.");
   }
+  if (membership.status !== "active") {
+    throw new Error("Unauthorized.");
+  }
+  requireTenantAdminAccess(membership.role);
 }
 
 function isKnowledgeDocumentActive(
@@ -1099,7 +1108,7 @@ export const upsertKnowledgeSnippet = mutation({
     active: v.boolean(),
   },
   handler: async (ctx: MutationCtx, args: UpsertKnowledgeSnippetArgs) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
 
     const snippetId =
       args.snippetId ??
@@ -1114,6 +1123,11 @@ export const upsertKnowledgeSnippet = mutation({
       }));
 
     if (args.snippetId) {
+      const existingSnippet = await ctx.db.get(args.snippetId);
+      if (!existingSnippet || existingSnippet.businessId !== args.businessId) {
+        throw new Error("Knowledge snippet not found.");
+      }
+
       await ctx.db.patch(args.snippetId, {
         ...(args.section !== undefined ? { section: args.section } : {}),
         title: args.title,
@@ -1151,7 +1165,7 @@ export const createKnowledgeDocument = mutation({
     contentHash: v.optional(v.string()),
   },
   handler: async (ctx: MutationCtx, args: CreateKnowledgeDocumentArgs) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const documentId = await ctx.db.insert("knowledge_documents", {
       businessId: args.businessId,
       ...(args.section !== undefined ? { section: args.section } : {}),
@@ -1193,7 +1207,7 @@ export const generateKnowledgeDocumentUploadUrl = mutation({
     businessId: v.id("businesses"),
   },
   handler: async (ctx: MutationCtx, args: BusinessIdArgs): Promise<string> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     return await ctx.storage.generateUploadUrl();
   },
 });

--- a/convex/ai/context/snapshots.ts
+++ b/convex/ai/context/snapshots.ts
@@ -11,7 +11,7 @@ import {
   type QueryCtx,
 } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
-import { requireMembership } from "../../lib/auth";
+import { requireMembership, requireTenantAdminMembership } from "../../lib/auth";
 import { scheduleSnapshotRefresh } from "../../businesses/admin";
 import {
   buildDefaultReceptionistSummary,
@@ -113,7 +113,7 @@ export const updateReceptionistProfile = mutation({
     appointmentChangePolicy: v.optional(appointmentChangePolicyValidator),
   },
   handler: async (ctx: MutationCtx, args: UpdateReceptionistProfileArgs) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const [business, existing] = await Promise.all([
       ctx.db.get(args.businessId),
       ctx.db

--- a/convex/ai/context/websiteIngestion.ts
+++ b/convex/ai/context/websiteIngestion.ts
@@ -15,7 +15,7 @@ import {
   type QueryCtx,
 } from "../../_generated/server";
 import { workflowManager } from "../../lib/components";
-import { requireMembership } from "../../lib/auth";
+import { requireMembership, requireTenantAdminMembership } from "../../lib/auth";
 import {
   WEBSITE_CRAWL_DEPTH,
   WEBSITE_CRAWL_FIRECRAWL_MODE,
@@ -224,7 +224,7 @@ export const submitWebsiteIngestionAfterPreflight = internalMutation({
     ctx: MutationCtx,
     args: SubmitWebsiteIngestionArgs,
   ): Promise<SubmitWebsiteIngestionResult> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
 
     const existingJobs = await ctx.db
       .query("website_ingestion_jobs")
@@ -318,7 +318,7 @@ export const deleteWebsiteIngestionJob = mutation({
     ctx: MutationCtx,
     args: DeleteWebsiteIngestionJobArgs,
   ): Promise<null> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
 
     const job = await ctx.db.get(args.websiteIngestionJobId);
     if (!job || job.businessId !== args.businessId) {

--- a/convex/businesses/admin.ts
+++ b/convex/businesses/admin.ts
@@ -272,6 +272,9 @@ export const listForCurrentUser = query({
 
     const businesses = [];
     for (const membership of memberships) {
+      if (membership.status !== "active") {
+        continue;
+      }
       const business = await ctx.db.get(membership.businessId);
       if (business) {
         businesses.push({

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -21,7 +21,12 @@ import {
   getPasswordAccountForUser,
   resolveUserForPasswordCredentials,
 } from "../lib/accountCredentials";
-import { getCurrentUser, requireMembership } from "../lib/auth";
+import {
+  getCurrentUser,
+  requireMembership,
+  requireTenantAdminAccess,
+  requireTenantAdminMembership,
+} from "../lib/auth";
 import {
   EMAIL_CHANGE_MAX_AGE_SECONDS,
   generateEmailChangeToken,
@@ -425,7 +430,7 @@ export const updateBusinessName = mutation({
     name: v.string(),
   },
   handler: async (ctx, args) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
 
     const name = args.name.trim();
     if (!name) {
@@ -787,6 +792,7 @@ export const assertCatalogWriteAccess = internalQuery({
     if (!membership || membership.status !== "active") {
       throw new Error("You do not have access to this business.");
     }
+    requireTenantAdminAccess(membership.role);
 
     return { userId: user._id };
   },
@@ -811,6 +817,11 @@ export const upsertServiceInternal = internalMutation({
     const localizedNames = normalizeLocalizedServiceNames(args.localizedNames);
 
     if (args.serviceId) {
+      const existingService = await ctx.db.get(args.serviceId);
+      if (!existingService || existingService.businessId !== args.businessId) {
+        throw new Error("Service not found for this business.");
+      }
+
       await ctx.db.patch(args.serviceId, {
         name: args.name,
         ...(localizedNames !== undefined ? { localizedNames } : {}),
@@ -928,9 +939,14 @@ export const upsertStaff = mutation({
     transferNumber: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
 
     if (args.staffId) {
+      const existingStaff = await ctx.db.get(args.staffId);
+      if (!existingStaff || existingStaff.businessId !== args.businessId) {
+        throw new Error("Staff member not found for this business.");
+      }
+
       await ctx.db.patch(args.staffId, {
         name: args.name,
         timezone: args.timezone,
@@ -969,7 +985,7 @@ export const replaceBusinessHours = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const existing = await ctx.db
       .query("business_hours")
       .withIndex("by_business_id_and_day_of_week", (q) =>
@@ -1007,7 +1023,7 @@ export const replaceClosures = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const existing = await ctx.db
       .query("closures")
       .withIndex("by_business_id_and_starts_at", (q) => q.eq("businessId", args.businessId))
@@ -1042,7 +1058,7 @@ export const replaceStaffServiceAssignments = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     await replaceBusinessStaffServiceAssignments(ctx, {
       businessId: args.businessId,
       assignments: args.assignments,

--- a/convex/integrations/calendar.ts
+++ b/convex/integrations/calendar.ts
@@ -16,7 +16,11 @@ import {
 } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
-import { requireIdentity, requireMembership } from "../lib/auth";
+import {
+  hasTenantAdminAccess,
+  requireIdentity,
+  requireMembership,
+} from "../lib/auth";
 import { workflowManager } from "../lib/components";
 import {
   enqueuePostHogEventBestEffort,
@@ -139,12 +143,6 @@ async function ensureAuthorizedDefaultStaffAccess(
   );
 }
 
-const CALENDAR_INTEGRATION_ADMIN_ROLES = new Set([
-  "business_owner",
-  "business_admin",
-  "owner",
-]);
-
 const CALENDAR_CONNECTION_RESET_STATES = new Set<CalendarSyncState>([
   "pending",
   "syncing",
@@ -155,7 +153,7 @@ const CALENDAR_CONNECTION_RESET_STATES = new Set<CalendarSyncState>([
 ]);
 
 function requireCalendarIntegrationAdminRole(role: string): void {
-  if (!CALENDAR_INTEGRATION_ADMIN_ROLES.has(role)) {
+  if (!hasTenantAdminAccess(role)) {
     throw new Error("Calendar integrations require admin access.");
   }
 }

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -231,3 +231,28 @@ export async function requireMembership(
   }
   return membership;
 }
+
+export const TENANT_ADMIN_ROLES: ReadonlySet<string> = new Set([
+  "business_owner",
+  "business_admin",
+  "owner",
+]);
+
+export function hasTenantAdminAccess(role: string): boolean {
+  return TENANT_ADMIN_ROLES.has(role);
+}
+
+export function requireTenantAdminAccess(role: string): void {
+  if (!hasTenantAdminAccess(role)) {
+    throw new Error("Tenant admin access required.");
+  }
+}
+
+export async function requireTenantAdminMembership(
+  ctx: ReaderAuthContext,
+  businessId: Id<"businesses">,
+): Promise<Doc<"business_memberships">> {
+  const membership = await requireMembership(ctx, businessId);
+  requireTenantAdminAccess(membership.role);
+  return membership;
+}

--- a/convex/lib/billingAccess.ts
+++ b/convex/lib/billingAccess.ts
@@ -1,11 +1,7 @@
-const BILLING_ADMIN_ROLES = new Set([
-  "business_owner",
-  "business_admin",
-  "owner",
-]);
+import { hasTenantAdminAccess } from "./auth";
 
 export function hasBillingManagementAccess(role: string): boolean {
-  return BILLING_ADMIN_ROLES.has(role);
+  return hasTenantAdminAccess(role);
 }
 
 export function requireBillingManagementAccess(role: string): void {

--- a/convex/lib/indexedQueries.ts
+++ b/convex/lib/indexedQueries.ts
@@ -24,6 +24,20 @@ export async function replaceBusinessStaffServiceAssignments(
     }>;
   },
 ): Promise<void> {
+  for (const assignment of input.assignments) {
+    const [staff, service] = await Promise.all([
+      ctx.db.get(assignment.staffId),
+      ctx.db.get(assignment.serviceId),
+    ]);
+
+    if (!staff || staff.businessId !== input.businessId) {
+      throw new Error("Staff member not found for this business.");
+    }
+    if (!service || service.businessId !== input.businessId) {
+      throw new Error("Service not found for this business.");
+    }
+  }
+
   const existing = await listStaffServiceAssignmentsForBusiness(ctx, input.businessId);
 
   for (const row of existing) {

--- a/convex/onboarding/attribution.ts
+++ b/convex/onboarding/attribution.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
-import { ensureCurrentUser, requireMembership } from "../lib/auth";
+import { ensureCurrentUser, requireTenantAdminMembership } from "../lib/auth";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
 import { observedMutation as mutation } from "../telemetry/observedFunctions";
 
@@ -32,7 +32,7 @@ export const submitOnboardingAttribution = mutation({
     source: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args: SubmitAttributionArgs): Promise<{ status: "submitted" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     await requireBusinessInAttributionStage(ctx, args.businessId);
     const user = await ensureCurrentUser(ctx);
     const source = args.source?.trim();

--- a/convex/onboarding/greeting.ts
+++ b/convex/onboarding/greeting.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { scheduleSnapshotRefresh } from "../businesses/admin";
-import { requireMembership } from "../lib/auth";
+import { requireTenantAdminMembership } from "../lib/auth";
 import { DEFAULT_APPOINTMENT_CHANGE_POLICY } from "../lib/appointmentChangePolicy";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
 import {
@@ -45,7 +45,7 @@ export const submitOnboardingGreeting = mutation({
     greeting: v.string(),
   },
   handler: async (ctx, args: SubmitGreetingArgs): Promise<{ status: "submitted" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const { business, shouldAdvance } = await requireBusinessAtOrPastGreetingStage(
       ctx,
       args.businessId,

--- a/convex/onboarding/knowledge.ts
+++ b/convex/onboarding/knowledge.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
-import { requireMembership } from "../lib/auth";
+import { requireTenantAdminMembership } from "../lib/auth";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
 import { observedMutation as mutation } from "../telemetry/observedFunctions";
 
@@ -34,7 +34,7 @@ export const completeOnboardingKnowledge = mutation({
     businessId: v.id("businesses"),
   },
   handler: async (ctx, args: BusinessIdArgs): Promise<{ status: "completed" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const { shouldAdvance } = await requireBusinessAtOrPastKnowledgeStage(ctx, args.businessId);
 
     if (shouldAdvance) {
@@ -52,7 +52,7 @@ export const skipOnboardingKnowledge = mutation({
     businessId: v.id("businesses"),
   },
   handler: async (ctx, args: BusinessIdArgs): Promise<{ status: "skipped" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const { shouldAdvance } = await requireBusinessAtOrPastKnowledgeStage(ctx, args.businessId);
 
     if (shouldAdvance) {

--- a/convex/onboarding/phoneNumbersSkip.ts
+++ b/convex/onboarding/phoneNumbersSkip.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 
-import { requireMembership } from "../lib/auth";
+import { requireTenantAdminMembership } from "../lib/auth";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
 import { observedMutation as mutation } from "../telemetry/observedFunctions";
 
@@ -18,7 +18,7 @@ export const skipOnboardingNumber = mutation({
     businessId: v.id("businesses"),
   },
   handler: async (ctx, args): Promise<{ status: "skipped" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const business = await ctx.db.get(args.businessId);
     if (!business) {
       throw new Error("Business not found.");

--- a/convex/onboarding/plan.ts
+++ b/convex/onboarding/plan.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
-import { requireMembership } from "../lib/auth";
+import { requireTenantAdminMembership } from "../lib/auth";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
 import { observedMutation as mutation } from "../telemetry/observedFunctions";
 
@@ -40,7 +40,7 @@ export const selectOnboardingPlan = mutation({
     plan: onboardingPlanValidator,
   },
   handler: async (ctx, args: SelectPlanArgs): Promise<{ status: "selected" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     const { shouldAdvance } = await requireBusinessAtOrPastPlanStage(ctx, args.businessId);
 
     if (args.plan === "pro") {

--- a/convex/onboarding/websites.ts
+++ b/convex/onboarding/websites.ts
@@ -6,7 +6,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { type ActionCtx, type MutationCtx } from "../_generated/server";
-import { requireMembership } from "../lib/auth";
+import { requireTenantAdminMembership } from "../lib/auth";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
 
 import { observedAction as action } from "../telemetry/observedFunctions";
@@ -125,7 +125,7 @@ export const skipOnboardingWebsite = mutation({
     businessId: v.id("businesses"),
   },
   handler: async (ctx, args: BusinessIdArgs): Promise<{ status: "skipped" }> => {
-    await requireMembership(ctx, args.businessId);
+    await requireTenantAdminMembership(ctx, args.businessId);
     await requireBusinessAtOrPastWebsiteStage(ctx, args.businessId);
 
     const business = await ctx.db.get(args.businessId);

--- a/convex/tests/tenantAdminAuthorization.test.ts
+++ b/convex/tests/tenantAdminAuthorization.test.ts
@@ -1,0 +1,397 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { scheduleSnapshotRefreshMock } = vi.hoisted(() => ({
+  scheduleSnapshotRefreshMock: vi.fn(),
+}));
+
+vi.mock("../businesses/admin.ts", async () => {
+  const actual = await vi.importActual<typeof import("../businesses/admin")>(
+    "../businesses/admin.ts",
+  );
+
+  return {
+    ...actual,
+    scheduleSnapshotRefresh: scheduleSnapshotRefreshMock,
+  };
+});
+
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+const convexModules = modules;
+
+type ConvexHarness = TestConvex<typeof schema>;
+type TestRunFunction = Parameters<ConvexHarness["run"]>[0];
+type TestContext = Parameters<TestRunFunction>[0];
+type TenantRole = "business_owner" | "business_admin" | "owner" | "scheduler" | "viewer";
+
+async function insertBusiness(
+  ctx: TestContext,
+  input: {
+    slug: string;
+    name?: string;
+    onboardingStage?: string;
+  },
+): Promise<Id<"businesses">> {
+  return await ctx.db.insert("businesses", {
+    slug: input.slug,
+    name: input.name ?? "Tenant Auth Business",
+    timezone: "America/Toronto",
+    businessType: "clinic",
+    defaultLocale: "en",
+    deploymentMode: "manual",
+    status: "active",
+    ...(input.onboardingStage !== undefined
+      ? { onboardingStage: input.onboardingStage }
+      : {}),
+  });
+}
+
+async function seedMember(
+  t: ConvexHarness,
+  input: {
+    subject: string;
+    role: TenantRole;
+    status?: "active" | "inactive";
+    businessSlug?: string;
+  },
+) {
+  const seeded = await t.run(async (ctx: TestContext) => {
+    const businessId = await insertBusiness(ctx, {
+      slug: input.businessSlug ?? `tenant-auth-${input.subject}`,
+    });
+    const userId = await ctx.db.insert("users", {
+      authSubject: input.subject,
+      email: `${input.subject}@example.com`,
+    });
+    await ctx.db.insert("business_memberships", {
+      businessId,
+      userId,
+      role: input.role,
+      status: input.status ?? "active",
+    });
+
+    return { businessId, userId };
+  });
+
+  return {
+    ...seeded,
+    authed: t.withIdentity({ subject: input.subject }),
+  };
+}
+
+async function seedOutsider(t: ConvexHarness, subject: string) {
+  await t.run(async (ctx: TestContext) => {
+    await ctx.db.insert("users", {
+      authSubject: subject,
+      email: `${subject}@example.com`,
+    });
+  });
+  return t.withIdentity({ subject });
+}
+
+const adminRoles = ["business_owner", "business_admin", "owner"] as const;
+const memberOnlyRoles = ["scheduler", "viewer"] as const;
+
+describe("tenant admin authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scheduleSnapshotRefreshMock.mockResolvedValue(null);
+  });
+
+  it.each(adminRoles)("allows %s to mutate tenant configuration", async (role) => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, authed } = await seedMember(t, {
+      subject: `tenant-admin-${role}`,
+      role,
+    });
+
+    await authed.mutation(api.businesses.catalog.updateBusinessName, {
+      businessId,
+      name: `${role} Updated`,
+    });
+    const staffResult = await authed.mutation(api.businesses.catalog.upsertStaff, {
+      businessId,
+      name: "Front Desk",
+      timezone: "America/Toronto",
+      active: true,
+    });
+    const uploadUrl = await authed.mutation(
+      api.ai.context.knowledge.generateKnowledgeDocumentUploadUrl,
+      { businessId },
+    );
+
+    const persisted = await t.run(async (ctx: TestContext) => ({
+      business: await ctx.db.get(businessId),
+      staff: await ctx.db.get(staffResult.staffId),
+    }));
+
+    expect(persisted.business?.name).toBe(`${role} Updated`);
+    expect(persisted.staff).toMatchObject({
+      businessId,
+      name: "Front Desk",
+    });
+    expect(uploadUrl).toEqual(expect.any(String));
+  });
+
+  it.each(memberOnlyRoles)("blocks %s from tenant configuration writes", async (role) => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, authed } = await seedMember(t, {
+      subject: `tenant-member-${role}`,
+      role,
+    });
+
+    await expect(
+      authed.mutation(api.businesses.catalog.updateBusinessName, {
+        businessId,
+        name: "Should Not Save",
+      }),
+    ).rejects.toThrow("Tenant admin access required.");
+
+    await expect(
+      authed.mutation(api.ai.context.knowledge.generateKnowledgeDocumentUploadUrl, {
+        businessId,
+      }),
+    ).rejects.toThrow("Tenant admin access required.");
+  });
+
+  it("blocks inactive members and outsiders from tenant configuration writes", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, authed: inactiveMember } = await seedMember(t, {
+      subject: "tenant-inactive-member",
+      role: "business_owner",
+      status: "inactive",
+    });
+    const outsider = await seedOutsider(t, "tenant-outsider");
+
+    await expect(
+      inactiveMember.mutation(api.businesses.catalog.updateBusinessName, {
+        businessId,
+        name: "Inactive Update",
+      }),
+    ).rejects.toThrow("You do not have access to this business.");
+
+    await expect(
+      outsider.mutation(api.businesses.catalog.updateBusinessName, {
+        businessId,
+        name: "Outsider Update",
+      }),
+    ).rejects.toThrow("You do not have access to this business.");
+  });
+
+  it("keeps read and operational member paths open for active operators", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, userId, authed } = await seedMember(t, {
+      subject: "tenant-active-scheduler",
+      role: "scheduler",
+    });
+
+    const configuration = await authed.query(api.businesses.catalog.getBusinessConfiguration, {
+      businessId,
+    });
+    await authed.mutation(api.businesses.admin.setActiveBusiness, {
+      businessId,
+    });
+
+    const user = await t.run(async (ctx: TestContext) => await ctx.db.get(userId));
+
+    expect(configuration.business?._id).toBe(businessId);
+    expect(user?.activeBusinessId).toBe(businessId);
+  });
+
+  it("filters inactive memberships from the current user's business list", async () => {
+    const t = convexTest(schema, convexModules);
+    const subject = "tenant-list-filter";
+    const { activeBusinessId, inactiveBusinessId } = await t.run(async (ctx: TestContext) => {
+      const activeBusinessId = await insertBusiness(ctx, {
+        slug: "tenant-list-filter-active",
+        name: "Active Business",
+      });
+      const inactiveBusinessId = await insertBusiness(ctx, {
+        slug: "tenant-list-filter-inactive",
+        name: "Inactive Business",
+      });
+      const userId = await ctx.db.insert("users", {
+        authSubject: subject,
+      });
+      await ctx.db.insert("business_memberships", {
+        businessId: activeBusinessId,
+        userId,
+        role: "scheduler",
+        status: "active",
+      });
+      await ctx.db.insert("business_memberships", {
+        businessId: inactiveBusinessId,
+        userId,
+        role: "business_owner",
+        status: "inactive",
+      });
+
+      return { activeBusinessId, inactiveBusinessId };
+    });
+
+    const businesses = await t
+      .withIdentity({ subject })
+      .query(api.businesses.admin.listForCurrentUser, {});
+
+    expect(businesses.map((entry) => entry.business._id)).toEqual([activeBusinessId]);
+    expect(businesses.map((entry) => entry.business._id)).not.toContain(inactiveBusinessId);
+  });
+
+  it("rejects cross-business staff, service, assignment, phone, and knowledge IDs", async () => {
+    const t = convexTest(schema, convexModules);
+    const subject = "tenant-cross-business-admin";
+    const seeded = await t.run(async (ctx: TestContext) => {
+      const businessAId = await insertBusiness(ctx, {
+        slug: "tenant-cross-business-a",
+        name: "Business A",
+      });
+      const businessBId = await insertBusiness(ctx, {
+        slug: "tenant-cross-business-b",
+        name: "Business B",
+      });
+      const userId = await ctx.db.insert("users", {
+        authSubject: subject,
+      });
+      await ctx.db.insert("business_memberships", {
+        businessId: businessAId,
+        userId,
+        role: "business_owner",
+        status: "active",
+      });
+      const staffAId = await ctx.db.insert("staff", {
+        businessId: businessAId,
+        name: "Staff A",
+        timezone: "America/Toronto",
+        active: true,
+      });
+      const staffBId = await ctx.db.insert("staff", {
+        businessId: businessBId,
+        name: "Staff B",
+        timezone: "America/Toronto",
+        active: true,
+      });
+      const serviceBId = await ctx.db.insert("services", {
+        businessId: businessBId,
+        name: "Service B",
+        slug: "service-b",
+        durationMinutes: 30,
+        active: true,
+      });
+      const phoneBId = await ctx.db.insert("phone_numbers", {
+        businessId: businessBId,
+        e164: "+14165550123",
+        voiceEnabled: true,
+        smsEnabled: true,
+        status: "active",
+      });
+      const snippetBId = await ctx.db.insert("knowledge_snippets", {
+        businessId: businessBId,
+        title: "Snippet B",
+        content: "Business B private knowledge.",
+        tags: [],
+        priority: 50,
+        active: true,
+      });
+      const documentBId = await ctx.db.insert("knowledge_documents", {
+        businessId: businessBId,
+        active: true,
+        sourceType: "manual",
+        title: "Document B",
+        textContent: "Business B private document.",
+        status: "indexed",
+        processingProgress: 100,
+        tags: [],
+        importance: 50,
+      });
+
+      return {
+        businessAId,
+        staffAId,
+        staffBId,
+        serviceBId,
+        phoneBId,
+        snippetBId,
+        documentBId,
+      };
+    });
+
+    const authed = t.withIdentity({ subject });
+
+    await expect(
+      authed.mutation(api.businesses.catalog.upsertStaff, {
+        businessId: seeded.businessAId,
+        staffId: seeded.staffBId,
+        name: "Hijacked Staff",
+        timezone: "America/Toronto",
+        active: false,
+      }),
+    ).rejects.toThrow("Staff member not found for this business.");
+
+    await expect(
+      t.mutation(internal.businesses.catalog.upsertServiceInternal, {
+        businessId: seeded.businessAId,
+        serviceId: seeded.serviceBId,
+        name: "Hijacked Service",
+        slug: "hijacked-service",
+        durationMinutes: 45,
+        active: false,
+      }),
+    ).rejects.toThrow("Service not found for this business.");
+
+    await expect(
+      authed.mutation(api.businesses.catalog.replaceStaffServiceAssignments, {
+        businessId: seeded.businessAId,
+        assignments: [
+          {
+            staffId: seeded.staffAId,
+            serviceId: seeded.serviceBId,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Service not found for this business.");
+
+    await expect(
+      authed.action(api.businesses.catalog.savePhoneNumber, {
+        businessId: seeded.businessAId,
+        phoneNumberId: seeded.phoneBId,
+        e164: "+14165550123",
+        voiceEnabled: true,
+        smsEnabled: true,
+        status: "active",
+      }),
+    ).rejects.toThrow("Phone number not found for this business.");
+
+    await expect(
+      authed.action(api.ai.context.knowledge.deleteKnowledgeEntry, {
+        businessId: seeded.businessAId,
+        snippetId: seeded.snippetBId,
+      }),
+    ).rejects.toThrow("Knowledge snippet not found.");
+
+    await expect(
+      authed.action(api.ai.context.knowledge.setKnowledgeEntryActive, {
+        businessId: seeded.businessAId,
+        documentId: seeded.documentBId,
+        active: false,
+      }),
+    ).rejects.toThrow("Knowledge document not found.");
+
+    const persisted = await t.run(async (ctx: TestContext) => ({
+      staffB: await ctx.db.get(seeded.staffBId),
+      serviceB: await ctx.db.get(seeded.serviceBId),
+      phoneB: await ctx.db.get(seeded.phoneBId),
+      snippetB: await ctx.db.get(seeded.snippetBId),
+      documentB: await ctx.db.get(seeded.documentBId),
+    }));
+
+    expect(persisted.staffB).toMatchObject({ name: "Staff B", active: true });
+    expect(persisted.serviceB).toMatchObject({ name: "Service B", active: true });
+    expect(persisted.phoneB).toMatchObject({ businessId: expect.any(String) });
+    expect(persisted.snippetB).toMatchObject({ title: "Snippet B", active: true });
+    expect(persisted.documentB).toMatchObject({ title: "Document B", active: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Introduce shared tenant-admin auth helpers in Convex and apply them across tenant configuration, onboarding, calendar, billing, and knowledge write paths.
- Filter inactive memberships from active-business selection and hide or disable dashboard write controls for non-admin operators.
- Tighten cross-business ID checks for staff, services, phone numbers, and knowledge entries.
- Add regression coverage for tenant-admin authorization and dashboard knowledge controls.

## Testing
- `pnpm --filter @lobbystack/web exec vitest run src/features/agent/AgentKnowledgePage.test.tsx`
- `pnpm test:convex -- convex/tests/tenantAdminAuthorization.test.ts`
- `pnpm --filter @lobbystack/web typecheck`
- `pnpm typecheck:convex`