### PR TITLE
Harden production fallbacks and restore docs validation

### DIFF
--- a/apps/voice-gateway/src/context/fetchSnapshot.ts
+++ b/apps/voice-gateway/src/context/fetchSnapshot.ts
@@ -28,7 +28,7 @@ export async function fetchSnapshotForPhoneNumber(
     const payload = (await response.json()) as VoiceContextResponse;
     return payload.snapshot;
   } catch (error) {
-    if (env.DEPLOYMENT_MODE === "development") {
+    if (env.DEPLOYMENT_MODE === "development" && env.NODE_ENV !== "production") {
       console.warn("[voice-gateway] Falling back to demo snapshot.", error);
       return demoSnapshot;
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,6 @@
     "react-phone-number-input": "^3.4.16",
     "react-router-dom": "^7.4.0",
     "recharts": "3.8.0",
-    "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
@@ -64,6 +63,7 @@
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^29.0.1",
+    "shadcn": "^4.7.0",
     "vite": "^8.0.10"
   }
 }

--- a/convex/ai/context/websiteIngestionActions.test.ts
+++ b/convex/ai/context/websiteIngestionActions.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { lookup } from "node:dns/promises";
 
 import {
+  assertWebsiteCrawlTargetIsPublic,
   buildExistingWebsiteDocumentsBySourceUrl,
   isWebsiteDocumentInScope,
   resolveRunningWebsiteCrawlStatus,
@@ -8,8 +10,13 @@ import {
   startOrReuseFirecrawlScrapeJob,
 } from "./websiteIngestionActions";
 
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
 describe("websiteIngestionActions helpers", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.unstubAllEnvs();
   });
 
@@ -96,6 +103,16 @@ describe("websiteIngestionActions helpers", () => {
         fetchMock,
       ),
     ).rejects.toThrow("Failed to fetch Firecrawl markdown file (503 Service Unavailable).");
+  });
+
+  it("fails closed when DNS public-target verification has a transient error", async () => {
+    const error = new Error("temporary resolver failure") as NodeJS.ErrnoException;
+    error.code = "EAI_AGAIN";
+    vi.mocked(lookup).mockRejectedValueOnce(error);
+
+    await expect(assertWebsiteCrawlTargetIsPublic("https://example.com")).rejects.toThrow(
+      "Could not verify that the website URL resolves to a public hostname. Please retry.",
+    );
   });
 
   it("marks running crawls stalled when provider progress stops", () => {

--- a/convex/ai/context/websiteIngestionActions.ts
+++ b/convex/ai/context/websiteIngestionActions.ts
@@ -380,7 +380,7 @@ function isTransientDnsLookupError(error: unknown): boolean {
   );
 }
 
-async function assertWebsiteCrawlTargetIsPublic(websiteUrl: string): Promise<void> {
+export async function assertWebsiteCrawlTargetIsPublic(websiteUrl: string): Promise<void> {
   const parsed = new URL(websiteUrl);
   if (isDirectlyBlockedWebsiteHostname(parsed.hostname)) {
     throw new Error(WEBSITE_PUBLIC_URL_ERROR_MESSAGE);
@@ -405,7 +405,7 @@ async function assertWebsiteCrawlTargetIsPublic(websiteUrl: string): Promise<voi
       throw new Error("Enter a public website URL with a live hostname.");
     }
     if (isTransientDnsLookupError(error)) {
-      return;
+      throw new Error("Could not verify that the website URL resolves to a public hostname. Please retry.");
     }
     throw error;
   }

--- a/convex/lib/turnstile.ts
+++ b/convex/lib/turnstile.ts
@@ -20,7 +20,7 @@ export async function verifyTurnstileForSignUp(
 ): Promise<void> {
   const secret = process.env.TURNSTILE_SECRET_KEY?.trim();
   if (!secret) {
-    if (process.env.DEPLOYMENT_MODE === "development") {
+    if (process.env.DEPLOYMENT_MODE === "development" && process.env.NODE_ENV !== "production") {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -12,14 +12,23 @@
       "@hono/node-server": "1.19.13",
       "@xmldom/xmldom": "0.8.13",
       "axios": "1.15.2",
+      "basic-ftp": "5.3.1",
       "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
+      "@mintlify/previewing": "4.0.1096",
+      "@mintlify/scraping>zod": "3.25.76",
+      "@mintlify/validation>zod": "3.25.76",
       "dompurify": "3.4.0",
       "follow-redirects": "1.16.0",
-      "hono": "4.12.14",
+      "fast-uri": "3.1.2",
+      "hono": "4.12.18",
+      "ip-address": "10.1.1",
+      "js-yaml": "4.1.1",
+      "lodash": "4.18.1",
       "path-to-regexp@>=8.0.0 <8.4.0": "8.4.0",
       "picomatch": "2.3.2",
       "postcss": "8.5.10",
       "protobufjs@<7.5.5": "7.5.5",
+      "tar": "7.5.15",
       "uuid": "14.0.0"
     },
     "supportedArchitectures": {
@@ -38,7 +47,10 @@
     },
     "onlyBuiltDependencies": [
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mintlify/previewing@4.0.1096": "patches/@mintlify__previewing@4.0.1096.patch"
+    }
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.43",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { loadVoiceGatewayEnv } from "./index";
+
+const baseVoiceGatewayEnv = {
+  VOICE_GATEWAY_BASE_URL: "https://voice.example.com",
+  CONVEX_SITE_URL: "https://example.convex.site",
+  INTERNAL_SERVICE_TOKEN: "test-token",
+};
+
+describe("loadVoiceGatewayEnv", () => {
+  it("rejects development deployment mode in production", () => {
+    expect(() =>
+      loadVoiceGatewayEnv({
+        ...baseVoiceGatewayEnv,
+        NODE_ENV: "production",
+        DEPLOYMENT_MODE: "development",
+      }),
+    ).toThrow("DEPLOYMENT_MODE=development is not allowed when NODE_ENV=production.");
+  });
+
+  it("allows development deployment mode outside production", () => {
+    expect(
+      loadVoiceGatewayEnv({
+        ...baseVoiceGatewayEnv,
+        NODE_ENV: "development",
+        DEPLOYMENT_MODE: "development",
+      }).DEPLOYMENT_MODE,
+    ).toBe("development");
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -98,6 +98,14 @@ const voiceGatewayEnvSchema = z.object({
   POSTHOG_KEY: z.string().optional(),
   POSTHOG_HOST: z.string().url().optional(),
   POSTHOG_PRIVACY_MODE: booleanEnvSchema,
+}).superRefine((env, ctx) => {
+  if (env.NODE_ENV === "production" && env.DEPLOYMENT_MODE === "development") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "DEPLOYMENT_MODE=development is not allowed when NODE_ENV=production.",
+      path: ["DEPLOYMENT_MODE"],
+    });
+  }
 });
 
 export type ServerEnv = z.infer<typeof serverEnvSchema>;

--- a/patches/@mintlify__previewing@4.0.1096.patch
+++ b/patches/@mintlify__previewing@4.0.1096.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/local-preview/client.js b/dist/local-preview/client.js
+index f14d091602c068664b73aff6a50c891315b902ff..beaf891c2011261d130e7cd8b41594556c5be5b3 100644
+--- a/dist/local-preview/client.js
++++ b/dist/local-preview/client.js
+@@ -2,7 +2,7 @@ import fse from 'fs-extra';
+ import got from 'got';
+ import isOnline from 'is-online';
+ import { pipeline } from 'node:stream/promises';
+-import tar from 'tar';
++import * as tar from 'tar';
+ import yaml from 'js-yaml';
+ import { DOT_MINTLIFY, DOT_MINTLIFY_LAST, VERSION_PATH, TAR_PATH, TARGET_MINT_VERSION_URL, MINT_VERSION_MAP_URL, } from '../constants.js';
+ import { restoreMintlifyLast, getTarUrl } from '../util.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,29 @@ overrides:
   '@hono/node-server': 1.19.13
   '@xmldom/xmldom': 0.8.13
   axios: 1.15.2
+  basic-ftp: 5.3.1
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  '@mintlify/previewing': 4.0.1096
+  '@mintlify/scraping>zod': 3.25.76
+  '@mintlify/validation>zod': 3.25.76
   dompurify: 3.4.0
   follow-redirects: 1.16.0
-  hono: 4.12.14
+  fast-uri: 3.1.2
+  hono: 4.12.18
+  ip-address: 10.1.1
+  js-yaml: 4.1.1
+  lodash: 4.18.1
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.0
   picomatch: 2.3.2
   postcss: 8.5.10
   protobufjs@<7.5.5: 7.5.5
+  tar: 7.5.15
   uuid: 14.0.0
+
+patchedDependencies:
+  '@mintlify/previewing@4.0.1096':
+    hash: 8d5f5a9791563cf6b3cda9df22ec0b0682f0b0d1c699df07770078d1c200515b
+    path: patches/@mintlify__previewing@4.0.1096.patch
 
 importers:
 
@@ -30,7 +44,7 @@ importers:
         version: 0.3.0(convex@1.37.0(react@19.2.4))
       '@convex-dev/agent':
         specifier: latest
-        version: 0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)
+        version: 0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)
       '@convex-dev/auth':
         specifier: latest
         version: 0.0.91(@auth/core@0.37.4)(convex@1.37.0(react@19.2.4))(react@19.2.4)
@@ -39,25 +53,25 @@ importers:
         version: 0.2.0(convex@1.37.0(react@19.2.4))
       '@convex-dev/persistent-text-streaming':
         specifier: 0.3.2
-        version: 0.3.2(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.3.2(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       '@convex-dev/polar':
         specifier: ^0.9.0
-        version: 0.9.0(@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@polar-sh/sdk@0.47.0)(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.9.0(@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@polar-sh/sdk@0.47.0)(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       '@convex-dev/rag':
         specifier: latest
-        version: 0.7.2(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(zod@3.25.76)
+        version: 0.7.2(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(zod@3.25.76)
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
         version: 0.3.2(convex@1.37.0(react@19.2.4))(react@19.2.4)
       '@convex-dev/resend':
         specifier: ^0.2.3
-        version: 0.2.3(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)
+        version: 0.2.3(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)
       '@convex-dev/workflow':
         specifier: latest
-        version: 0.3.6(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
+        version: 0.3.6(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
       '@convex-dev/workpool':
         specifier: latest
-        version: 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
+        version: 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
       '@polar-sh/sdk':
         specifier: ^0.47.0
         version: 0.47.0
@@ -203,7 +217,7 @@ importers:
         version: 0.0.91(@auth/core@0.37.4)(convex@1.37.0(react@19.2.4))(react@19.2.4)
       '@convex-dev/persistent-text-streaming':
         specifier: 0.3.2
-        version: 0.3.2(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.3.2(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -303,9 +317,6 @@ importers:
       recharts:
         specifier: 3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
-      shadcn:
-        specifier: ^4.6.0
-        version: 4.6.0(@types/node@24.12.0)(typescript@5.9.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -346,6 +357,9 @@ importers:
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1(@noble/hashes@1.8.0)
+      shadcn:
+        specifier: ^4.7.0
+        version: 4.7.0(@types/node@24.12.0)(typescript@5.9.3)
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -1184,7 +1198,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.14
+      hono: 4.12.18
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1590,6 +1604,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jimp/core@1.6.1':
     resolution: {integrity: sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==}
     engines: {node: '>=18'}
@@ -1759,6 +1777,9 @@ packages:
   '@mintlify/common@1.0.866':
     resolution: {integrity: sha512-CklMEo/RvhUqrkaPK0IyeTV0IlBcNgKjA734U32cT5Ioo5Ks4PELN/YHRh5PdPHnXopbwsOPTPb3CwrVuLbuWQ==}
 
+  '@mintlify/common@1.0.891':
+    resolution: {integrity: sha512-kIs/WRucQ++egFffAcpTxALPyD0vr574YxSvhSTL+tHAGwxcUye6uqwDCYJTHSv/dSW3sz9Uam1thrgW4cLS4Q==}
+
   '@mintlify/link-rot@3.0.1044':
     resolution: {integrity: sha512-PZTp4Lm4YUdHxD5yZjgDCIvibzvUKGGMUzueX4sS4oh8CtDqJFHJUU6smiqhHirNcsLnr48pyzGp4bzd+P7ODg==}
     engines: {node: '>=18.0.0'}
@@ -1778,6 +1799,10 @@ packages:
     resolution: {integrity: sha512-XpmFKNxH3G/RvHolPbqnOMHOIDBZkD16TahXPzJFIkdJ0NtnUXnJKP539rbLZjT0lWBs0STa5jtDISOW6G82MA==}
     engines: {node: '>=18.0.0'}
 
+  '@mintlify/models@0.0.307':
+    resolution: {integrity: sha512-4lJrNXst3J1PcDhiFXHwYl+RnwhQyQt4l1sM2u6JotjoUR7Rx5NN5E8QukJmim1jLd7/v4qMzeD7s7F5TbV7zw==}
+    engines: {node: '>=18.0.0'}
+
   '@mintlify/openapi-parser@0.0.8':
     resolution: {integrity: sha512-9MBRq9lS4l4HITYCrqCL7T61MOb20q9IdU7HWhqYMNMM1jGO1nHjXasFy61yZ8V6gMZyyKQARGVoZ0ZrYN48Og==}
     engines: {node: '>=18'}
@@ -1785,8 +1810,11 @@ packages:
   '@mintlify/prebuild@1.0.1009':
     resolution: {integrity: sha512-4MSW8c82f3OYYIZFPUoTjpNdCz7ygs/v+VeuJmgZNzCnOliX/kIvvP/CNBweH59CYsoBX1llPXUb7/Ok3JZ9rw==}
 
-  '@mintlify/previewing@4.0.1070':
-    resolution: {integrity: sha512-+eH0mTxwUUJ7jg1PV5JfplE9GPwbL4j0NebF2F/hEkmDKyEHnXLMUSjLGpP3g+FL29eeOoCGXejJdsj662GahQ==}
+  '@mintlify/prebuild@1.0.1035':
+    resolution: {integrity: sha512-QIg9uVr+m6hrGCNs5sVZo75c2H73BLIRLIvNBPJ7oy8AAFyz0ELtn12QFrxZ8s2A6o1db+gIg7R2gIfrRKbw+A==}
+
+  '@mintlify/previewing@4.0.1096':
+    resolution: {integrity: sha512-+B39yQpA4XuUBxhN2WFGpPauYmxFrEJug2w2K36rDZGDN9fQzJ9DMuI139+3XhvqNng6AUCLQhsCjlPYfAve/Q==}
     engines: {node: '>=18.0.0'}
 
   '@mintlify/scraping@4.0.522':
@@ -1799,11 +1827,19 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  '@mintlify/scraping@4.0.755':
+    resolution: {integrity: sha512-7Ms+bWpvQv1bzyRoukyS0uUJjdrmEfrNVqS9xbRocGXstuK5Z/hUIMvFqTsEMU2vsxYtHQ5pkjeir062XYu/wQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   '@mintlify/validation@0.1.555':
     resolution: {integrity: sha512-11QVUReL4N5u8wSCgZt4RN7PA0jYQoMEBZ5IrUp5pgb5ZJBOoGV/vPsQrxPPa1cxsUDAuToNhtGxRQtOav/w8w==}
 
   '@mintlify/validation@0.1.677':
     resolution: {integrity: sha512-qxvqzOcPabkJkQIokjyn7t2dgnK1Aot+UCB2Tp1rmTW6yedt7kzIdIiKAh1tepsrVwEmweXPIa+Kmu7zEoFIiQ==}
+
+  '@mintlify/validation@0.1.697':
+    resolution: {integrity: sha512-BuzbfFf4bCOGQQfGxa1fS9DIDt5Uw7F8UOEFCJYxMmDT2kPSs2sbysqCG1YxzBs0rPO/NMKBOg24pOt4CZD+rg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3269,6 +3305,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -3608,8 +3645,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   better-opn@3.0.2:
@@ -3759,9 +3796,9 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chromium-bidi@0.6.2:
     resolution: {integrity: sha512-4WVBa6ijmUTVr9cZD4eicQD8Mdy/HCX3bzEIYYpmk0glqYLoWH+LqQEvV9RpDRzoQSbY1KJHloYXbDMXMbDPhg==}
@@ -3920,7 +3957,7 @@ packages:
     peerDependencies:
       '@standard-schema/spec': ^1.0.0
       convex: ^1.32.0
-      hono: 4.12.14
+      hono: 4.12.18
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       typescript: ^5.5
       zod: ^3.25.0 || ^4.0.0
@@ -4537,8 +4574,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -4679,10 +4716,6 @@ packages:
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
-
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -4900,8 +4933,8 @@ packages:
     resolution: {integrity: sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w==}
     engines: {node: '>=12'}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -5067,8 +5100,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.1.1:
+    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
 
   ip-regex@4.3.0:
@@ -5342,14 +5375,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -5573,9 +5598,6 @@ packages:
 
   lodash.topath@4.5.2:
     resolution: {integrity: sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -5921,21 +5943,13 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mint@4.2.532:
     resolution: {integrity: sha512-ex+IF01QCpRY6277xeRaengHBB6bd5ukD+tzwKKVzN0nMllXjXc63UWcSxEbqjpc41ewVcxo80xTNo/T/Z6soA==}
@@ -5947,11 +5961,6 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
@@ -7076,8 +7085,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.6.0:
-    resolution: {integrity: sha512-4XeMwFf8ZZxmqQQp+U+Nsq2M+cY4Da8Joo/EaMdHVc4uVuWSTJoeidlZ3gDjyxXCjYB1FLcxYwR4lYQAH8emOg==}
+  shadcn@4.7.0:
+    resolution: {integrity: sha512-70fwnesNrY1GgeD7Kdzn+3SsYeyfibm8immsA5L68+OusoPTvYF01oWExl8/latKpMpvVXcbgdbbE6VFBJQ38w==}
     hasBin: true
 
   sharp-ico@0.1.5:
@@ -7380,10 +7389,9 @@ packages:
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
-  tar@6.1.15:
-    resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -8002,8 +8010,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -8049,20 +8058,14 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@3.21.4:
-    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
-  zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8384,12 +8387,12 @@ snapshots:
     dependencies:
       convex: 1.37.0(react@19.2.4)
 
-  '@convex-dev/agent@0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)':
+  '@convex-dev/agent@0.3.2(@ai-sdk/provider-utils@4.0.19(zod@3.25.76))(ai@6.0.116(zod@3.25.76))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
       ai: 6.0.116(zod@3.25.76)
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       '@ungap/structured-clone': 1.3.0
       react: 19.2.4
@@ -8416,10 +8419,10 @@ snapshots:
       convex: 1.37.0(react@19.2.4)
       cron-parser: 4.9.0
 
-  '@convex-dev/persistent-text-streaming@0.3.2(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)':
+  '@convex-dev/persistent-text-streaming@0.3.2(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
@@ -8428,13 +8431,13 @@ snapshots:
       - typescript
       - zod
 
-  '@convex-dev/polar@0.9.0(@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@polar-sh/sdk@0.47.0)(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)':
+  '@convex-dev/polar@0.9.0(@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1))(@polar-sh/sdk@0.47.0)(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       '@polar-sh/sdk': 0.47.0
       buffer: 6.0.3
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       remeda: 2.33.6
@@ -8445,12 +8448,12 @@ snapshots:
       - typescript
       - zod
 
-  '@convex-dev/rag@0.7.2(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(zod@3.25.76)':
+  '@convex-dev/rag@0.7.2(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(zod@3.25.76)':
     dependencies:
-      '@convex-dev/workpool': 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
+      '@convex-dev/workpool': 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
       ai: 6.0.116(zod@3.25.76)
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 
@@ -8460,12 +8463,12 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
 
-  '@convex-dev/resend@0.2.3(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)':
+  '@convex-dev/resend@0.2.3(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@convex-dev/rate-limiter': 0.3.2(convex@1.37.0(react@19.2.4))(react@19.2.4)
-      '@convex-dev/workpool': 0.3.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
+      '@convex-dev/workpool': 0.3.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
       remeda: 2.33.6
       resend: 6.9.4
       svix: 1.89.0
@@ -8473,22 +8476,22 @@ snapshots:
       - '@react-email/render'
       - react
 
-  '@convex-dev/workflow@0.3.6(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))':
+  '@convex-dev/workflow@0.3.6(@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))':
     dependencies:
-      '@convex-dev/workpool': 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
+      '@convex-dev/workpool': 0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))
       async-channel: 0.2.0
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
 
-  '@convex-dev/workpool@0.3.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))':
+  '@convex-dev/workpool@0.3.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))':
     dependencies:
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
 
-  '@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))':
+  '@convex-dev/workpool@0.4.2(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76))(convex@1.37.0(react@19.2.4))':
     dependencies:
       convex: 1.37.0(react@19.2.4)
-      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76)
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -8755,7 +8758,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
 
   '@fastify/error@4.2.0': {}
 
@@ -8815,9 +8818,9 @@ snapshots:
 
   '@fontsource/geist-sans@5.2.5': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.14)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.18
 
   '@img/colour@1.1.0': {}
 
@@ -8967,7 +8970,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -9114,6 +9117,10 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@24.12.0)':
     optionalDependencies:
       '@types/node': 24.12.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jimp/core@1.6.1':
     dependencies:
@@ -9413,7 +9420,7 @@ snapshots:
       '@mintlify/common': 1.0.866(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/link-rot': 3.0.1044(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/prebuild': 1.0.1009(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@mintlify/previewing': 4.0.1070(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/previewing': 4.0.1096(patch_hash=8d5f5a9791563cf6b3cda9df22ec0b0682f0b0d1c699df07770078d1c200515b)(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/validation': 0.1.677(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       adm-zip: 0.5.16
       chalk: 5.2.0
@@ -9423,7 +9430,7 @@ snapshots:
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.14)(react@19.2.3)
       inquirer: 12.3.0(@types/node@24.12.0)
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.2.0
       open: 8.4.2
       openid-client: 6.8.4
@@ -9432,7 +9439,7 @@ snapshots:
       semver: 7.7.2
       unist-util-visit: 5.0.0
       yargs: 17.7.1
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       keytar: 7.9.0
     transitivePeerDependencies:
@@ -9474,8 +9481,8 @@ snapshots:
       hast-util-to-text: 4.0.2
       hex-rgb: 5.0.0
       ignore: 7.0.5
-      js-yaml: 4.1.0
-      lodash: 4.17.21
+      js-yaml: 4.1.1
+      lodash: 4.18.1
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
       mdast-util-mdx: 3.0.0
@@ -9535,7 +9542,71 @@ snapshots:
       hast-util-to-text: 4.0.2
       hex-rgb: 5.0.0
       ignore: 7.0.5
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
+      lodash: 4.18.1
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm: 3.0.0
+      mdast-util-mdx: 3.0.0
+      mdast-util-mdx-jsx: 3.1.3
+      micromark-extension-gfm: 3.0.0
+      micromark-extension-mdx-jsx: 3.0.1
+      micromark-extension-mdxjs: 3.0.0
+      openapi-types: 12.1.3
+      postcss: 8.5.10
+      rehype-stringify: 10.0.1
+      remark: 15.0.1
+      remark-frontmatter: 5.0.0
+      remark-gfm: 4.0.0
+      remark-math: 6.0.0
+      remark-mdx: 3.1.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.1
+      remark-stringify: 11.0.0
+      sucrase: 3.35.1
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+      unified: 11.0.5
+      unist-builder: 4.0.0
+      unist-util-map: 4.0.0
+      unist-util-remove: 4.0.0
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.0.0
+      unist-util-visit-parents: 6.0.1
+      vfile: 6.0.3
+      xss: 1.0.15
+    transitivePeerDependencies:
+      - '@radix-ui/react-popover'
+      - '@types/react'
+      - debug
+      - encoding
+      - react
+      - react-dom
+      - supports-color
+      - tsx
+      - typescript
+      - yaml
+
+  '@mintlify/common@1.0.891(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+    dependencies:
+      '@asyncapi/parser': 3.4.0
+      '@asyncapi/specs': 6.8.1
+      '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@mintlify/models': 0.0.307
+      '@mintlify/openapi-parser': 0.0.8
+      '@mintlify/validation': 0.1.697(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@sindresorhus/slugify': 2.2.0
+      '@types/mdast': 4.0.4
+      acorn: 8.11.2
+      acorn-jsx: 5.3.2(acorn@8.11.2)
+      color-blend: 4.0.0
+      estree-util-to-js: 2.0.0
+      estree-walker: 3.0.3
+      front-matter: 4.0.2
+      hast-util-from-html: 2.0.3
+      hast-util-to-html: 9.0.4
+      hast-util-to-text: 4.0.2
+      hex-rgb: 5.0.0
+      ignore: 7.0.5
+      js-yaml: 4.1.1
       lodash: 4.18.1
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.0.0
@@ -9583,7 +9654,7 @@ snapshots:
       '@mintlify/common': 1.0.866(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/models': 0.0.297
       '@mintlify/prebuild': 1.0.1009(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@mintlify/previewing': 4.0.1070(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/previewing': 4.0.1096(patch_hash=8d5f5a9791563cf6b3cda9df22ec0b0682f0b0d1c699df07770078d1c200515b)(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/scraping': 4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/validation': 0.1.677(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       fs-extra: 11.1.0
@@ -9647,6 +9718,13 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@mintlify/models@0.0.307':
+    dependencies:
+      axios: 1.15.2
+      openapi-types: 12.1.3
+    transitivePeerDependencies:
+      - debug
+
   '@mintlify/openapi-parser@0.0.8':
     dependencies:
       ajv: 8.18.0
@@ -9666,7 +9744,7 @@ snapshots:
       favicons: 7.2.0
       front-matter: 4.0.2
       fs-extra: 11.1.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       openapi-types: 12.1.3
       sharp: 0.33.5
       sharp-ico: 0.1.5
@@ -9689,11 +9767,44 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@mintlify/previewing@4.0.1070(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@mintlify/prebuild@1.0.1035(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
-      '@mintlify/common': 1.0.866(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@mintlify/prebuild': 1.0.1009(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@mintlify/validation': 0.1.677(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@mintlify/common': 1.0.891(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/openapi-parser': 0.0.8
+      '@mintlify/scraping': 4.0.755(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/validation': 0.1.697(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      chalk: 5.3.0
+      favicons: 7.2.0
+      front-matter: 4.0.2
+      fs-extra: 11.1.0
+      js-yaml: 4.1.1
+      openapi-types: 12.1.3
+      sharp: 0.33.5
+      sharp-ico: 0.1.5
+      unist-util-visit: 4.1.2
+      uuid: 14.0.0
+    transitivePeerDependencies:
+      - '@radix-ui/react-popover'
+      - '@types/react'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - debug
+      - encoding
+      - react
+      - react-dom
+      - react-native-b4a
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+
+  '@mintlify/previewing@4.0.1096(patch_hash=8d5f5a9791563cf6b3cda9df22ec0b0682f0b0d1c699df07770078d1c200515b)(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+    dependencies:
+      '@mintlify/common': 1.0.891(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/prebuild': 1.0.1035(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/validation': 0.1.697(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       adm-zip: 0.5.16
       better-opn: 3.0.2
       chalk: 5.2.0
@@ -9705,11 +9816,11 @@ snapshots:
       ink: 6.3.0(@types/react@19.2.14)(react@19.2.3)
       ink-spinner: 5.0.0(ink@6.3.0(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       is-online: 10.0.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       openapi-types: 12.1.3
       react: 19.2.3
       socket.io: 4.8.0
-      tar: 6.1.15
+      tar: 7.5.15
       unist-util-visit: 4.1.2
       yargs: 17.7.1
     transitivePeerDependencies:
@@ -9735,7 +9846,7 @@ snapshots:
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.1.3
       neotraverse: 0.6.18
       puppeteer: 22.14.0(typescript@5.9.3)
@@ -9747,7 +9858,7 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.0.0
       yargs: 17.7.1
-      zod: 3.21.4
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/react'
@@ -9770,7 +9881,7 @@ snapshots:
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.1.3
       neotraverse: 0.6.18
       puppeteer: 22.14.0(typescript@5.9.3)
@@ -9782,7 +9893,43 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.0.0
       yargs: 17.7.1
-      zod: 3.24.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@radix-ui/react-popover'
+      - '@types/react'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - debug
+      - encoding
+      - react
+      - react-dom
+      - react-native-b4a
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+
+  '@mintlify/scraping@4.0.755(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+    dependencies:
+      '@mintlify/common': 1.0.891(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/openapi-parser': 0.0.8
+      fs-extra: 11.1.1
+      hast-util-to-mdast: 10.1.0
+      js-yaml: 4.1.1
+      mdast-util-mdx-jsx: 3.1.3
+      neotraverse: 0.6.18
+      puppeteer: 22.14.0(typescript@5.9.3)
+      rehype-parse: 9.0.1
+      remark-gfm: 4.0.0
+      remark-mdx: 3.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      yargs: 17.7.1
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/react'
@@ -9805,14 +9952,14 @@ snapshots:
       '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/models': 0.0.255
       arktype: 2.1.27
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       lcm: 0.0.3
-      lodash: 4.17.21
+      lodash: 4.18.1
       object-hash: 3.0.0
       openapi-types: 12.1.3
       uuid: 14.0.0
-      zod: 3.21.4
-      zod-to-json-schema: 3.20.4(zod@3.21.4)
+      zod: 3.25.76
+      zod-to-json-schema: 3.20.4(zod@3.25.76)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/react'
@@ -9827,15 +9974,38 @@ snapshots:
       '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/models': 0.0.297
       arktype: 2.1.27
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       lcm: 0.0.3
       lodash: 4.18.1
       neotraverse: 0.6.18
       object-hash: 3.0.0
       openapi-types: 12.1.3
       uuid: 14.0.0
-      zod: 3.24.0
-      zod-to-json-schema: 3.20.4(zod@3.24.0)
+      zod: 3.25.76
+      zod-to-json-schema: 3.20.4(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@radix-ui/react-popover'
+      - '@types/react'
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - typescript
+
+  '@mintlify/validation@0.1.697(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
+    dependencies:
+      '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@mintlify/models': 0.0.307
+      arktype: 2.1.27
+      js-yaml: 4.1.1
+      lcm: 0.0.3
+      lodash: 4.18.1
+      neotraverse: 0.6.18
+      object-hash: 3.0.0
+      openapi-types: 12.1.3
+      uuid: 14.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.20.4(zod@3.25.76)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/react'
@@ -9847,7 +10017,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.14)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9857,7 +10027,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.14
+      hono: 4.12.18
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -11675,7 +11845,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11846,7 +12016,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@5.3.1: {}
 
   better-opn@3.0.2:
     dependencies:
@@ -12030,7 +12200,7 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
-  chownr@2.0.0: {}
+  chownr@3.0.0: {}
 
   chromium-bidi@0.6.2(devtools-protocol@0.0.1312386):
     dependencies:
@@ -12166,12 +12336,12 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
 
-  convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.14)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76):
+  convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.37.0(react@19.2.4))(hono@4.12.18)(react@19.2.4)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       convex: 1.37.0(react@19.2.4)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
-      hono: 4.12.14
+      hono: 4.12.18
       react: 19.2.4
       typescript: 5.9.3
       zod: 3.25.76
@@ -12813,7 +12983,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.1.1
 
   express@4.22.0:
     dependencies:
@@ -12915,7 +13085,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -12927,7 +13097,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -13072,7 +13242,7 @@ snapshots:
 
   front-matter@4.0.2:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.1.1
 
   fs-constants@1.0.0:
     optional: true
@@ -13100,10 +13270,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
-
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
 
   fsevents@2.3.2:
     optional: true
@@ -13181,7 +13347,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -13453,7 +13619,7 @@ snapshots:
 
   hex-rgb@5.0.0: {}
 
-  hono@4.12.14: {}
+  hono@4.12.18: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -13636,7 +13802,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.1.1: {}
 
   ip-regex@4.3.0: {}
 
@@ -13888,15 +14054,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -14104,8 +14261,6 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash.topath@4.5.2: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 
@@ -14751,18 +14906,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minipass@7.1.3: {}
 
-  minizlib@2.1.2:
+  minizlib@3.1.0:
     dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
+      minipass: 7.1.3
 
   mint@4.2.532(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@24.12.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
@@ -14790,8 +14938,6 @@ snapshots:
 
   mkdirp-classic@0.5.3:
     optional: true
-
-  mkdirp@1.0.4: {}
 
   motion-dom@12.38.0:
     dependencies:
@@ -16171,7 +16317,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.6.0(@types/node@24.12.0)(typescript@5.9.3):
+  shadcn@4.7.0(@types/node@24.12.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.0
@@ -16400,7 +16546,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.1.1
       smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
@@ -16549,7 +16695,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -16681,14 +16827,13 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@6.1.15:
+  tar@7.5.15:
     dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   teex@1.0.1:
     dependencies:
@@ -17334,7 +17479,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0: {}
+  yallist@5.0.0: {}
 
   yaml@2.8.3: {}
 
@@ -17373,26 +17518,18 @@ snapshots:
 
   zlibjs@0.3.1: {}
 
-  zod-to-json-schema@3.20.4(zod@3.21.4):
+  zod-to-json-schema@3.20.4(zod@3.25.76):
     dependencies:
-      zod: 3.21.4
-
-  zod-to-json-schema@3.20.4(zod@3.24.0):
-    dependencies:
-      zod: 3.24.0
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
-  zod@3.21.4: {}
-
   zod@3.23.8: {}
-
-  zod@3.24.0: {}
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Tighten production fallback handling in the voice gateway, website ingestion flow, and Turnstile/config helpers
- Refresh config and coverage tests to keep the new behavior bounded and regression-safe
- Update the Mintlify previewing patch and workspace metadata so docs validation runs cleanly again

## Testing
- Added and updated unit/integration coverage around snapshot fetching, website ingestion, and config resolution
- Verified the affected package tests and docs validation behavior locally