### PR TITLE
Add post-public security hardening

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "27 8 * * 2"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@convex-dev/workflow": "latest",
     "@convex-dev/workpool": "latest",
     "@polar-sh/sdk": "^0.47.0",
-    "ai": "latest",
+    "ai": "^6.0.116",
     "convex": "^1.37.0",
     "convex-firecrawl-scrape": "^0.1.3",
     "firecrawl": "^4.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         specifier: ^0.47.0
         version: 0.47.0
       ai:
-        specifier: latest
+        specifier: ^6.0.116
         version: 6.0.116(zod@3.25.76)
       convex:
         specifier: ^1.37.0


### PR DESCRIPTION
## Summary
- add CodeQL analysis for JavaScript and TypeScript
- pin `ai` to the already-resolved patched 6.0.116 range so Dependabot no longer treats the manifest as vulnerable

## Verification
- `pnpm audit --prod`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

## Notes
- GitHub repo settings were also updated after public release: Dependabot alerts/security updates, secret scanning, secret scanning push protection, and main branch protection are enabled.