### PR TITLE
Add lobbystack security.txt

### DIFF
--- a/apps/web/public/.well-known/security.txt
+++ b/apps/web/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:hello@lobbystack.com
+Expires: 2027-05-15T00:00:00Z
+Preferred-Languages: en
+Canonical: https://lobbystack.com/.well-known/security.txt


### PR DESCRIPTION
## Summary
- Add a standards-based security.txt file for lobbystack.com so Cloudflare Security Center can resolve the missing security.txt finding.

## Verification
- pnpm --filter @lobbystack/web build
- Verified public DMARC TXT records for _dmarc.lobbystack.com and _dmarc.send.lobbystack.com
- Verified lobbystack.com still returns HTTP 200 after Cloudflare bot settings changes

## Related Cloudflare changes
- Added DMARC monitoring records in Cloudflare DNS with p=none
- Enabled AI Labyrinth
- Set Block AI bots to Block on all pages
- Enabled Bot Fight Mode
- Enabled Managed robots.txt