### PR TITLE
OPE-131 hide AI SMS dashboard surfaces in prod

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -63,6 +63,7 @@ import {
   trackPageView,
 } from "@/lib/analytics";
 import { useResetAuthScopedClientStateOnSignOut } from "@/lib/auth-scoped-client-state";
+import { AI_SMS_DASHBOARD_ENABLED } from "@/lib/release-flags";
 
 type ActiveBusiness = {
   _id: Id<"businesses">;
@@ -410,7 +411,7 @@ function WorkspaceShell() {
     }
   }
 
-  const usesFixedMain = location.pathname === "/messages";
+  const usesFixedMain = AI_SMS_DASHBOARD_ENABLED && location.pathname === "/messages";
 
   return (
     <AuthenticatedLayout
@@ -442,10 +443,12 @@ function WorkspaceShell() {
               element={<CallDetailPage {...(businessId ? { businessId } : {})} />}
               path="/calls/:callId"
             />
-            <Route
-              element={<MessagesPage {...(businessId ? { businessId } : {})} />}
-              path="/messages"
-            />
+            {AI_SMS_DASHBOARD_ENABLED && (
+              <Route
+                element={<MessagesPage {...(businessId ? { businessId } : {})} />}
+                path="/messages"
+              />
+            )}
             <Route
               element={<AnalyticsPage {...(businessId ? { businessId } : {})} />}
               path="/analytics"
@@ -581,16 +584,18 @@ function WorkspaceShell() {
                 }
                 path="plan"
               />
-              <Route
-                element={
-                  businessId ? (
-                    <SettingsBillingCompliancePage businessId={businessId} />
-                  ) : (
-                    <Navigate replace to="/settings" />
-                  )
-                }
-                path="plan/ai-sms-compliance"
-              />
+              {AI_SMS_DASHBOARD_ENABLED && (
+                <Route
+                  element={
+                    businessId ? (
+                      <SettingsBillingCompliancePage businessId={businessId} />
+                    ) : (
+                      <Navigate replace to="/settings" />
+                    )
+                  }
+                  path="plan/ai-sms-compliance"
+                />
+              )}
               <Route
                 element={
                   businessId ? (

--- a/apps/web/src/components/app-sidebar.test.tsx
+++ b/apps/web/src/components/app-sidebar.test.tsx
@@ -103,6 +103,7 @@ describe("AppSidebar", () => {
     expect(screen.getByRole("link", { name: "Knowledge" }).getAttribute("href")).toBe("/agent/knowledge");
     expect(screen.getByRole("link", { name: "Services" }).getAttribute("href")).toBe("/agent/services");
     expect(screen.getByRole("link", { name: "Rules" }).getAttribute("href")).toBe("/agent/rules");
+    expect(screen.queryByRole("link", { name: "Messages" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Agent" })).toBeNull();
   });
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/sidebar";
 import { UsersIcon } from "@/components/ui/users";
 import { WorkflowIcon } from "@/components/ui/workflow";
+import { AI_SMS_DASHBOARD_ENABLED } from "@/lib/release-flags";
 import { cn } from "@/lib/utils";
 import type { SidebarIconProps } from "@/components/layout/sidebar-types";
 
@@ -107,7 +108,9 @@ export function AppSidebar({
           items: [
             { title: t("nav:items.home"), url: "/", icon: AnimatedHomeIcon },
             { title: t("nav:items.calls"), url: "/calls", icon: AnimatedCallsIcon },
-            { title: t("nav:items.messages"), url: "/messages", icon: AnimatedMessagesIcon },
+            ...(AI_SMS_DASHBOARD_ENABLED
+              ? [{ title: t("nav:items.messages"), url: "/messages", icon: AnimatedMessagesIcon }]
+              : []),
             { title: t("nav:items.contacts"), url: "/contacts", icon: AnimatedContactsIcon },
           ],
         },

--- a/apps/web/src/features/home/HomePage.tsx
+++ b/apps/web/src/features/home/HomePage.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/follow-up-task";
 import { formatDateTime, resolveLocale } from "@/lib/locale";
 import { formatPhoneNumberDisplay } from "@/lib/phone";
+import { AI_SMS_DASHBOARD_ENABLED } from "@/lib/release-flags";
 import { useRememberedConvexQuery } from "@/lib/remembered-convex-query";
 
 type HomePageProps = {
@@ -350,7 +351,7 @@ export function HomePage({ businessId }: HomePageProps) {
                                 ? {
                                     pathname: `/calls/${encodeURIComponent(String(item.callId))}`,
                                   }
-                                : item.conversationId
+                                : AI_SMS_DASHBOARD_ENABLED && item.conversationId
                                   ? {
                                       pathname: "/messages",
                                       search: `?conversationId=${encodeURIComponent(String(item.conversationId))}`,

--- a/apps/web/src/features/settings/SettingsBillingPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.test.tsx
@@ -91,6 +91,10 @@ vi.mock("@/lib/remembered-convex-query", () => ({
   useRememberedConvexQuery: vi.fn(),
 }));
 
+vi.mock("@/lib/release-flags", () => ({
+  AI_SMS_DASHBOARD_ENABLED: true,
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: (...args: unknown[]) => toastSuccessMock(...args),

--- a/apps/web/src/features/settings/SettingsBillingPage.tsx
+++ b/apps/web/src/features/settings/SettingsBillingPage.tsx
@@ -62,6 +62,7 @@ import {
   deleteCheckoutSessionTokenParam,
   takeCheckoutSessionToken,
 } from "@/lib/checkout-session-token";
+import { AI_SMS_DASHBOARD_ENABLED } from "@/lib/release-flags";
 
 type CheckoutReturnTarget = "pro" | "ai_sms";
 
@@ -914,7 +915,7 @@ function UsageSection({
         </BorderedItem>
       </BillingSection>
 
-      {(catalog.overagesBillable || status.aiSmsEnabled) && (
+      {(catalog.overagesBillable || (AI_SMS_DASHBOARD_ENABLED && status.aiSmsEnabled)) && (
         <BillingSection
           title={t("billing.usage.paygTitle")}
           description={
@@ -979,21 +980,21 @@ function UsageSection({
               </>
             )}
 
-            {status.aiSmsEnabled && (
+            {AI_SMS_DASHBOARD_ENABLED && status.aiSmsEnabled && (
               <div className="px-6 py-5 border-b border-border last:border-b-0">
                 <UsageMeterRow
-                label={t("billing.usage.aiSmsTitle")}
-                locale={locale}
-                t={t}
-                used={usage.aiSmsSegmentsUsed}
-                included={null}
-                unit={segmentsUnit}
-                blocked={false}
-                overageRateCents={billingAddonCatalog.ai_sms.usageRatePerSegmentCents}
-                overageBillable
-                metered
-                mode="payg"
-              />
+                  label={t("billing.usage.aiSmsTitle")}
+                  locale={locale}
+                  t={t}
+                  used={usage.aiSmsSegmentsUsed}
+                  included={null}
+                  unit={segmentsUnit}
+                  blocked={false}
+                  overageRateCents={billingAddonCatalog.ai_sms.usageRatePerSegmentCents}
+                  overageBillable
+                  metered
+                  mode="payg"
+                />
               </div>
             )}
           </BorderedItem>
@@ -2527,7 +2528,7 @@ function BillingOverviewSkeleton({
   return (
     <div className="flex w-full flex-col gap-10">
       <PlanSectionSkeleton t={t} />
-      <AddonsSectionSkeleton t={t} />
+      {AI_SMS_DASHBOARD_ENABLED && <AddonsSectionSkeleton t={t} />}
       <SpendingCapSectionSkeleton t={t} />
       <TransactionsSectionSkeleton t={t} />
     </div>
@@ -2635,12 +2636,14 @@ export function SettingsBillingPage(props: SettingsBillingPageProps) {
         locale={locale}
         t={t}
       />
-      <AddonsSection
-        status={status}
-        businessId={props.businessId}
-        locale={locale}
-        t={t}
-      />
+      {AI_SMS_DASHBOARD_ENABLED && (
+        <AddonsSection
+          status={status}
+          businessId={props.businessId}
+          locale={locale}
+          t={t}
+        />
+      )}
       <SpendingCapSection status={status} t={t} />
       <TransactionsSection status={status} locale={locale} t={t} />
     </div>
@@ -2650,8 +2653,10 @@ export function SettingsBillingPage(props: SettingsBillingPageProps) {
 export function SettingsBillingCompliancePage(props: SettingsBillingPageProps) {
   const { t } = useTranslation("settings");
   const { data: status, isInitialLoading: isLoadingStatus } = useBillingStatus(props.businessId);
+
   const shouldFetchCompliance = Boolean(
-    status &&
+    AI_SMS_DASHBOARD_ENABLED &&
+      status &&
       status.hasBillingManagementAccess &&
       status.plan !== "self_host" &&
       status.aiSmsEnabled,
@@ -2660,6 +2665,10 @@ export function SettingsBillingCompliancePage(props: SettingsBillingPageProps) {
     data: compliance,
     isInitialLoading: isLoadingCompliance,
   } = useSmsComplianceStatus(props.businessId, shouldFetchCompliance);
+
+  if (!AI_SMS_DASHBOARD_ENABLED) {
+    return <Navigate replace to="/settings/plan" />;
+  }
 
   if (isLoadingStatus || !status || (shouldFetchCompliance && isLoadingCompliance)) {
     return <AiSmsComplianceSectionSkeleton t={t} />;

--- a/apps/web/src/lib/release-flags.ts
+++ b/apps/web/src/lib/release-flags.ts
@@ -1,0 +1,1 @@
+export const AI_SMS_DASHBOARD_ENABLED = false;


### PR DESCRIPTION
## Summary
- replay the OPE-131 dashboard-hide commit onto main so production gets the temporary AI SMS removal
- gates the Messages route/sidebar link, billing add-ons section, and related home/billing AI SMS UI behind AI_SMS_DASHBOARD_ENABLED=false

## Why
PR #53 was merged into the OPE-131 feature branch instead of main, so prod still showed the Messages tab and AI SMS add-on.

## Verification
- pnpm typecheck
- pnpm --filter @lobbystack/web test -- app-sidebar SettingsBillingPage