### PR TITLE
OPE-131 hide messages KPI while SMS is disabled

### DIFF
--- a/apps/web/src/components/loading-skeletons.tsx
+++ b/apps/web/src/components/loading-skeletons.tsx
@@ -25,8 +25,10 @@ export function PageHeaderSkeleton({
 }
 
 export function MetricCardGridSkeleton({ count = 4 }: { count?: number }) {
+  const columnClass = count === 3 ? "md:grid-cols-3" : "md:grid-cols-4";
+
   return (
-    <Surface className="grid sm:grid-cols-2 md:grid-cols-4">
+    <Surface className={`grid sm:grid-cols-2 ${columnClass}`}>
       {Array.from({ length: count }).map((_, index) => (
         <div
           className="border-b p-5 last:border-b-0 sm:odd:border-r sm:[&:nth-last-child(-n+2)]:border-b-0 md:border-b-0 md:border-r md:last:border-r-0"

--- a/apps/web/src/features/home/HomePage.tsx
+++ b/apps/web/src/features/home/HomePage.tsx
@@ -245,11 +245,15 @@ export function HomePage({ businessId }: HomePageProps) {
           value: summary.kpis.calls.total.toLocaleString(i18n.language),
           description: formatDelta(summary.kpis.calls.deltaPercent),
         },
-        {
-          key: "messages",
-          value: summary.kpis.messages.total.toLocaleString(i18n.language),
-          description: formatDelta(summary.kpis.messages.deltaPercent),
-        },
+        ...(AI_SMS_DASHBOARD_ENABLED
+          ? [
+              {
+                key: "messages" as const,
+                value: summary.kpis.messages.total.toLocaleString(i18n.language),
+                description: formatDelta(summary.kpis.messages.deltaPercent),
+              },
+            ]
+          : []),
         {
           key: "appointments",
           value: summary.kpis.appointments.total.toLocaleString(i18n.language),
@@ -268,9 +272,13 @@ export function HomePage({ businessId }: HomePageProps) {
       <PageHeader title={t("home.title")} />
       <div className="space-y-6">
         {isLoadingSummary ? (
-          <MetricCardGridSkeleton />
+          <MetricCardGridSkeleton count={AI_SMS_DASHBOARD_ENABLED ? 4 : 3} />
         ) : (
-          <Surface className="grid sm:grid-cols-2 md:grid-cols-4">
+          <Surface
+            className={`grid sm:grid-cols-2 ${
+              AI_SMS_DASHBOARD_ENABLED ? "md:grid-cols-4" : "md:grid-cols-3"
+            }`}
+          >
             {metricCards.map((card) => {
               return (
                 <section


### PR DESCRIPTION
## Summary
- hide the Home dashboard Messages KPI when AI_SMS_DASHBOARD_ENABLED is false
- render the loading KPI skeleton as three cards while SMS dashboard surfaces are disabled

## Verification
- pnpm typecheck
- pnpm --filter @lobbystack/web test -- app-sidebar SettingsBillingPage HomePage