### PR TITLE
Fix auth email validation feedback

### DIFF
--- a/apps/web/public/locales/en/auth.json
+++ b/apps/web/public/locales/en/auth.json
@@ -27,6 +27,13 @@
       "number": "At least one number",
       "specialCharacter": "At least one special character"
     },
+    "legal": {
+      "prefix": "By clicking \"Create account\", you agree to our",
+      "terms": "Terms of Service",
+      "and": "and",
+      "privacy": "Privacy Policy",
+      "suffix": "."
+    },
     "securityCheck": "Security check",
     "submit": "Create account",
     "submitting": "Creating account...",

--- a/apps/web/public/locales/fr/auth.json
+++ b/apps/web/public/locales/fr/auth.json
@@ -27,6 +27,13 @@
       "number": "Au moins un chiffre",
       "specialCharacter": "Au moins un caractère spécial"
     },
+    "legal": {
+      "prefix": "En cliquant sur \"Créer le compte\", vous acceptez nos",
+      "terms": "conditions d'utilisation",
+      "and": "et notre",
+      "privacy": "politique de confidentialité",
+      "suffix": "."
+    },
     "securityCheck": "Vérification de sécurité",
     "submit": "Créer le compte",
     "submitting": "Création du compte...",

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -59,7 +59,10 @@ export function LoginForm({
                   "border-destructive text-destructive focus-visible:border-destructive focus-visible:ring-destructive/20",
               )}
               onBlur={() => setHasBlurredEmail(true)}
-              onChange={(event) => onEmailChange(event.target.value)}
+              onChange={(event) => {
+                setHasBlurredEmail(false);
+                onEmailChange(event.target.value);
+              }}
               placeholder={t("login.emailPlaceholder")}
               required
               type="email"

--- a/apps/web/src/components/signup-form.tsx
+++ b/apps/web/src/components/signup-form.tsx
@@ -88,7 +88,10 @@ export function SignupForm({
                   "border-destructive text-destructive focus-visible:border-destructive focus-visible:ring-destructive/20",
               )}
               onBlur={() => setHasBlurredEmail(true)}
-              onChange={(event) => onEmailChange(event.target.value)}
+              onChange={(event) => {
+                setHasBlurredEmail(false);
+                onEmailChange(event.target.value);
+              }}
               placeholder={t("signup.emailPlaceholder")}
               required
               type="email"

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -79,9 +79,29 @@ describe("LoginPage", () => {
     expect(emailInput.getAttribute("aria-invalid")).toBe("true");
 
     await user.clear(emailInput);
+    await user.type(emailInput, "o");
+
+    expect(screen.queryByText("login.emailInvalid")).toBeNull();
+
+    await user.tab();
+
+    expect(screen.getByText("login.emailInvalid")).toBeTruthy();
+
+    await user.clear(emailInput);
     await user.type(emailInput, "owner@example.com");
 
     expect(screen.queryByText("login.emailInvalid")).toBeNull();
+  });
+
+  it("keeps the default legal footer on login", () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("shell.terms")).toBeTruthy();
+    expect(screen.getByText("shell.privacy")).toBeTruthy();
   });
 });
 
@@ -229,9 +249,36 @@ describe("SignupPage", () => {
     expect(emailInput.getAttribute("aria-invalid")).toBe("true");
 
     await user.clear(emailInput);
+    await user.type(emailInput, "o");
+
+    expect(screen.queryByText("signup.emailInvalid")).toBeNull();
+
+    await user.tab();
+
+    expect(screen.getByText("signup.emailInvalid")).toBeTruthy();
+
+    await user.clear(emailInput);
     await user.type(emailInput, "owner@example.com");
 
     expect(screen.queryByText("signup.emailInvalid")).toBeNull();
+  });
+
+  it("uses the signup-specific legal footer", () => {
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/signup\.legal\.prefix/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "signup.legal.terms" }).getAttribute("href")).toBe(
+      "/terms",
+    );
+    expect(screen.getByRole("link", { name: "signup.legal.privacy" }).getAttribute("href")).toBe(
+      "/privacy",
+    );
+    expect(screen.queryByText("shell.terms")).toBeNull();
+    expect(screen.queryByText("shell.privacy")).toBeNull();
   });
 
   it("shows password criteria only after the password field is focused", async () => {

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -288,6 +288,29 @@ export function SignupPage() {
 
   return (
     <OnboardingShell
+      legalFooter={
+        <p className="max-w-full text-center text-xs leading-5 text-muted-foreground sm:whitespace-nowrap">
+          {t("signup.legal.prefix")} {" "}
+          <a
+            className="underline underline-offset-4 hover:text-foreground"
+            href="/terms"
+            rel="noreferrer"
+            target="_blank"
+          >
+            {t("signup.legal.terms")}
+          </a>{" "}
+          {t("signup.legal.and")} {" "}
+          <a
+            className="underline underline-offset-4 hover:text-foreground"
+            href="/privacy"
+            rel="noreferrer"
+            target="_blank"
+          >
+            {t("signup.legal.privacy")}
+          </a>
+          {t("signup.legal.suffix")}
+        </p>
+      }
       progress={{ current: 1, total: 10 }}
       title={t("signup.title")}
       width="sm"

--- a/apps/web/src/features/onboarding/components/OnboardingShell.tsx
+++ b/apps/web/src/features/onboarding/components/OnboardingShell.tsx
@@ -24,6 +24,8 @@ type OnboardingShellProps = {
   children: ReactNode;
   /** Optional links/CTAs rendered below the progress indicator. */
   footer?: ReactNode;
+  /** Optional legal footer override. Defaults to Terms / Privacy links. */
+  legalFooter?: ReactNode;
 };
 
 const widthMap: Record<NonNullable<OnboardingShellProps["width"]>, string> = {
@@ -64,6 +66,7 @@ export function OnboardingShell({
   width = "md",
   children,
   footer,
+  legalFooter,
   onSignOut,
 }: OnboardingShellProps) {
   const { t } = useTranslation("onboarding");
@@ -116,15 +119,17 @@ export function OnboardingShell({
             total={progress.total}
           />
         ) : null}
-        <div className="flex items-center gap-4 text-xs text-muted-foreground">
-          <a className="hover:text-foreground" href="/terms" rel="noreferrer" target="_blank">
-            {t("shell.terms")}
-          </a>
-          <span aria-hidden="true">·</span>
-          <a className="hover:text-foreground" href="/privacy" rel="noreferrer" target="_blank">
-            {t("shell.privacy")}
-          </a>
-        </div>
+        {legalFooter ?? (
+          <div className="flex items-center gap-4 text-xs text-muted-foreground">
+            <a className="hover:text-foreground" href="/terms" rel="noreferrer" target="_blank">
+              {t("shell.terms")}
+            </a>
+            <span aria-hidden="true">·</span>
+            <a className="hover:text-foreground" href="/privacy" rel="noreferrer" target="_blank">
+              {t("shell.privacy")}
+            </a>
+          </div>
+        )}
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- clear email validation errors while users edit login and signup email fields after a blur
- add regression coverage for re-editing invalid emails before the next blur
- add signup-specific legal footer copy matching the Create account button

## Tests
- pnpm --filter @lobbystack/web test src/features/auth/AuthPages.test.tsx