### PR TITLE
feat: reusable web voice widget with call recording, abuse control, and stale cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 coverage
 dist
 node_modules
+.pnpm-store
 *.log
 .env
 .env.local

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DEPLOYMENT_MODE=development
 APP_BASE_URL=http://localhost:5173
 SITE_URL=http://localhost:5173
 VOICE_GATEWAY_BASE_URL=https://your-public-voice-gateway.example.com
+VOICE_GATEWAY_TRUST_PROXY=false
 PORT=3001
 CONVEX_URL=https://your-deployment.convex.cloud
 CONVEX_SITE_URL=https://your-deployment.convex.site

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ OPENAI_REALTIME_TEXT_OUTPUT_TOKEN_PRICE_USD=
 OPENAI_REALTIME_AUDIO_OUTPUT_TOKEN_PRICE_USD=
 OPENAI_REALTIME_CACHED_INPUT_TOKEN_PRICE_USD=
 OPENAI_REALTIME_VOICE=marin
+WEB_CALL_ALLOWED_ORIGINS=https://lobbystack.com,http://localhost:4321,http://127.0.0.1:4321
 OPENAI_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 # Optional PostHog cost fallback for separate input transcription model usage.
 # Values are USD per token, not per million tokens.

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ OPENAI_REALTIME_TEXT_OUTPUT_TOKEN_PRICE_USD=
 OPENAI_REALTIME_AUDIO_OUTPUT_TOKEN_PRICE_USD=
 OPENAI_REALTIME_CACHED_INPUT_TOKEN_PRICE_USD=
 OPENAI_REALTIME_VOICE=marin
+# Include localhost only for local development; production should use public origins only.
 WEB_CALL_ALLOWED_ORIGINS=https://lobbystack.com,http://localhost:4321,http://127.0.0.1:4321
 OPENAI_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 # Optional PostHog cost fallback for separate input transcription model usage.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 coverage
 dist
 node_modules
+.pnpm-store/
 *.log
 .env
 .env.*

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -313,6 +313,7 @@ export async function uploadVoiceRecording(input: {
   callId: string;
   durationMs: number;
   audio: Buffer;
+  contentType?: string;
 }): Promise<void> {
   const env = loadVoiceGatewayEnv(process.env);
   const url = new URL("/voice/call/recording", env.CONVEX_SITE_URL);
@@ -320,14 +321,15 @@ export async function uploadVoiceRecording(input: {
   url.searchParams.set("durationMs", String(input.durationMs));
   const bytes = Uint8Array.from(input.audio);
   const arrayBuffer = bytes.buffer as ArrayBuffer;
+  const contentType = input.contentType ?? "audio/wav";
 
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "audio/wav",
+      "Content-Type": contentType,
       "x-internal-service-token": env.INTERNAL_SERVICE_TOKEN,
     },
-    body: new Blob([arrayBuffer], { type: "audio/wav" }),
+    body: new Blob([arrayBuffer], { type: contentType }),
   });
 
   if (!response.ok) {

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -392,6 +392,7 @@ export async function bookVoiceAppointment(input: {
   serviceName: string;
   startsAt: string;
   timezone: string;
+  channel?: "voice" | "web_voice";
   preferredStaffId?: string;
   conversationId?: string;
   contactName?: string;

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -459,6 +459,7 @@ export async function takeVoiceMessage(input: {
   businessId: string;
   callId: string;
   conversationId?: string;
+  channel?: "voice" | "web_voice";
   callerName?: string;
   callbackPhone?: string;
   message: string;

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -39,6 +39,7 @@ type StartWebCallResponse = {
 
 type WebCallRecordingTargetResponse = {
   callId: string;
+  providerCallId?: string;
   startedAt: string;
   endedAt?: string;
   status: string;

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -42,6 +42,7 @@ type WebCallRecordingTargetResponse = {
   startedAt: string;
   endedAt?: string;
   status: string;
+  webCallMaxDurationMs?: number;
 };
 
 type CheckAvailabilityResponse = {

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -37,6 +37,13 @@ type StartWebCallResponse = {
   conversationId: string;
 };
 
+type WebCallRecordingTargetResponse = {
+  callId: string;
+  startedAt: string;
+  endedAt?: string;
+  status: string;
+};
+
 type CheckAvailabilityResponse = {
   serviceId: string;
   serviceName: string;
@@ -213,9 +220,26 @@ export async function startWebVoiceCall(input: {
   originUrl?: string;
   userAgent?: string;
   widgetId?: string;
+  maxDurationMs?: number;
   startedAt: string;
 }): Promise<StartWebCallResponse> {
   return await postJson<StartWebCallResponse>("/voice/call/start-web", input);
+}
+
+export async function fetchWebCallRecordingTarget(input: {
+  gatewaySessionId: string;
+}): Promise<WebCallRecordingTargetResponse | null> {
+  try {
+    return await postJson<WebCallRecordingTargetResponse>(
+      "/voice/call/web-recording-target",
+      input,
+    );
+  } catch (error) {
+    if (error instanceof RuntimeRequestError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export async function appendVoiceTranscript(input: {

--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -3,6 +3,7 @@ import { loadVoiceGatewayEnv } from "@lobbystack/config";
 import {
   recordRecordingUploadFailure,
 } from "../observability/posthog";
+import type { BusinessContextSnapshot } from "@lobbystack/shared";
 
 export class RuntimeRequestError extends Error {
   status: number;
@@ -23,6 +24,17 @@ type StartCallResponse = {
   blocked: boolean;
   conversationId?: string;
   contactId: string;
+};
+
+type WebVoiceContextResponse = {
+  businessId: string;
+  snapshot: BusinessContextSnapshot;
+};
+
+type StartWebCallResponse = {
+  businessId: string;
+  callId: string;
+  conversationId: string;
 };
 
 type CheckAvailabilityResponse = {
@@ -182,6 +194,28 @@ export async function startVoiceCall(input: {
   startedAt: string;
 }): Promise<StartCallResponse> {
   return await postJson<StartCallResponse>("/voice/call/start", input);
+}
+
+export async function fetchWebVoiceContext(input: {
+  businessSlug: string;
+  origin?: string;
+  ipHash?: string;
+  visitorId?: string;
+  widgetId?: string;
+}): Promise<WebVoiceContextResponse> {
+  return await postJson<WebVoiceContextResponse>("/voice/context/by-slug", input);
+}
+
+export async function startWebVoiceCall(input: {
+  businessSlug: string;
+  providerCallId: string;
+  gatewaySessionId?: string;
+  originUrl?: string;
+  userAgent?: string;
+  widgetId?: string;
+  startedAt: string;
+}): Promise<StartWebCallResponse> {
+  return await postJson<StartWebCallResponse>("/voice/call/start-web", input);
 }
 
 export async function appendVoiceTranscript(input: {

--- a/apps/voice-gateway/src/http/server.ts
+++ b/apps/voice-gateway/src/http/server.ts
@@ -7,6 +7,7 @@ import type { BusinessContextSnapshot } from "@lobbystack/shared";
 
 import { handleMediaStreamConnection } from "../telephony/mediaStream";
 import { registerVoiceRoutes } from "../telephony/routes";
+import { registerWebCallRoutes } from "../webCall/routes";
 import { validateMediaStreamSignature } from "../telephony/twilioRequest";
 import {
   capturePostHogException,
@@ -93,6 +94,7 @@ export function createServer(): ReturnType<typeof Fastify> {
   });
 
   registerVoiceRoutes(server);
+  registerWebCallRoutes(server);
   return server;
 }
 

--- a/apps/voice-gateway/src/http/server.ts
+++ b/apps/voice-gateway/src/http/server.ts
@@ -16,11 +16,12 @@ import {
 import { createSnapshotCache } from "../sessions/snapshotCache";
 
 export function createServer(): ReturnType<typeof Fastify> {
+  const env = loadVoiceGatewayEnv(process.env);
   const server = Fastify({
     logger: true,
+    trustProxy: env.VOICE_GATEWAY_TRUST_PROXY,
   });
 
-  const env = loadVoiceGatewayEnv(process.env);
   const cache = createSnapshotCache();
 
   server.decorate("snapshotCache", cache);

--- a/apps/voice-gateway/src/realtime/toolDefinitions.ts
+++ b/apps/voice-gateway/src/realtime/toolDefinitions.ts
@@ -1,0 +1,135 @@
+export function createWebRealtimeToolDefinitions() {
+  return [
+    {
+      type: "function",
+      name: "getBusinessHours",
+      description: "Get the authoritative business hours and closure information.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "getBusinessServices",
+      description:
+        "List the structured services configured for this business, including duration and short descriptions when available.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "searchKnowledge",
+      description:
+        "Search indexed business knowledge and uploaded documents for a specific question.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "findAvailability",
+      description:
+        "Find candidate appointment slots for a service on a specific local date, optionally near a preferred hour.",
+      parameters: {
+        type: "object",
+        properties: {
+          serviceName: { type: "string" },
+          date: {
+            type: "string",
+            description: "Local business date in YYYY-MM-DD format.",
+          },
+          timezone: { type: "string" },
+          preferredStaffId: { type: "string" },
+          preferredHour24: { type: "integer" },
+          preferredMinute: { type: "integer" },
+          limit: { type: "integer" },
+        },
+        required: ["serviceName", "date"],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "checkAvailability",
+      description:
+        "Check appointment availability for a named service at an exact ISO datetime before promising a slot.",
+      parameters: {
+        type: "object",
+        properties: {
+          serviceName: { type: "string" },
+          startsAt: { type: "string" },
+          timezone: { type: "string" },
+          preferredStaffId: { type: "string" },
+        },
+        required: ["serviceName", "startsAt"],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "bookAppointment",
+      description:
+        "Book an appointment only after availability is confirmed. Collect the caller's phone number first and pass it as contactPhone.",
+      parameters: {
+        type: "object",
+        properties: {
+          serviceName: { type: "string" },
+          startsAt: { type: "string" },
+          timezone: { type: "string" },
+          preferredStaffId: { type: "string" },
+          contactName: { type: "string" },
+          contactPhone: { type: "string" },
+        },
+        required: ["serviceName", "startsAt", "contactPhone"],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "takeMessage",
+      description:
+        "Create a follow-up message for the operator after collecting the caller's message and callback details.",
+      parameters: {
+        type: "object",
+        properties: {
+          callerName: { type: "string" },
+          callbackPhone: { type: "string" },
+          message: { type: "string" },
+          urgency: { type: "string" },
+          callbackWindow: { type: "string" },
+        },
+        required: ["message"],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
+      name: "endCall",
+      description:
+        "End the web voice session after a clear closing cue, abuse, spam, or silence timeout.",
+      parameters: {
+        type: "object",
+        properties: {
+          reason: {
+            type: "string",
+            enum: ["caller_finished", "abuse", "silence_timeout", "spam"],
+          },
+          message: { type: "string" },
+          severity: { type: "string", enum: ["borderline", "severe"] },
+        },
+        required: ["reason", "message"],
+        additionalProperties: false,
+      },
+    },
+  ];
+}

--- a/apps/voice-gateway/src/realtime/toolDefinitions.ts
+++ b/apps/voice-gateway/src/realtime/toolDefinitions.ts
@@ -119,7 +119,7 @@ export function createWebRealtimeToolDefinitions() {
           urgency: { type: "string" },
           callbackWindow: { type: "string" },
         },
-        required: ["message"],
+        required: ["message", "callbackPhone"],
         additionalProperties: false,
       },
     },

--- a/apps/voice-gateway/src/realtime/toolDefinitions.ts
+++ b/apps/voice-gateway/src/realtime/toolDefinitions.ts
@@ -2,6 +2,17 @@ export function createWebRealtimeToolDefinitions() {
   return [
     {
       type: "function",
+      name: "waitForUser",
+      description:
+        "Use when the latest audio is silence, background noise, echo of the assistant's own audio, hold music, TV audio, side conversation, or speech not addressed to the assistant. This keeps listening without a spoken reply.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
       name: "getBusinessHours",
       description: "Get the authoritative business hours and closure information.",
       parameters: {

--- a/apps/voice-gateway/src/realtime/toolExecutor.test.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.test.ts
@@ -37,6 +37,26 @@ vi.mock("../convex/runtimeClient", () => ({
 
 import { executeVoiceTool } from "./toolExecutor";
 
+describe("executeVoiceTool waitForUser", () => {
+  it("returns a silent wait result for background audio turns", async () => {
+    const result = await executeVoiceTool({
+      toolName: "waitForUser",
+      rawArguments: "{}",
+      snapshot: demoSnapshot,
+      businessId: "business_123",
+      callerPhone: "+14165550000",
+    });
+
+    expect(result).toEqual({
+      result: {
+        ok: true,
+        action: "wait_for_user",
+      },
+      suppressResponse: true,
+    });
+  });
+});
+
 describe("executeVoiceTool searchKnowledge", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/voice-gateway/src/realtime/toolExecutor.test.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { demoSnapshot } from "@lobbystack/shared";
 
 const {
+  bookVoiceAppointmentMock,
   cancelVoiceAppointmentMock,
   lookupVoiceAppointmentForChangeMock,
   rescheduleVoiceAppointmentMock,
@@ -11,6 +12,7 @@ const {
   verifyVoiceAppointmentChangeOtpMock,
   verifyVoiceAppointmentForChangeMock,
 } = vi.hoisted(() => ({
+  bookVoiceAppointmentMock: vi.fn(),
   cancelVoiceAppointmentMock: vi.fn(),
   lookupVoiceAppointmentForChangeMock: vi.fn(),
   rescheduleVoiceAppointmentMock: vi.fn(),
@@ -21,7 +23,7 @@ const {
 }));
 
 vi.mock("../convex/runtimeClient", () => ({
-  bookVoiceAppointment: vi.fn(),
+  bookVoiceAppointment: bookVoiceAppointmentMock,
   cancelVoiceAppointment: cancelVoiceAppointmentMock,
   checkVoiceAvailability: vi.fn(),
   findVoiceAvailability: vi.fn(),
@@ -416,6 +418,57 @@ describe("executeVoiceTool appointment changes", () => {
       verificationId: "verification_123",
       code: "123456",
     });
+  });
+});
+
+describe("executeVoiceTool bookings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires an explicit contact phone for website bookings", async () => {
+    const result = await executeVoiceTool({
+      toolName: "bookAppointment",
+      rawArguments: JSON.stringify({
+        serviceName: "Consultation",
+        startsAt: "2030-05-15T14:00:00.000Z",
+      }),
+      snapshot: demoSnapshot,
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+      callerPhone: "web",
+    });
+
+    expect(result.result).toEqual({
+      ok: false,
+      reason: "A contact phone number is required for website voice bookings.",
+    });
+    expect(bookVoiceAppointmentMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a provided contact phone for website bookings", async () => {
+    bookVoiceAppointmentMock.mockResolvedValue({ ok: true, appointmentId: "appointment_123" });
+
+    const result = await executeVoiceTool({
+      toolName: "bookAppointment",
+      rawArguments: JSON.stringify({
+        serviceName: "Consultation",
+        startsAt: "2030-05-15T14:00:00.000Z",
+        contactPhone: " +14165550123 ",
+      }),
+      snapshot: demoSnapshot,
+      businessId: "business_123",
+      callerPhone: "web",
+    });
+
+    expect(bookVoiceAppointmentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        businessId: "business_123",
+        contactPhone: "+14165550123",
+      }),
+    );
+    expect(result.result).toEqual({ ok: true, appointmentId: "appointment_123" });
   });
 });
 

--- a/apps/voice-gateway/src/realtime/toolExecutor.test.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.test.ts
@@ -470,6 +470,29 @@ describe("executeVoiceTool bookings", () => {
     );
     expect(result.result).toEqual({ ok: true, appointmentId: "appointment_123" });
   });
+
+  it("passes the web voice channel when booking from a website call", async () => {
+    bookVoiceAppointmentMock.mockResolvedValue({ ok: true, appointmentId: "appointment_123" });
+
+    await executeVoiceTool({
+      toolName: "bookAppointment",
+      rawArguments: JSON.stringify({
+        serviceName: "Consultation",
+        startsAt: "2030-05-15T14:00:00.000Z",
+        contactPhone: "+14165550123",
+      }),
+      snapshot: demoSnapshot,
+      businessId: "business_123",
+      callerPhone: "web",
+      channel: "web_voice",
+    });
+
+    expect(bookVoiceAppointmentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "web_voice",
+      }),
+    );
+  });
 });
 
 describe("executeVoiceTool call control", () => {

--- a/apps/voice-gateway/src/realtime/toolExecutor.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.ts
@@ -378,6 +378,15 @@ export async function executeVoiceTool(input: {
       }
       case "bookAppointment": {
         const parsed = bookAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        const contactPhone = parsed.contactPhone?.trim() || undefined;
+        if ((!contactPhone || contactPhone.toLowerCase() === "web") && input.callerPhone === "web") {
+          return {
+            result: {
+              ok: false,
+              reason: "A contact phone number is required for website voice bookings.",
+            },
+          };
+        }
         const result = await bookVoiceAppointment({
           businessId: input.businessId,
           serviceName: parsed.serviceName,
@@ -390,7 +399,7 @@ export async function executeVoiceTool(input: {
             ? { conversationId: input.conversationId }
             : {}),
           ...(parsed.contactName !== undefined ? { contactName: parsed.contactName } : {}),
-          contactPhone: parsed.contactPhone ?? input.callerPhone,
+          contactPhone: contactPhone ?? input.callerPhone,
         });
         return {
           result,

--- a/apps/voice-gateway/src/realtime/toolExecutor.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.ts
@@ -225,6 +225,7 @@ export type ExecutedToolResult = {
   pendingTransferDestination?: string;
   endCall?: EndCallRequest;
   hold?: HoldGrantResult;
+  suppressResponse?: boolean;
 };
 
 export async function executeVoiceTool(input: {
@@ -252,361 +253,370 @@ export async function executeVoiceTool(input: {
 
   try {
     switch (input.toolName) {
-          case "getBusinessHours": {
+      case "waitForUser": {
+        return {
+          result: {
+            ok: true,
+            action: "wait_for_user",
+          },
+          suppressResponse: true,
+        };
+      }
+      case "getBusinessHours": {
+        return {
+          result: {
+            timezone: input.snapshot.timezone,
+            summary: buildHoursSummary(input.snapshot),
+            closures: input.snapshot.closures,
+          },
+        };
+      }
+      case "getBusinessServices": {
+        return {
+          result: {
+            summary: buildServicesSummary(input.snapshot),
+            services: input.snapshot.services,
+            count: input.snapshot.services.length,
+          },
+        };
+      }
+      case "searchKnowledge": {
+        const parsed = searchKnowledgeSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        try {
+          const matches = await searchVoiceKnowledge({
+            businessId: input.businessId,
+            query: parsed.query,
+          });
+
+          if (matches.length > 0) {
             return {
               result: {
-                timezone: input.snapshot.timezone,
-                summary: buildHoursSummary(input.snapshot),
-                closures: input.snapshot.closures,
+                matches,
+                source: "rag",
+                fallbackUsed: false,
               },
             };
           }
-          case "getBusinessServices": {
+
+          const fallbackMatches = buildSnapshotFallbackMatches(input.snapshot, parsed.query);
+          if (fallbackMatches.length > 0) {
             return {
               result: {
-                summary: buildServicesSummary(input.snapshot),
-                services: input.snapshot.services,
-                count: input.snapshot.services.length,
+                matches: fallbackMatches,
+                source: "snapshot_fallback",
+                fallbackUsed: true,
+                fallbackReason: "no_matches",
               },
             };
           }
-          case "searchKnowledge": {
-            const parsed = searchKnowledgeSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            try {
-              const matches = await searchVoiceKnowledge({
-                businessId: input.businessId,
-                query: parsed.query,
-              });
 
-              if (matches.length > 0) {
-                return {
-                  result: {
-                    matches,
-                    source: "rag",
-                    fallbackUsed: false,
-                  },
-                };
-              }
-
-              const fallbackMatches = buildSnapshotFallbackMatches(input.snapshot, parsed.query);
-              if (fallbackMatches.length > 0) {
-                return {
-                  result: {
-                    matches: fallbackMatches,
-                    source: "snapshot_fallback",
-                    fallbackUsed: true,
-                    fallbackReason: "no_matches",
-                  },
-                };
-              }
-
-              return {
-                result: {
-                  matches: [],
-                  source: "none",
-                  fallbackUsed: false,
-                },
-              };
-            } catch {
-              const fallbackMatches = buildSnapshotFallbackMatches(input.snapshot, parsed.query);
-              if (fallbackMatches.length > 0) {
-                return {
-                  result: {
-                    matches: fallbackMatches,
-                    source: "snapshot_fallback",
-                    fallbackUsed: true,
-                    fallbackReason: "rag_error",
-                  },
-                };
-              }
-
-              return {
-                result: {
-                  matches: [],
-                  source: "none",
-                  fallbackUsed: false,
-                },
-              };
-            }
-          }
-          case "checkAvailability": {
-            const parsed = checkAvailabilitySchema.parse(JSON.parse(input.rawArguments || "{}"));
-            const result = await checkVoiceAvailability({
-              businessId: input.businessId,
-              serviceName: parsed.serviceName,
-              startsAt: parsed.startsAt,
-              timezone: parsed.timezone ?? input.snapshot.timezone,
-              ...(parsed.preferredStaffId !== undefined
-                ? { preferredStaffId: parsed.preferredStaffId }
-                : {}),
-            });
-            return {
-              result,
-            };
-          }
-          case "findAvailability": {
-            const parsed = findAvailabilitySchema.parse(JSON.parse(input.rawArguments || "{}"));
-            const result = await findVoiceAvailability({
-              businessId: input.businessId,
-              serviceName: parsed.serviceName,
-              date: parsed.date,
-              timezone: parsed.timezone ?? input.snapshot.timezone,
-              ...(parsed.preferredStaffId !== undefined
-                ? { preferredStaffId: parsed.preferredStaffId }
-                : {}),
-              ...(parsed.preferredHour24 !== undefined
-                ? { preferredHour24: parsed.preferredHour24 }
-                : {}),
-              ...(parsed.preferredMinute !== undefined
-                ? { preferredMinute: parsed.preferredMinute }
-                : {}),
-              ...(parsed.limit !== undefined ? { limit: parsed.limit } : {}),
-            });
-            return {
-              result,
-            };
-          }
-          case "bookAppointment": {
-            const parsed = bookAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            const result = await bookVoiceAppointment({
-              businessId: input.businessId,
-              serviceName: parsed.serviceName,
-              startsAt: parsed.startsAt,
-              timezone: parsed.timezone ?? input.snapshot.timezone,
-              ...(parsed.preferredStaffId !== undefined
-                ? { preferredStaffId: parsed.preferredStaffId }
-                : {}),
-              ...(input.conversationId !== undefined
-                ? { conversationId: input.conversationId }
-                : {}),
-              ...(parsed.contactName !== undefined ? { contactName: parsed.contactName } : {}),
-              contactPhone: parsed.contactPhone ?? input.callerPhone,
-            });
-            return {
-              result,
-            };
-          }
-          case "lookupAppointmentForChange": {
-            try {
-              const result = await lookupVoiceAppointmentForChange({
-                businessId: input.businessId,
-                callerPhone: input.callerPhone,
-              });
-              return { result };
-            } catch (error) {
-              return { result: safeAppointmentToolError(error) };
-            }
-          }
-          case "verifyAppointmentForChange": {
-            const parsed = verifyAppointmentForChangeSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            try {
-              const result = await verifyVoiceAppointmentForChange({
-                businessId: input.businessId,
-                action: parsed.action,
-                callerPhone: input.callerPhone,
-                ...(parsed.appointmentId !== undefined ? { appointmentId: parsed.appointmentId } : {}),
-                ...(parsed.callerName !== undefined ? { callerName: parsed.callerName } : {}),
-                ...(parsed.appointmentStartsAt !== undefined
-                  ? { appointmentStartsAt: parsed.appointmentStartsAt }
-                  : {}),
-                ...(parsed.serviceName !== undefined ? { serviceName: parsed.serviceName } : {}),
-                ...(input.callId !== undefined ? { callId: input.callId } : {}),
-                ...(input.conversationId !== undefined
-                  ? { conversationId: input.conversationId }
-                  : {}),
-              });
-              return { result };
-            } catch (error) {
-              return { result: safeAppointmentToolError(error) };
-            }
-          }
-          case "sendAppointmentChangeOtp": {
-            const parsed = appointmentChangeOtpSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            try {
-              const result = await sendVoiceAppointmentChangeOtp({
-                verificationId: parsed.verificationId,
-              });
-              return { result };
-            } catch (error) {
-              return { result: safeAppointmentToolError(error) };
-            }
-          }
-          case "verifyAppointmentChangeOtp": {
-            const parsed = verifyAppointmentChangeOtpSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            try {
-              const result = await verifyVoiceAppointmentChangeOtp({
-                verificationId: parsed.verificationId,
-                code: parsed.code,
-              });
-              return { result };
-            } catch (error) {
-              return { result: safeAppointmentToolError(error) };
-            }
-          }
-          case "cancelAppointment": {
-            const parsed = cancelAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            try {
-              const result = await cancelVoiceAppointment({
-                businessId: input.businessId,
-                appointmentId: parsed.appointmentId,
-                callerPhone: input.callerPhone,
-                finalConfirmation: parsed.finalConfirmation,
-                ...(parsed.verificationId !== undefined
-                  ? { verificationId: parsed.verificationId }
-                  : {}),
-                ...(input.callId !== undefined ? { callId: input.callId } : {}),
-                ...(input.conversationId !== undefined
-                  ? { conversationId: input.conversationId }
-                  : {}),
-              });
-              return { result };
-            } catch (error) {
-              return { result: safeAppointmentToolError(error) };
-            }
-          }
-          case "rescheduleAppointment": {
-            const parsed = rescheduleAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            try {
-              const result = await rescheduleVoiceAppointment({
-                businessId: input.businessId,
-                appointmentId: parsed.appointmentId,
-                callerPhone: input.callerPhone,
-                startsAt: parsed.startsAt,
-                timezone: parsed.timezone ?? input.snapshot.timezone,
-                ...(parsed.preferredStaffId !== undefined
-                  ? { preferredStaffId: parsed.preferredStaffId }
-                  : {}),
-                finalConfirmation: parsed.finalConfirmation,
-                ...(parsed.verificationId !== undefined
-                  ? { verificationId: parsed.verificationId }
-                  : {}),
-                ...(input.callId !== undefined ? { callId: input.callId } : {}),
-                ...(input.conversationId !== undefined
-                  ? { conversationId: input.conversationId }
-                  : {}),
-              });
-              return { result };
-            } catch (error) {
-              return { result: safeAppointmentToolError(error) };
-            }
-          }
-          case "transferCall": {
-            const parsed = transferCallSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            if (!isTransferAllowed(input.snapshot) || !input.snapshot.transferPolicy.transferNumber) {
-              return {
-                result: {
-                  ok: false,
-                  reason:
-                    "Transfers are not enabled for this business or no transfer number is configured.",
-                },
-              };
-            }
-
-            if (input.callId) {
-              await updateVoiceTransferState({
-                callId: input.callId,
-                transferState: "requested",
-              });
-            }
-
+          return {
+            result: {
+              matches: [],
+              source: "none",
+              fallbackUsed: false,
+            },
+          };
+        } catch {
+          const fallbackMatches = buildSnapshotFallbackMatches(input.snapshot, parsed.query);
+          if (fallbackMatches.length > 0) {
             return {
               result: {
-                ok: true,
-                destination: input.snapshot.transferPolicy.transferNumber,
-                reason: parsed.reason ?? "Caller requested a human handoff.",
-              },
-              pendingTransferDestination: input.snapshot.transferPolicy.transferNumber,
-            };
-          }
-          case "endCall": {
-            const parsed = endCallSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            return {
-              result: {
-                ok: true,
-                reason: parsed.reason,
-                message: parsed.message,
-                ...(parsed.severity !== undefined ? { severity: parsed.severity } : {}),
-              },
-              endCall: {
-                reason: parsed.reason,
-                message: parsed.message,
-                ...(parsed.severity !== undefined ? { severity: parsed.severity } : {}),
+                matches: fallbackMatches,
+                source: "snapshot_fallback",
+                fallbackUsed: true,
+                fallbackReason: "rag_error",
               },
             };
           }
-          case "setCallHold": {
-            const parsed = setCallHoldSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            const remainingHoldSeconds =
-              input.holdBudget?.remainingHoldSeconds ?? MAX_CUMULATIVE_HOLD_SECONDS;
-            const grantedDurationSeconds = Math.min(
-              parsed.durationSeconds,
-              MAX_SINGLE_HOLD_SECONDS,
-              Math.max(0, remainingHoldSeconds),
-            );
 
-            if (grantedDurationSeconds <= 0) {
-              const hold: HoldGrantResult = {
-                ok: false,
-                requestedDurationSeconds: parsed.durationSeconds,
-                grantedDurationSeconds: 0,
-                remainingHoldSeconds: 0,
-                capped: true,
-                reason: parsed.reason,
-                error: "hold_limit_reached",
-              };
-              return {
-                result: hold,
-                hold,
-              };
-            }
-
-            const hold: HoldGrantResult = {
-              ok: true,
-              requestedDurationSeconds: parsed.durationSeconds,
-              grantedDurationSeconds,
-              remainingHoldSeconds: Math.max(0, remainingHoldSeconds - grantedDurationSeconds),
-              capped: grantedDurationSeconds < parsed.durationSeconds,
-              reason: parsed.reason,
-            };
-
-            return {
-              result: hold,
-              hold,
-            };
-          }
-          case "takeMessage": {
-            const parsed = takeMessageSchema.parse(JSON.parse(input.rawArguments || "{}"));
-            if (!input.callId) {
-              throw new Error("Call has not been initialized yet.");
-            }
-
-            const result = await takeVoiceMessage({
-              businessId: input.businessId,
-              callId: input.callId,
-              ...(input.conversationId !== undefined
-                ? { conversationId: input.conversationId }
-                : {}),
-              ...(parsed.callerName !== undefined ? { callerName: parsed.callerName } : {}),
-              callbackPhone: parsed.callbackPhone ?? input.callerPhone,
-              message: parsed.message,
-              ...(parsed.urgency !== undefined ? { urgency: parsed.urgency } : {}),
-              ...(parsed.callbackWindow !== undefined
-                ? { callbackWindow: parsed.callbackWindow }
-                : {}),
-            });
-            return {
-              result,
-            };
-          }
-          default: {
-            return {
-              result: {
-                ok: false,
-                reason: `Unsupported tool: ${input.toolName}`,
-              },
-            };
-          }
+          return {
+            result: {
+              matches: [],
+              source: "none",
+              fallbackUsed: false,
+            },
+          };
         }
+      }
+      case "checkAvailability": {
+        const parsed = checkAvailabilitySchema.parse(JSON.parse(input.rawArguments || "{}"));
+        const result = await checkVoiceAvailability({
+          businessId: input.businessId,
+          serviceName: parsed.serviceName,
+          startsAt: parsed.startsAt,
+          timezone: parsed.timezone ?? input.snapshot.timezone,
+          ...(parsed.preferredStaffId !== undefined
+            ? { preferredStaffId: parsed.preferredStaffId }
+            : {}),
+        });
+        return {
+          result,
+        };
+      }
+      case "findAvailability": {
+        const parsed = findAvailabilitySchema.parse(JSON.parse(input.rawArguments || "{}"));
+        const result = await findVoiceAvailability({
+          businessId: input.businessId,
+          serviceName: parsed.serviceName,
+          date: parsed.date,
+          timezone: parsed.timezone ?? input.snapshot.timezone,
+          ...(parsed.preferredStaffId !== undefined
+            ? { preferredStaffId: parsed.preferredStaffId }
+            : {}),
+          ...(parsed.preferredHour24 !== undefined
+            ? { preferredHour24: parsed.preferredHour24 }
+            : {}),
+          ...(parsed.preferredMinute !== undefined
+            ? { preferredMinute: parsed.preferredMinute }
+            : {}),
+          ...(parsed.limit !== undefined ? { limit: parsed.limit } : {}),
+        });
+        return {
+          result,
+        };
+      }
+      case "bookAppointment": {
+        const parsed = bookAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        const result = await bookVoiceAppointment({
+          businessId: input.businessId,
+          serviceName: parsed.serviceName,
+          startsAt: parsed.startsAt,
+          timezone: parsed.timezone ?? input.snapshot.timezone,
+          ...(parsed.preferredStaffId !== undefined
+            ? { preferredStaffId: parsed.preferredStaffId }
+            : {}),
+          ...(input.conversationId !== undefined
+            ? { conversationId: input.conversationId }
+            : {}),
+          ...(parsed.contactName !== undefined ? { contactName: parsed.contactName } : {}),
+          contactPhone: parsed.contactPhone ?? input.callerPhone,
+        });
+        return {
+          result,
+        };
+      }
+      case "lookupAppointmentForChange": {
+        try {
+          const result = await lookupVoiceAppointmentForChange({
+            businessId: input.businessId,
+            callerPhone: input.callerPhone,
+          });
+          return { result };
+        } catch (error) {
+          return { result: safeAppointmentToolError(error) };
+        }
+      }
+      case "verifyAppointmentForChange": {
+        const parsed = verifyAppointmentForChangeSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        try {
+          const result = await verifyVoiceAppointmentForChange({
+            businessId: input.businessId,
+            action: parsed.action,
+            callerPhone: input.callerPhone,
+            ...(parsed.appointmentId !== undefined ? { appointmentId: parsed.appointmentId } : {}),
+            ...(parsed.callerName !== undefined ? { callerName: parsed.callerName } : {}),
+            ...(parsed.appointmentStartsAt !== undefined
+              ? { appointmentStartsAt: parsed.appointmentStartsAt }
+              : {}),
+            ...(parsed.serviceName !== undefined ? { serviceName: parsed.serviceName } : {}),
+            ...(input.callId !== undefined ? { callId: input.callId } : {}),
+            ...(input.conversationId !== undefined
+              ? { conversationId: input.conversationId }
+              : {}),
+          });
+          return { result };
+        } catch (error) {
+          return { result: safeAppointmentToolError(error) };
+        }
+      }
+      case "sendAppointmentChangeOtp": {
+        const parsed = appointmentChangeOtpSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        try {
+          const result = await sendVoiceAppointmentChangeOtp({
+            verificationId: parsed.verificationId,
+          });
+          return { result };
+        } catch (error) {
+          return { result: safeAppointmentToolError(error) };
+        }
+      }
+      case "verifyAppointmentChangeOtp": {
+        const parsed = verifyAppointmentChangeOtpSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        try {
+          const result = await verifyVoiceAppointmentChangeOtp({
+            verificationId: parsed.verificationId,
+            code: parsed.code,
+          });
+          return { result };
+        } catch (error) {
+          return { result: safeAppointmentToolError(error) };
+        }
+      }
+      case "cancelAppointment": {
+        const parsed = cancelAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        try {
+          const result = await cancelVoiceAppointment({
+            businessId: input.businessId,
+            appointmentId: parsed.appointmentId,
+            callerPhone: input.callerPhone,
+            finalConfirmation: parsed.finalConfirmation,
+            ...(parsed.verificationId !== undefined
+              ? { verificationId: parsed.verificationId }
+              : {}),
+            ...(input.callId !== undefined ? { callId: input.callId } : {}),
+            ...(input.conversationId !== undefined
+              ? { conversationId: input.conversationId }
+              : {}),
+          });
+          return { result };
+        } catch (error) {
+          return { result: safeAppointmentToolError(error) };
+        }
+      }
+      case "rescheduleAppointment": {
+        const parsed = rescheduleAppointmentSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        try {
+          const result = await rescheduleVoiceAppointment({
+            businessId: input.businessId,
+            appointmentId: parsed.appointmentId,
+            callerPhone: input.callerPhone,
+            startsAt: parsed.startsAt,
+            timezone: parsed.timezone ?? input.snapshot.timezone,
+            ...(parsed.preferredStaffId !== undefined
+              ? { preferredStaffId: parsed.preferredStaffId }
+              : {}),
+            finalConfirmation: parsed.finalConfirmation,
+            ...(parsed.verificationId !== undefined
+              ? { verificationId: parsed.verificationId }
+              : {}),
+            ...(input.callId !== undefined ? { callId: input.callId } : {}),
+            ...(input.conversationId !== undefined
+              ? { conversationId: input.conversationId }
+              : {}),
+          });
+          return { result };
+        } catch (error) {
+          return { result: safeAppointmentToolError(error) };
+        }
+      }
+      case "transferCall": {
+        const parsed = transferCallSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        if (!isTransferAllowed(input.snapshot) || !input.snapshot.transferPolicy.transferNumber) {
+          return {
+            result: {
+              ok: false,
+              reason:
+                "Transfers are not enabled for this business or no transfer number is configured.",
+            },
+          };
+        }
+
+        if (input.callId) {
+          await updateVoiceTransferState({
+            callId: input.callId,
+            transferState: "requested",
+          });
+        }
+
+        return {
+          result: {
+            ok: true,
+            destination: input.snapshot.transferPolicy.transferNumber,
+            reason: parsed.reason ?? "Caller requested a human handoff.",
+          },
+          pendingTransferDestination: input.snapshot.transferPolicy.transferNumber,
+        };
+      }
+      case "endCall": {
+        const parsed = endCallSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        return {
+          result: {
+            ok: true,
+            reason: parsed.reason,
+            message: parsed.message,
+            ...(parsed.severity !== undefined ? { severity: parsed.severity } : {}),
+          },
+          endCall: {
+            reason: parsed.reason,
+            message: parsed.message,
+            ...(parsed.severity !== undefined ? { severity: parsed.severity } : {}),
+          },
+        };
+      }
+      case "setCallHold": {
+        const parsed = setCallHoldSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        const remainingHoldSeconds =
+          input.holdBudget?.remainingHoldSeconds ?? MAX_CUMULATIVE_HOLD_SECONDS;
+        const grantedDurationSeconds = Math.min(
+          parsed.durationSeconds,
+          MAX_SINGLE_HOLD_SECONDS,
+          Math.max(0, remainingHoldSeconds),
+        );
+
+        if (grantedDurationSeconds <= 0) {
+          const hold: HoldGrantResult = {
+            ok: false,
+            requestedDurationSeconds: parsed.durationSeconds,
+            grantedDurationSeconds: 0,
+            remainingHoldSeconds: 0,
+            capped: true,
+            reason: parsed.reason,
+            error: "hold_limit_reached",
+          };
+          return {
+            result: hold,
+            hold,
+          };
+        }
+
+        const hold: HoldGrantResult = {
+          ok: true,
+          requestedDurationSeconds: parsed.durationSeconds,
+          grantedDurationSeconds,
+          remainingHoldSeconds: Math.max(0, remainingHoldSeconds - grantedDurationSeconds),
+          capped: grantedDurationSeconds < parsed.durationSeconds,
+          reason: parsed.reason,
+        };
+
+        return {
+          result: hold,
+          hold,
+        };
+      }
+      case "takeMessage": {
+        const parsed = takeMessageSchema.parse(JSON.parse(input.rawArguments || "{}"));
+        if (!input.callId) {
+          throw new Error("Call has not been initialized yet.");
+        }
+
+        const result = await takeVoiceMessage({
+          businessId: input.businessId,
+          callId: input.callId,
+          ...(input.conversationId !== undefined
+            ? { conversationId: input.conversationId }
+            : {}),
+          ...(parsed.callerName !== undefined ? { callerName: parsed.callerName } : {}),
+          callbackPhone: parsed.callbackPhone ?? input.callerPhone,
+          message: parsed.message,
+          ...(parsed.urgency !== undefined ? { urgency: parsed.urgency } : {}),
+          ...(parsed.callbackWindow !== undefined
+            ? { callbackWindow: parsed.callbackWindow }
+            : {}),
+        });
+        return {
+          result,
+        };
+      }
+      default: {
+        return {
+          result: {
+            ok: false,
+            reason: `Unsupported tool: ${input.toolName}`,
+          },
+        };
+      }
+    }
   } catch (error) {
     recordToolExecutionFailure(attributes);
     throw error;

--- a/apps/voice-gateway/src/realtime/toolExecutor.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.ts
@@ -393,6 +393,7 @@ export async function executeVoiceTool(input: {
           serviceName: parsed.serviceName,
           startsAt: parsed.startsAt,
           timezone: parsed.timezone ?? input.snapshot.timezone,
+          ...(input.channel !== undefined ? { channel: input.channel } : {}),
           ...(parsed.preferredStaffId !== undefined
             ? { preferredStaffId: parsed.preferredStaffId }
             : {}),

--- a/apps/voice-gateway/src/realtime/toolExecutor.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.ts
@@ -236,6 +236,7 @@ export async function executeVoiceTool(input: {
   callId?: string;
   conversationId?: string;
   callerPhone: string;
+  channel?: "voice" | "web_voice";
   holdBudget?: {
     remainingHoldSeconds: number;
   };
@@ -615,6 +616,7 @@ export async function executeVoiceTool(input: {
           ...(input.conversationId !== undefined
             ? { conversationId: input.conversationId }
             : {}),
+          ...(input.channel !== undefined ? { channel: input.channel } : {}),
           ...(parsed.callerName !== undefined ? { callerName: parsed.callerName } : {}),
           callbackPhone: callbackPhone ?? input.callerPhone,
           message: parsed.message,

--- a/apps/voice-gateway/src/realtime/toolExecutor.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.ts
@@ -590,6 +590,16 @@ export async function executeVoiceTool(input: {
           throw new Error("Call has not been initialized yet.");
         }
 
+        const callbackPhone = parsed.callbackPhone?.trim() || undefined;
+        if (!callbackPhone && input.callerPhone === "web") {
+          return {
+            result: {
+              ok: false,
+              reason: "A callback phone number is required for website voice messages.",
+            },
+          };
+        }
+
         const result = await takeVoiceMessage({
           businessId: input.businessId,
           callId: input.callId,
@@ -597,7 +607,7 @@ export async function executeVoiceTool(input: {
             ? { conversationId: input.conversationId }
             : {}),
           ...(parsed.callerName !== undefined ? { callerName: parsed.callerName } : {}),
-          callbackPhone: parsed.callbackPhone ?? input.callerPhone,
+          callbackPhone: callbackPhone ?? input.callerPhone,
           message: parsed.message,
           ...(parsed.urgency !== undefined ? { urgency: parsed.urgency } : {}),
           ...(parsed.callbackWindow !== undefined

--- a/apps/voice-gateway/src/telephony/mediaStream.test.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.test.ts
@@ -12,6 +12,7 @@ import {
   shouldSystemBlockForEndCall,
 } from "../realtime/callControl";
 import {
+  createRealtimeTurnDetectionConfig,
   estimateRealtimeTotalCostUsd,
   getImplicitEndCallForAssistantTranscript,
   getRealtimeGenerationOutcome,
@@ -21,6 +22,31 @@ import {
   shouldSkipImplicitEndCallResponseDone,
   shouldUseAssistantFinalMessageForToolEndCall,
 } from "./mediaStream";
+
+describe("createRealtimeTurnDetectionConfig", () => {
+  it("can disable auto responses and interruptions during the opening greeting", () => {
+    expect(
+      createRealtimeTurnDetectionConfig(30_000, {
+        createResponse: false,
+        interruptResponse: false,
+      }),
+    ).toEqual({
+      type: "server_vad",
+      create_response: false,
+      interrupt_response: false,
+      idle_timeout_ms: 30_000,
+    });
+  });
+
+  it("defaults to normal caller turn handling after the greeting", () => {
+    expect(createRealtimeTurnDetectionConfig(30_000)).toEqual({
+      type: "server_vad",
+      create_response: true,
+      interrupt_response: true,
+      idle_timeout_ms: 30_000,
+    });
+  });
+});
 
 describe("estimateRealtimeTotalCostUsd", () => {
   it("prefers provider-reported total cost when available", () => {

--- a/apps/voice-gateway/src/telephony/mediaStream.test.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.test.ts
@@ -32,6 +32,9 @@ describe("createRealtimeTurnDetectionConfig", () => {
       }),
     ).toEqual({
       type: "server_vad",
+      threshold: 0.65,
+      prefix_padding_ms: 300,
+      silence_duration_ms: 700,
       create_response: false,
       interrupt_response: false,
       idle_timeout_ms: 30_000,
@@ -41,6 +44,9 @@ describe("createRealtimeTurnDetectionConfig", () => {
   it("defaults to normal caller turn handling after the greeting", () => {
     expect(createRealtimeTurnDetectionConfig(30_000)).toEqual({
       type: "server_vad",
+      threshold: 0.65,
+      prefix_padding_ms: 300,
+      silence_duration_ms: 700,
       create_response: true,
       interrupt_response: true,
       idle_timeout_ms: 30_000,

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -214,6 +214,7 @@ type ActiveVoiceSession = {
   openingGreetingResponseDone: boolean;
   openingGreetingPlaybackDone: boolean;
   openingGreetingPlaybackMarkName: string | null;
+  openingGreetingTurnDetectionTimer: ReturnType<typeof setTimeout> | null;
 };
 
 type RealtimeUsageMetrics = {
@@ -251,6 +252,10 @@ function isTransferQuotaError(error: unknown): boolean {
 const TRANSFER_QUOTA_REACHED_MESSAGE =
   "This business has reached its transfer limit for this billing period. Please try again later.";
 const IMPLICIT_TERMINAL_HANGUP_RETRY_DELAYS_MS = [250, 1_000, 2_500];
+const REALTIME_VAD_THRESHOLD = 0.65;
+const REALTIME_VAD_PREFIX_PADDING_MS = 300;
+const REALTIME_VAD_SILENCE_DURATION_MS = 700;
+const POST_GREETING_INPUT_GRACE_MS = 1_500;
 
 function asUnknownRecord(
   value: unknown,
@@ -643,6 +648,17 @@ function createRealtimeToolDefinitions() {
   return [
     {
       type: "function",
+      name: "waitForUser",
+      description:
+        "Use when the latest audio is silence, background noise, echo of the assistant's own audio, hold music, TV audio, side conversation, or speech not addressed to the assistant. This keeps listening without a spoken reply.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      type: "function",
       name: "getBusinessHours",
       description: "Get the authoritative business hours and closure information.",
       parameters: {
@@ -951,6 +967,9 @@ export function createRealtimeTurnDetectionConfig(
 ): Record<string, unknown> {
   return {
     type: "server_vad",
+    threshold: REALTIME_VAD_THRESHOLD,
+    prefix_padding_ms: REALTIME_VAD_PREFIX_PADDING_MS,
+    silence_duration_ms: REALTIME_VAD_SILENCE_DURATION_MS,
     create_response: options.createResponse ?? true,
     interrupt_response: options.interruptResponse ?? true,
     idle_timeout_ms: idleTimeoutMs,
@@ -971,7 +990,7 @@ function updateRealtimeIdleTimeout(socket: WebSocket, idleTimeoutMs: number): vo
   });
 }
 
-function finishOpeningGreeting(
+function enableCallerTurnDetectionAfterOpeningGreeting(
   server: FastifyInstance,
   openAiSocket: WebSocket,
   twilioSocket: WebSocket,
@@ -982,6 +1001,10 @@ function finishOpeningGreeting(
     return;
   }
 
+  if (session.openingGreetingTurnDetectionTimer !== null) {
+    clearTimeout(session.openingGreetingTurnDetectionTimer);
+    session.openingGreetingTurnDetectionTimer = null;
+  }
   session.openingGreetingActive = false;
   session.openingGreetingResponseDone = true;
   session.openingGreetingPlaybackDone = true;
@@ -1001,6 +1024,50 @@ function finishOpeningGreeting(
       reason,
     },
     "Enabled caller turn detection after opening greeting",
+  );
+}
+
+function finishOpeningGreeting(
+  server: FastifyInstance,
+  openAiSocket: WebSocket,
+  twilioSocket: WebSocket,
+  session: ActiveVoiceSession,
+  reason: string,
+): void {
+  if (
+    !session.openingGreetingActive ||
+    session.finalized ||
+    session.openingGreetingTurnDetectionTimer !== null
+  ) {
+    return;
+  }
+
+  session.openingGreetingResponseDone = true;
+  session.openingGreetingPlaybackDone = true;
+  session.openingGreetingPlaybackMarkName = null;
+  session.pendingInboundAudio = [];
+
+  postRealtimeEvent(openAiSocket, { type: "input_audio_buffer.clear" });
+  session.openingGreetingTurnDetectionTimer = setTimeout(() => {
+    session.openingGreetingTurnDetectionTimer = null;
+    enableCallerTurnDetectionAfterOpeningGreeting(
+      server,
+      openAiSocket,
+      twilioSocket,
+      session,
+      reason,
+    );
+  }, POST_GREETING_INPUT_GRACE_MS);
+
+  server.log.info(
+    {
+      callId: session.callId,
+      callSid: session.callSid,
+      streamSid: session.streamSid,
+      reason,
+      graceMs: POST_GREETING_INPUT_GRACE_MS,
+    },
+    "Waiting briefly before enabling caller turn detection after opening greeting",
   );
 }
 
@@ -1619,6 +1686,10 @@ async function finalizeCall(
   await applyPendingImplicitEndCallBeforeFinalize(server, session);
   session.finalized = true;
   clearInactivityTimer(session);
+  if (session.openingGreetingTurnDetectionTimer !== null) {
+    clearTimeout(session.openingGreetingTurnDetectionTimer);
+    session.openingGreetingTurnDetectionTimer = null;
+  }
   if (session.activeCallCounted) {
     session.activeCallCounted = false;
   }
@@ -2124,6 +2195,7 @@ async function configureOpenAiSession(
         "You are speaking on a live phone call.",
         "Start in the language implied by the configured greeting.",
         "Use the configured greeting only once at the start of the call. Never repeat it after the opening greeting, even after interruptions, silence, or filler speech.",
+        "If the latest audio is silence, background noise, echo of your own previous audio, hold music, TV audio, side conversation, or speech not addressed to you, call waitForUser and do not speak.",
         "After the greeting, adapt to the caller's language as soon as the caller clearly establishes one.",
         "Answer from the supplied business snapshot whenever possible.",
         "Use tools for authoritative actions like booking, appointment changes, transfer, and message taking.",
@@ -2159,6 +2231,7 @@ async function configureOpenAiSession(
       audio: {
         input: {
           format: { type: "audio/pcmu" },
+          noise_reduction: { type: "near_field" },
           transcription: {
             model: runtimeConfig.OPENAI_TRANSCRIPTION_MODEL,
           },
@@ -2336,6 +2409,13 @@ async function handleToolCall(
         output: JSON.stringify(toolOutput),
       },
     });
+
+    if (result.suppressResponse) {
+      session.pendingInboundAudio = [];
+      postRealtimeEvent(openAiSocket, { type: "input_audio_buffer.clear" });
+      scheduleInactivityTimer(server, openAiSocket, twilioSocket, session);
+      return;
+    }
 
     if (result.endCall) {
       if (shouldUseAssistantFinalMessageForToolEndCall(result.endCall)) {
@@ -3230,6 +3310,7 @@ export async function handleMediaStreamConnection(
     openingGreetingResponseDone: false,
     openingGreetingPlaybackDone: false,
     openingGreetingPlaybackMarkName: null,
+    openingGreetingTurnDetectionTimer: null,
   };
 
   const runtimeConfig = server.runtimeConfig;

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -210,6 +210,10 @@ type ActiveVoiceSession = {
   assistantResponseRequestedAtMs: number | null;
   assistantFirstOutputAtMs: number | null;
   activeCallCounted: boolean;
+  openingGreetingActive: boolean;
+  openingGreetingResponseDone: boolean;
+  openingGreetingPlaybackDone: boolean;
+  openingGreetingPlaybackMarkName: string | null;
 };
 
 type RealtimeUsageMetrics = {
@@ -938,11 +942,17 @@ function postRealtimeEvent(socket: WebSocket, payload: Record<string, unknown>):
   }
 }
 
-function createRealtimeTurnDetectionConfig(idleTimeoutMs: number): Record<string, unknown> {
+export function createRealtimeTurnDetectionConfig(
+  idleTimeoutMs: number,
+  options: {
+    createResponse?: boolean;
+    interruptResponse?: boolean;
+  } = {},
+): Record<string, unknown> {
   return {
     type: "server_vad",
-    create_response: true,
-    interrupt_response: true,
+    create_response: options.createResponse ?? true,
+    interrupt_response: options.interruptResponse ?? true,
     idle_timeout_ms: idleTimeoutMs,
   };
 }
@@ -959,6 +969,39 @@ function updateRealtimeIdleTimeout(socket: WebSocket, idleTimeoutMs: number): vo
       },
     },
   });
+}
+
+function finishOpeningGreeting(
+  server: FastifyInstance,
+  openAiSocket: WebSocket,
+  twilioSocket: WebSocket,
+  session: ActiveVoiceSession,
+  reason: string,
+): void {
+  if (!session.openingGreetingActive || session.finalized) {
+    return;
+  }
+
+  session.openingGreetingActive = false;
+  session.openingGreetingResponseDone = true;
+  session.openingGreetingPlaybackDone = true;
+  session.openingGreetingPlaybackMarkName = null;
+  session.pendingInboundAudio = [];
+
+  postRealtimeEvent(openAiSocket, { type: "input_audio_buffer.clear" });
+  updateRealtimeIdleTimeout(openAiSocket, NORMAL_IDLE_TIMEOUT_MS);
+  session.inactivity = markAssistantResponseDone(session.inactivity, Date.now());
+  scheduleInactivityTimer(server, openAiSocket, twilioSocket, session);
+
+  server.log.info(
+    {
+      callId: session.callId,
+      callSid: session.callSid,
+      streamSid: session.streamSid,
+      reason,
+    },
+    "Enabled caller turn detection after opening greeting",
+  );
 }
 
 function clearInactivityTimer(session: ActiveVoiceSession): void {
@@ -2080,6 +2123,7 @@ async function configureOpenAiSession(
         buildVoiceSystemPrompt(session.snapshot),
         "You are speaking on a live phone call.",
         "Start in the language implied by the configured greeting.",
+        "Use the configured greeting only once at the start of the call. Never repeat it after the opening greeting, even after interruptions, silence, or filler speech.",
         "After the greeting, adapt to the caller's language as soon as the caller clearly establishes one.",
         "Answer from the supplied business snapshot whenever possible.",
         "Use tools for authoritative actions like booking, appointment changes, transfer, and message taking.",
@@ -2118,7 +2162,10 @@ async function configureOpenAiSession(
           transcription: {
             model: runtimeConfig.OPENAI_TRANSCRIPTION_MODEL,
           },
-          turn_detection: createRealtimeTurnDetectionConfig(NORMAL_IDLE_TIMEOUT_MS),
+          turn_detection: createRealtimeTurnDetectionConfig(NORMAL_IDLE_TIMEOUT_MS, {
+            createResponse: false,
+            interruptResponse: false,
+          }),
         },
         output: {
           format: { type: "audio/pcmu" },
@@ -2141,12 +2188,8 @@ async function configureOpenAiSession(
       provider: "openai",
     });
   }
-  for (const payload of session.pendingInboundAudio) {
-    postRealtimeEvent(openAiSocket, {
-      type: "input_audio_buffer.append",
-      audio: payload,
-    });
-  }
+  // Audio captured before the opening greeting is usually ringback, room noise,
+  // or caller echo. Do not let it interrupt or answer the greeting.
   session.pendingInboundAudio = [];
 
   session.assistantResponseRequestedAtMs = Date.now();
@@ -2158,6 +2201,7 @@ async function configureOpenAiSession(
         `Begin the call by greeting the caller with this exact greeting: "${session.snapshot.greeting}"`,
         "After the greeting, continue in the language implied by that greeting unless the caller clearly prefers another language.",
         "After the greeting, stop speaking and wait for the caller to respond.",
+        "Do not repeat this greeting later in the call.",
         "Do not add any extra sentence before or after the greeting.",
       ].join(" "),
     },
@@ -2627,6 +2671,23 @@ function handleOpenAiMessage(
     case "response.audio.done":
     case "response.output_audio.done": {
       const markName = queuePendingPlaybackMark();
+      if (session.openingGreetingActive) {
+        if (markName) {
+          session.openingGreetingPlaybackMarkName = markName;
+        } else {
+          session.openingGreetingPlaybackDone = true;
+          if (session.openingGreetingResponseDone) {
+            finishOpeningGreeting(
+              server,
+              openAiSocket,
+              twilioSocket,
+              session,
+              "audio_done_without_playback_mark",
+            );
+          }
+        }
+        return;
+      }
       if (
         shouldSkipImplicitEndCallAudioDone({
           pendingImplicitEndCall: session.pendingImplicitEndCall,
@@ -2779,6 +2840,32 @@ function handleOpenAiMessage(
       session.assistantResponseRequestedAtMs = null;
       session.assistantFirstOutputAtMs = null;
 
+      if (session.openingGreetingActive) {
+        session.openingGreetingResponseDone = true;
+        if (
+          !session.openingGreetingPlaybackDone &&
+          !session.openingGreetingPlaybackMarkName &&
+          payload.response?.id &&
+          payload.response.id === session.activeAssistantResponseId &&
+          session.pendingOutboundAudio.length > 0
+        ) {
+          session.openingGreetingPlaybackMarkName = queuePendingPlaybackMark();
+        }
+        if (!session.openingGreetingPlaybackMarkName) {
+          session.openingGreetingPlaybackDone = true;
+        }
+        if (session.openingGreetingPlaybackDone) {
+          finishOpeningGreeting(
+            server,
+            openAiSocket,
+            twilioSocket,
+            session,
+            "response_done",
+          );
+        }
+        return;
+      }
+
       if (
         payload.response?.id &&
         payload.response.id === session.activeAssistantResponseId &&
@@ -2815,6 +2902,17 @@ function handleOpenAiMessage(
       return;
     }
     case "input_audio_buffer.speech_started": {
+      if (session.openingGreetingActive) {
+        server.log.info(
+          {
+            callId: session.callId,
+            callSid: session.callSid,
+            streamSid: session.streamSid,
+          },
+          "Ignored caller speech detection during opening greeting",
+        );
+        return;
+      }
       interruptAssistantPlaybackForCallerSpeech(server, openAiSocket, twilioSocket, session);
       resetInactivityForCallerActivity(openAiSocket, session);
       return;
@@ -3001,12 +3099,29 @@ export async function handleMediaStreamConnection(
         }
         if (payload.mark?.name) {
           acknowledgeOutboundPlaybackMark(session, payload.mark.name);
+          if (payload.mark.name === session.openingGreetingPlaybackMarkName) {
+            session.openingGreetingPlaybackDone = true;
+            session.openingGreetingPlaybackMarkName = null;
+            if (session.openingGreetingResponseDone) {
+              finishOpeningGreeting(
+                server,
+                openAiSocket as WebSocket,
+                twilioSocket,
+                session,
+                "playback_mark",
+              );
+            }
+          }
         }
         return;
       }
 
       if (payload.event === "media" && payload.media?.payload) {
         if (payload.media.track && payload.media.track !== "inbound") {
+          return;
+        }
+
+        if (session.openingGreetingActive) {
           return;
         }
 
@@ -3111,6 +3226,10 @@ export async function handleMediaStreamConnection(
     assistantResponseRequestedAtMs: null,
     assistantFirstOutputAtMs: null,
     activeCallCounted: false,
+    openingGreetingActive: true,
+    openingGreetingResponseDone: false,
+    openingGreetingPlaybackDone: false,
+    openingGreetingPlaybackMarkName: null,
   };
 
   const runtimeConfig = server.runtimeConfig;

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -41,6 +41,30 @@ vi.mock("../convex/runtimeClient", () => ({
 }));
 
 import { createServer } from "../http/server";
+import { createWebRealtimeTurnDetectionConfig } from "./routes";
+
+describe("createWebRealtimeTurnDetectionConfig", () => {
+  it("can disable auto responses and interruptions during the opening greeting", () => {
+    expect(
+      createWebRealtimeTurnDetectionConfig({
+        createResponse: false,
+        interruptResponse: false,
+      }),
+    ).toEqual({
+      type: "server_vad",
+      create_response: false,
+      interrupt_response: false,
+    });
+  });
+
+  it("defaults to normal web caller turn handling after the greeting", () => {
+    expect(createWebRealtimeTurnDetectionConfig()).toEqual({
+      type: "server_vad",
+      create_response: true,
+      interrupt_response: true,
+    });
+  });
+});
 
 describe("web call routes", () => {
   beforeEach(() => {

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -921,6 +921,30 @@ describe("web call routes", () => {
     );
   });
 
+  it("rejects stale durable web recording targets", async () => {
+    const startedAtMs = Date.now() - 7 * 60 * 1000;
+    fetchWebCallRecordingTargetMock.mockResolvedValueOnce({
+      callId: "call_durable_stale",
+      startedAt: new Date(startedAtMs).toISOString(),
+      status: "in_progress",
+      webCallMaxDurationMs: 5 * 60 * 1000,
+    });
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions/gateway-session-stale/recording",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "audio/webm",
+      },
+      payload: Buffer.from("webm-recording"),
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(uploadVoiceRecordingMock).not.toHaveBeenCalled();
+  });
+
   it("requests a final assistant message before ending an AI-directed web call", async () => {
     fetchWebVoiceContextMock
       .mockResolvedValueOnce({ snapshot: demoSnapshot })
@@ -957,6 +981,7 @@ describe("web call routes", () => {
     });
 
     expect(createResponse.statusCode).toBe(200);
+    vi.useFakeTimers();
     webSocketInstances[0]?.emit(
       "message",
       Buffer.from(
@@ -972,22 +997,21 @@ describe("web call routes", () => {
       ),
     );
 
-    await vi.waitFor(() => {
-      const sentMessages = webSocketInstances[0]?.send.mock.calls.map((call) =>
-        JSON.parse(String(call[0])),
-      );
-      expect(sentMessages).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: "response.create",
-            response: expect.objectContaining({
-              metadata: { lobbystack_purpose: "web_final_message" },
-              tool_choice: "none",
-            }),
+    await vi.advanceTimersByTimeAsync(0);
+    const sentMessages = webSocketInstances[0]?.send.mock.calls.map((call) =>
+      JSON.parse(String(call[0])),
+    );
+    expect(sentMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "response.create",
+          response: expect.objectContaining({
+            metadata: { lobbystack_purpose: "web_final_message" },
+            tool_choice: "none",
           }),
-        ]),
-      );
-    });
+        }),
+      ]),
+    );
     expect(completeVoiceCallMock).not.toHaveBeenCalled();
 
     webSocketInstances[0]?.emit(
@@ -1004,14 +1028,16 @@ describe("web call routes", () => {
       ),
     );
 
-    await vi.waitFor(() => {
-      expect(completeVoiceCallMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          callId: "call_123",
-          disposition: "caller_finished",
-        }),
-      );
-    });
+    await vi.advanceTimersByTimeAsync(1_599);
+    expect(completeVoiceCallMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(completeVoiceCallMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_123",
+        disposition: "caller_finished",
+      }),
+    );
   });
 
   it("passes web_voice when a website visitor leaves a message", async () => {

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 const {
   appendVoiceTranscriptMock,
   completeVoiceCallMock,
+  fetchWebCallRecordingTargetMock,
   fetchWebVoiceContextMock,
   runtimeRequestErrorClass,
   startWebVoiceCallMock,
@@ -12,6 +13,7 @@ const {
 } = vi.hoisted(() => ({
   appendVoiceTranscriptMock: vi.fn(),
   completeVoiceCallMock: vi.fn(),
+  fetchWebCallRecordingTargetMock: vi.fn(),
   fetchWebVoiceContextMock: vi.fn(),
   runtimeRequestErrorClass: class RuntimeRequestError extends Error {
     status: number;
@@ -82,6 +84,7 @@ vi.mock("ws", () => {
 vi.mock("../convex/runtimeClient", () => ({
   appendVoiceTranscript: appendVoiceTranscriptMock,
   completeVoiceCall: completeVoiceCallMock,
+  fetchWebCallRecordingTarget: fetchWebCallRecordingTargetMock,
   fetchWebVoiceContext: fetchWebVoiceContextMock,
   recordVoiceAiCost: vi.fn(),
   RuntimeRequestError: runtimeRequestErrorClass,
@@ -104,7 +107,7 @@ vi.mock("../convex/runtimeClient", () => ({
 import { demoSnapshot } from "@lobbystack/shared";
 
 import { createServer } from "../http/server";
-import { createWebRealtimeTurnDetectionConfig } from "./routes";
+import { createWebRealtimeTurnDetectionConfig, resetWebCallRouteStateForTests } from "./routes";
 
 describe("createWebRealtimeTurnDetectionConfig", () => {
   it("can disable auto responses and interruptions during the opening greeting", () => {
@@ -147,6 +150,7 @@ describe("web call routes", () => {
   });
 
   afterEach(() => {
+    resetWebCallRouteStateForTests();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
@@ -226,7 +230,13 @@ describe("web call routes", () => {
     expect(response.headers["access-control-allow-origin"]).toBe("http://localhost:4321");
   });
 
-  it("rejects unknown public widget business slugs", async () => {
+  it("returns Convex lookup failures for unknown public widget business slugs", async () => {
+    fetchWebVoiceContextMock.mockRejectedValueOnce(
+      new runtimeRequestErrorClass({
+        message: "Not found",
+        status: 404,
+      }),
+    );
     const server = createServer();
 
     const response = await server.inject({
@@ -242,8 +252,10 @@ describe("web call routes", () => {
       },
     });
 
-    expect(response.statusCode).toBe(403);
-    expect(fetchWebVoiceContextMock).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(404);
+    expect(fetchWebVoiceContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ businessSlug: "other-business" }),
+    );
     expect(startWebVoiceCallMock).not.toHaveBeenCalled();
   });
 
@@ -265,6 +277,55 @@ describe("web call routes", () => {
     expect(response.statusCode).toBe(400);
     expect(fetchWebVoiceContextMock).not.toHaveBeenCalled();
     expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("does not rate limit syntactically invalid start attempts", async () => {
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      ),
+    );
+    const server = createServer();
+
+    for (let index = 0; index < 13; index += 1) {
+      const invalidResponse = await server.inject({
+        method: "POST",
+        url: "/web-call/sessions",
+        headers: {
+          origin: "https://lobbystack.com",
+          "content-type": "application/json",
+        },
+        payload: {
+          businessSlug: "lobbystack",
+        },
+      });
+      expect(invalidResponse.statusCode).toBe(400);
+    }
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
   });
 
   it("returns durable Convex rate limits before starting an OpenAI web call", async () => {
@@ -650,6 +711,39 @@ describe("web call routes", () => {
       expect.objectContaining({
         callId: "call_123",
         durationMs: 1234,
+      }),
+    );
+  });
+
+  it("resolves recording uploads through Convex when the gateway session is not local", async () => {
+    const endedAtMs = Date.now();
+    fetchWebCallRecordingTargetMock.mockResolvedValueOnce({
+      callId: "call_durable_123",
+      startedAt: new Date(endedAtMs - 5 * 60 * 1000).toISOString(),
+      endedAt: new Date(endedAtMs).toISOString(),
+      status: "completed",
+    });
+    uploadVoiceRecordingMock.mockResolvedValueOnce(null);
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions/gateway-session-durable/recording",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "audio/webm",
+      },
+      payload: Buffer.from("webm-recording"),
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(fetchWebCallRecordingTargetMock).toHaveBeenCalledWith({
+      gatewaySessionId: "gateway-session-durable",
+    });
+    expect(uploadVoiceRecordingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_durable_123",
+        durationMs: 5 * 60 * 1000,
       }),
     );
   });

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -543,6 +543,65 @@ describe("web call routes", () => {
     );
   });
 
+  it("ignores spoofed forwarded IP headers from untrusted direct clients", async () => {
+    process.env.VOICE_GATEWAY_TRUST_PROXY = "true";
+    fetchWebVoiceContextMock
+      .mockResolvedValueOnce({ snapshot: demoSnapshot })
+      .mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock
+      .mockResolvedValueOnce({
+        businessId: "business_123",
+        callId: "call_123",
+        conversationId: "conversation_123",
+      })
+      .mockResolvedValueOnce({
+        businessId: "business_123",
+        callId: "call_456",
+        conversationId: "conversation_456",
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response("answer-sdp", {
+            status: 200,
+            headers: { location: "/v1/realtime/calls/rtc_test_1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response("answer-sdp", {
+            status: 200,
+            headers: { location: "/v1/realtime/calls/rtc_test_2" },
+          }),
+        ),
+    );
+    const server = createServer();
+
+    for (const forwardedFor of ["203.0.113.10", "198.51.100.77"]) {
+      const response = await server.inject({
+        method: "POST",
+        url: "/web-call/sessions",
+        remoteAddress: "198.51.100.10",
+        headers: {
+          origin: "https://lobbystack.com",
+          "content-type": "application/json",
+          "x-forwarded-for": forwardedFor,
+        },
+        payload: {
+          businessSlug: "lobbystack",
+          sdp: "v=0",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    }
+
+    expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).toBe(
+      fetchWebVoiceContextMock.mock.calls[1]?.[0].ipHash,
+    );
+  });
+
   it("treats an unknown session end as idempotent", async () => {
     const server = createServer();
 
@@ -620,7 +679,7 @@ describe("web call routes", () => {
     expect(webSocketInstances[0]?.close).toHaveBeenCalledWith(1000, "web call ended");
   });
 
-  it("uploads browser web call recordings for active sessions", async () => {
+  it("uploads browser web call recordings for completed sessions", async () => {
     fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
     startWebVoiceCallMock.mockResolvedValueOnce({
       businessId: "business_123",
@@ -653,6 +712,12 @@ describe("web call routes", () => {
     });
     const { sessionId } = createResponse.json() as { sessionId: string };
 
+    await server.inject({
+      method: "POST",
+      url: `/web-call/sessions/${sessionId}/end`,
+      headers: { origin: "https://lobbystack.com" },
+    });
+
     const response = await server.inject({
       method: "POST",
       url: `/web-call/sessions/${sessionId}/recording?durationMs=1234`,
@@ -666,7 +731,7 @@ describe("web call routes", () => {
     expect(response.statusCode).toBe(204);
     expect(uploadVoiceRecordingMock).toHaveBeenCalledWith({
       callId: "call_123",
-      durationMs: 1234,
+      durationMs: expect.any(Number),
       audio: Buffer.from("webm-recording"),
       contentType: "audio/webm",
     });
@@ -705,6 +770,12 @@ describe("web call routes", () => {
     });
     const { sessionId } = createResponse.json() as { sessionId: string };
     const recording = Buffer.alloc(1024 * 1024 + 1, 1);
+
+    await server.inject({
+      method: "POST",
+      url: `/web-call/sessions/${sessionId}/end`,
+      headers: { origin: "https://lobbystack.com" },
+    });
 
     const response = await server.inject({
       method: "POST",
@@ -883,7 +954,37 @@ describe("web call routes", () => {
     expect(uploadVoiceRecordingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         callId: "call_123",
-        durationMs: 1234,
+        durationMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it("clamps reported recording duration to the actual web call window", async () => {
+    const endedAtMs = Date.now();
+    fetchWebCallRecordingTargetMock.mockResolvedValueOnce({
+      callId: "call_durable_clamped",
+      startedAt: new Date(endedAtMs - 2_000).toISOString(),
+      endedAt: new Date(endedAtMs).toISOString(),
+      status: "completed",
+    });
+    uploadVoiceRecordingMock.mockResolvedValueOnce(null);
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions/gateway-session-durable-clamped/recording?durationMs=999999",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "audio/webm",
+      },
+      payload: Buffer.from("webm-recording"),
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(uploadVoiceRecordingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_durable_clamped",
+        durationMs: 2_000,
       }),
     );
   });

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -1,27 +1,75 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
-const { fetchWebVoiceContextMock, runtimeRequestErrorClass, startWebVoiceCallMock } = vi.hoisted(
-  () => ({
-    fetchWebVoiceContextMock: vi.fn(),
-    runtimeRequestErrorClass: class RuntimeRequestError extends Error {
-      status: number;
-      code?: string;
+const {
+  completeVoiceCallMock,
+  fetchWebVoiceContextMock,
+  runtimeRequestErrorClass,
+  startWebVoiceCallMock,
+  webSocketInstances,
+} = vi.hoisted(() => ({
+  completeVoiceCallMock: vi.fn(),
+  fetchWebVoiceContextMock: vi.fn(),
+  runtimeRequestErrorClass: class RuntimeRequestError extends Error {
+    status: number;
+    code?: string;
 
-      constructor(input: { message: string; status: number; code?: string }) {
-        super(input.message);
-        this.name = "RuntimeRequestError";
-        this.status = input.status;
-        if (input.code !== undefined) {
-          this.code = input.code;
-        }
+    constructor(input: { message: string; status: number; code?: string }) {
+      super(input.message);
+      this.name = "RuntimeRequestError";
+      this.status = input.status;
+      if (input.code !== undefined) {
+        this.code = input.code;
       }
-    },
-    startWebVoiceCallMock: vi.fn(),
-  }),
-);
+    }
+  },
+  startWebVoiceCallMock: vi.fn(),
+  webSocketInstances: [] as Array<{
+    close: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock("ws", () => {
+  class MockWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+
+    readyState = MockWebSocket.OPEN;
+    close = vi.fn(() => {
+      this.readyState = MockWebSocket.CLOSED;
+      this.handlers.close?.forEach((handler) => handler());
+    });
+    send = vi.fn();
+    private handlers: Record<string, Array<(...args: Array<unknown>) => void>> = {};
+
+    constructor() {
+      webSocketInstances.push(this);
+    }
+
+    on(event: string, handler: (...args: Array<unknown>) => void) {
+      this.handlers[event] = [...(this.handlers[event] ?? []), handler];
+      return this;
+    }
+  }
+
+  class MockWebSocketServer {
+    handleUpgrade = vi.fn(
+      (
+        _request: unknown,
+        _socket: unknown,
+        _head: unknown,
+        callback: (socket: MockWebSocket) => void,
+      ) => {
+        callback(new MockWebSocket());
+      },
+    );
+  }
+
+  return { default: MockWebSocket, WebSocketServer: MockWebSocketServer };
+});
 
 vi.mock("../convex/runtimeClient", () => ({
-  completeVoiceCall: vi.fn(),
+  completeVoiceCall: completeVoiceCallMock,
   fetchWebVoiceContext: fetchWebVoiceContextMock,
   recordVoiceAiCost: vi.fn(),
   RuntimeRequestError: runtimeRequestErrorClass,
@@ -40,6 +88,8 @@ vi.mock("../convex/runtimeClient", () => ({
   verifyVoiceAppointmentForChange: vi.fn(),
 }));
 
+import { demoSnapshot } from "@lobbystack/shared";
+
 import { createServer } from "../http/server";
 import { createWebRealtimeTurnDetectionConfig } from "./routes";
 
@@ -52,6 +102,9 @@ describe("createWebRealtimeTurnDetectionConfig", () => {
       }),
     ).toEqual({
       type: "server_vad",
+      threshold: 0.65,
+      prefix_padding_ms: 300,
+      silence_duration_ms: 700,
       create_response: false,
       interrupt_response: false,
     });
@@ -60,6 +113,9 @@ describe("createWebRealtimeTurnDetectionConfig", () => {
   it("defaults to normal web caller turn handling after the greeting", () => {
     expect(createWebRealtimeTurnDetectionConfig()).toEqual({
       type: "server_vad",
+      threshold: 0.65,
+      prefix_padding_ms: 300,
+      silence_duration_ms: 700,
       create_response: true,
       interrupt_response: true,
     });
@@ -78,9 +134,13 @@ describe("web call routes", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
+    webSocketInstances.length = 0;
     delete process.env.OPENAI_API_KEY;
     delete process.env.WEB_CALL_ALLOWED_ORIGINS;
+    delete process.env.WEB_CALL_MAX_DURATION_MS;
   });
 
   it("rejects untrusted origins before starting a web call", async () => {
@@ -199,5 +259,68 @@ describe("web call routes", () => {
     });
 
     expect(response.statusCode).toBe(204);
+  });
+
+  it("hangs up OpenAI and completes the call after the max web call duration", async () => {
+    process.env.WEB_CALL_MAX_DURATION_MS = "1";
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    completeVoiceCallMock.mockResolvedValueOnce(null);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+        visitorId: "visitor-123",
+        widgetId: "lobbystack-landing",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(completeVoiceCallMock).toHaveBeenCalled();
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.openai.com/v1/realtime/calls/rtc_test/hangup",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-openai-key",
+        },
+      }),
+    );
+    expect(completeVoiceCallMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_123",
+        status: "completed",
+        disposition: "duration_limit",
+        providerDurationSeconds: expect.any(Number),
+      }),
+    );
+    expect(webSocketInstances[0]?.close).toHaveBeenCalledWith(1000, "web call ended");
   });
 });

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -191,6 +191,22 @@ describe("web call routes", () => {
     expect(response.statusCode).toBe(403);
   });
 
+  it("rejects localhost origins in cloud mode when allowed origins are unset", async () => {
+    process.env.DEPLOYMENT_MODE = "cloud";
+    delete process.env.WEB_CALL_ALLOWED_ORIGINS;
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "OPTIONS",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "http://localhost:4321",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
   it("allows localhost origins in cloud mode only when explicitly configured", async () => {
     process.env.DEPLOYMENT_MODE = "cloud";
     process.env.WEB_CALL_ALLOWED_ORIGINS = "https://lobbystack.com,http://localhost:4321";

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 const {
   appendVoiceTranscriptMock,
+  bookVoiceAppointmentMock,
   completeVoiceCallMock,
   fetchWebCallRecordingTargetMock,
   fetchWebVoiceContextMock,
@@ -12,6 +13,7 @@ const {
   webSocketInstances,
 } = vi.hoisted(() => ({
   appendVoiceTranscriptMock: vi.fn(),
+  bookVoiceAppointmentMock: vi.fn(),
   completeVoiceCallMock: vi.fn(),
   fetchWebCallRecordingTargetMock: vi.fn(),
   fetchWebVoiceContextMock: vi.fn(),
@@ -90,7 +92,7 @@ vi.mock("../convex/runtimeClient", () => ({
   RuntimeRequestError: runtimeRequestErrorClass,
   startWebVoiceCall: startWebVoiceCallMock,
   uploadVoiceRecording: uploadVoiceRecordingMock,
-  bookVoiceAppointment: vi.fn(),
+  bookVoiceAppointment: bookVoiceAppointmentMock,
   cancelVoiceAppointment: vi.fn(),
   checkVoiceAvailability: vi.fn(),
   findVoiceAvailability: vi.fn(),
@@ -156,6 +158,7 @@ describe("web call routes", () => {
     vi.clearAllMocks();
     webSocketInstances.length = 0;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.VOICE_GATEWAY_TRUST_PROXY;
     delete process.env.WEB_CALL_ALLOWED_ORIGINS;
     delete process.env.WEB_CALL_MAX_DURATION_MS;
   });
@@ -368,6 +371,122 @@ describe("web call routes", () => {
     );
     expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).toHaveLength(64);
     expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("does not trust spoofed forwarded IP headers by default", async () => {
+    fetchWebVoiceContextMock
+      .mockResolvedValueOnce({ snapshot: demoSnapshot })
+      .mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock
+      .mockResolvedValueOnce({
+        businessId: "business_123",
+        callId: "call_123",
+        conversationId: "conversation_123",
+      })
+      .mockResolvedValueOnce({
+        businessId: "business_123",
+        callId: "call_456",
+        conversationId: "conversation_456",
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response("answer-sdp", {
+            status: 200,
+            headers: { location: "/v1/realtime/calls/rtc_test_1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response("answer-sdp", {
+            status: 200,
+            headers: { location: "/v1/realtime/calls/rtc_test_2" },
+          }),
+        ),
+    );
+    const server = createServer();
+
+    for (const forwardedFor of ["203.0.113.10", "198.51.100.77"]) {
+      const response = await server.inject({
+        method: "POST",
+        url: "/web-call/sessions",
+        headers: {
+          origin: "https://lobbystack.com",
+          "content-type": "application/json",
+          "x-forwarded-for": forwardedFor,
+        },
+        payload: {
+          businessSlug: "lobbystack",
+          sdp: "v=0",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    }
+
+    expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).toBe(
+      fetchWebVoiceContextMock.mock.calls[1]?.[0].ipHash,
+    );
+  });
+
+  it("uses trusted forwarded IP headers when proxy trust is enabled", async () => {
+    process.env.VOICE_GATEWAY_TRUST_PROXY = "true";
+    fetchWebVoiceContextMock
+      .mockResolvedValueOnce({ snapshot: demoSnapshot })
+      .mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock
+      .mockResolvedValueOnce({
+        businessId: "business_123",
+        callId: "call_123",
+        conversationId: "conversation_123",
+      })
+      .mockResolvedValueOnce({
+        businessId: "business_123",
+        callId: "call_456",
+        conversationId: "conversation_456",
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response("answer-sdp", {
+            status: 200,
+            headers: { location: "/v1/realtime/calls/rtc_test_1" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response("answer-sdp", {
+            status: 200,
+            headers: { location: "/v1/realtime/calls/rtc_test_2" },
+          }),
+        ),
+    );
+    const server = createServer();
+
+    for (const forwardedFor of ["203.0.113.10", "198.51.100.77"]) {
+      const response = await server.inject({
+        method: "POST",
+        url: "/web-call/sessions",
+        headers: {
+          origin: "https://lobbystack.com",
+          "content-type": "application/json",
+          "x-forwarded-for": forwardedFor,
+        },
+        payload: {
+          businessSlug: "lobbystack",
+          sdp: "v=0",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    }
+
+    expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).toHaveLength(64);
+    expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).not.toBe(
+      fetchWebVoiceContextMock.mock.calls[1]?.[0].ipHash,
+    );
   });
 
   it("treats an unknown session end as idempotent", async () => {
@@ -895,6 +1014,73 @@ describe("web call routes", () => {
       expect(takeVoiceMessageMock).toHaveBeenCalledWith(
         expect.objectContaining({
           callId: "call_123",
+          conversationId: "conversation_123",
+          channel: "web_voice",
+        }),
+      );
+    });
+  });
+
+  it("passes web_voice when a website visitor books an appointment", async () => {
+    fetchWebVoiceContextMock
+      .mockResolvedValueOnce({ snapshot: demoSnapshot })
+      .mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    bookVoiceAppointmentMock.mockResolvedValueOnce({
+      appointmentId: "appointment_123",
+      contactId: "contact_123",
+      serviceId: "service_123",
+      serviceName: "Consultation",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      ),
+    );
+    const server = createServer();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.done",
+          name: "bookAppointment",
+          call_id: "tool-call-1",
+          arguments: JSON.stringify({
+            serviceName: "Consultation",
+            startsAt: "2030-05-15T14:00:00.000Z",
+            contactPhone: "+14165550123",
+          }),
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => {
+      expect(bookVoiceAppointmentMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessId: "business_123",
           conversationId: "conversation_123",
           channel: "web_voice",
         }),

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 const {
+  appendVoiceTranscriptMock,
   completeVoiceCallMock,
   fetchWebVoiceContextMock,
   runtimeRequestErrorClass,
   startWebVoiceCallMock,
+  uploadVoiceRecordingMock,
   webSocketInstances,
 } = vi.hoisted(() => ({
+  appendVoiceTranscriptMock: vi.fn(),
   completeVoiceCallMock: vi.fn(),
   fetchWebVoiceContextMock: vi.fn(),
   runtimeRequestErrorClass: class RuntimeRequestError extends Error {
@@ -23,8 +26,10 @@ const {
     }
   },
   startWebVoiceCallMock: vi.fn(),
+  uploadVoiceRecordingMock: vi.fn(),
   webSocketInstances: [] as Array<{
     close: ReturnType<typeof vi.fn>;
+    emit: (event: string, ...args: Array<unknown>) => void;
     send: ReturnType<typeof vi.fn>;
   }>,
 }));
@@ -50,6 +55,10 @@ vi.mock("ws", () => {
       this.handlers[event] = [...(this.handlers[event] ?? []), handler];
       return this;
     }
+
+    emit(event: string, ...args: Array<unknown>) {
+      this.handlers[event]?.forEach((handler) => handler(...args));
+    }
   }
 
   class MockWebSocketServer {
@@ -69,11 +78,13 @@ vi.mock("ws", () => {
 });
 
 vi.mock("../convex/runtimeClient", () => ({
+  appendVoiceTranscript: appendVoiceTranscriptMock,
   completeVoiceCall: completeVoiceCallMock,
   fetchWebVoiceContext: fetchWebVoiceContextMock,
   recordVoiceAiCost: vi.fn(),
   RuntimeRequestError: runtimeRequestErrorClass,
   startWebVoiceCall: startWebVoiceCallMock,
+  uploadVoiceRecording: uploadVoiceRecordingMock,
   bookVoiceAppointment: vi.fn(),
   cancelVoiceAppointment: vi.fn(),
   checkVoiceAvailability: vi.fn(),
@@ -322,5 +333,219 @@ describe("web call routes", () => {
       }),
     );
     expect(webSocketInstances[0]?.close).toHaveBeenCalledWith(1000, "web call ended");
+  });
+
+  it("uploads browser web call recordings for active sessions", async () => {
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    uploadVoiceRecordingMock.mockResolvedValueOnce(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      ),
+    );
+    const server = createServer();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+    const { sessionId } = createResponse.json() as { sessionId: string };
+
+    const response = await server.inject({
+      method: "POST",
+      url: `/web-call/sessions/${sessionId}/recording?durationMs=1234`,
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "audio/webm",
+      },
+      payload: Buffer.from("webm-recording"),
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(uploadVoiceRecordingMock).toHaveBeenCalledWith({
+      callId: "call_123",
+      durationMs: 1234,
+      audio: Buffer.from("webm-recording"),
+      contentType: "audio/webm",
+    });
+  });
+
+  it("orders delayed caller transcripts before the matching assistant reply", async () => {
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    appendVoiceTranscriptMock.mockResolvedValue(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      ),
+    );
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.output_audio_transcript.done",
+          item_id: "greeting-item-1",
+          content_index: 0,
+          transcript: "Thanks for calling LobbyStack QA. How can I help?",
+        }),
+      ),
+    );
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.done", response: { id: "greeting" } })),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 2_050));
+
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.output_audio_transcript.done",
+          item_id: "assistant-item-1",
+          content_index: 0,
+          transcript: "I can help with that.",
+        }),
+      ),
+    );
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.completed",
+          item_id: "caller-item-1",
+          content_index: 0,
+          transcript: "I need help booking an appointment.",
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => {
+      expect(appendVoiceTranscriptMock).toHaveBeenCalledTimes(3);
+    });
+    expect(appendVoiceTranscriptMock).toHaveBeenNthCalledWith(1, {
+      businessId: "business_123",
+      callId: "call_123",
+      sequence: 1,
+      speaker: "assistant",
+      text: "Thanks for calling LobbyStack QA. How can I help?",
+      final: true,
+    });
+    expect(appendVoiceTranscriptMock).toHaveBeenNthCalledWith(2, {
+      businessId: "business_123",
+      callId: "call_123",
+      sequence: 2,
+      speaker: "caller",
+      text: "I need help booking an appointment.",
+      final: true,
+    });
+    expect(appendVoiceTranscriptMock).toHaveBeenNthCalledWith(3, {
+      businessId: "business_123",
+      callId: "call_123",
+      sequence: 3,
+      speaker: "assistant",
+      text: "I can help with that.",
+      final: true,
+    });
+  });
+
+  it("allows recording upload shortly after the web session ends", async () => {
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    completeVoiceCallMock.mockResolvedValueOnce(null);
+    uploadVoiceRecordingMock.mockResolvedValueOnce(null);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+    const { sessionId } = createResponse.json() as { sessionId: string };
+
+    await server.inject({
+      method: "POST",
+      url: `/web-call/sessions/${sessionId}/end`,
+      headers: { origin: "https://lobbystack.com" },
+    });
+
+    const response = await server.inject({
+      method: "POST",
+      url: `/web-call/sessions/${sessionId}/recording?durationMs=1234`,
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "audio/webm",
+      },
+      payload: Buffer.from("webm-recording"),
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(uploadVoiceRecordingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_123",
+        durationMs: 1234,
+      }),
+    );
   });
 });

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -6,6 +6,7 @@ const {
   fetchWebVoiceContextMock,
   runtimeRequestErrorClass,
   startWebVoiceCallMock,
+  takeVoiceMessageMock,
   uploadVoiceRecordingMock,
   webSocketInstances,
 } = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ const {
     }
   },
   startWebVoiceCallMock: vi.fn(),
+  takeVoiceMessageMock: vi.fn(),
   uploadVoiceRecordingMock: vi.fn(),
   webSocketInstances: [] as Array<{
     close: ReturnType<typeof vi.fn>;
@@ -93,7 +95,7 @@ vi.mock("../convex/runtimeClient", () => ({
   rescheduleVoiceAppointment: vi.fn(),
   searchVoiceKnowledge: vi.fn(),
   sendVoiceAppointmentChangeOtp: vi.fn(),
-  takeVoiceMessage: vi.fn(),
+  takeVoiceMessage: takeVoiceMessageMock,
   updateVoiceTransferState: vi.fn(),
   verifyVoiceAppointmentChangeOtp: vi.fn(),
   verifyVoiceAppointmentForChange: vi.fn(),
@@ -650,5 +652,159 @@ describe("web call routes", () => {
         durationMs: 1234,
       }),
     );
+  });
+
+  it("requests a final assistant message before ending an AI-directed web call", async () => {
+    fetchWebVoiceContextMock
+      .mockResolvedValueOnce({ snapshot: demoSnapshot })
+      .mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    completeVoiceCallMock.mockResolvedValueOnce(null);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.done",
+          name: "endCall",
+          call_id: "tool-call-1",
+          arguments: JSON.stringify({
+            reason: "caller_finished",
+            message: "Thanks for visiting. Goodbye.",
+          }),
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => {
+      const sentMessages = webSocketInstances[0]?.send.mock.calls.map((call) =>
+        JSON.parse(String(call[0])),
+      );
+      expect(sentMessages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "response.create",
+            response: expect.objectContaining({
+              metadata: { lobbystack_purpose: "web_final_message" },
+              tool_choice: "none",
+            }),
+          }),
+        ]),
+      );
+    });
+    expect(completeVoiceCallMock).not.toHaveBeenCalled();
+
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.done",
+          response: {
+            id: "final-response-1",
+            status: "completed",
+            metadata: { lobbystack_purpose: "web_final_message" },
+          },
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => {
+      expect(completeVoiceCallMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callId: "call_123",
+          disposition: "caller_finished",
+        }),
+      );
+    });
+  });
+
+  it("passes web_voice when a website visitor leaves a message", async () => {
+    fetchWebVoiceContextMock
+      .mockResolvedValueOnce({ snapshot: demoSnapshot })
+      .mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    takeVoiceMessageMock.mockResolvedValueOnce({ inboxItemId: "inbox_123" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      ),
+    );
+    const server = createServer();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    webSocketInstances[0]?.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.done",
+          name: "takeMessage",
+          call_id: "tool-call-1",
+          arguments: JSON.stringify({
+            callbackPhone: "+14165550123",
+            message: "Please call me tomorrow.",
+          }),
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => {
+      expect(takeVoiceMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callId: "call_123",
+          conversationId: "conversation_123",
+          channel: "web_voice",
+        }),
+      );
+    });
   });
 });

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -175,6 +175,39 @@ describe("web call routes", () => {
     expect(startWebVoiceCallMock).not.toHaveBeenCalled();
   });
 
+  it("rejects implicit localhost origins in cloud mode", async () => {
+    process.env.DEPLOYMENT_MODE = "cloud";
+    process.env.WEB_CALL_ALLOWED_ORIGINS = "https://lobbystack.com";
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "OPTIONS",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "http://localhost:4321",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("allows localhost origins in cloud mode only when explicitly configured", async () => {
+    process.env.DEPLOYMENT_MODE = "cloud";
+    process.env.WEB_CALL_ALLOWED_ORIGINS = "https://lobbystack.com,http://localhost:4321";
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "OPTIONS",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "http://localhost:4321",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["access-control-allow-origin"]).toBe("http://localhost:4321");
+  });
+
   it("rejects unknown public widget business slugs", async () => {
     const server = createServer();
 
@@ -385,6 +418,60 @@ describe("web call routes", () => {
       audio: Buffer.from("webm-recording"),
       contentType: "audio/webm",
     });
+  });
+
+  it("accepts browser recordings over Fastify's default body limit", async () => {
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    uploadVoiceRecordingMock.mockResolvedValueOnce(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response("answer-sdp", {
+          status: 200,
+          headers: { location: "/v1/realtime/calls/rtc_test" },
+        }),
+      ),
+    );
+    const server = createServer();
+
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+    const { sessionId } = createResponse.json() as { sessionId: string };
+    const recording = Buffer.alloc(1024 * 1024 + 1, 1);
+
+    const response = await server.inject({
+      method: "POST",
+      url: `/web-call/sessions/${sessionId}/recording?durationMs=1234`,
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "audio/webm",
+      },
+      payload: recording,
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(uploadVoiceRecordingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_123",
+        audio: expect.any(Buffer),
+      }),
+    );
+    expect(uploadVoiceRecordingMock.mock.calls[0]?.[0].audio).toHaveLength(recording.length);
   });
 
   it("orders delayed caller transcripts before the matching assistant reply", async () => {

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+const { fetchWebVoiceContextMock, runtimeRequestErrorClass, startWebVoiceCallMock } = vi.hoisted(
+  () => ({
+    fetchWebVoiceContextMock: vi.fn(),
+    runtimeRequestErrorClass: class RuntimeRequestError extends Error {
+      status: number;
+      code?: string;
+
+      constructor(input: { message: string; status: number; code?: string }) {
+        super(input.message);
+        this.name = "RuntimeRequestError";
+        this.status = input.status;
+        if (input.code !== undefined) {
+          this.code = input.code;
+        }
+      }
+    },
+    startWebVoiceCallMock: vi.fn(),
+  }),
+);
+
+vi.mock("../convex/runtimeClient", () => ({
+  completeVoiceCall: vi.fn(),
+  fetchWebVoiceContext: fetchWebVoiceContextMock,
+  recordVoiceAiCost: vi.fn(),
+  RuntimeRequestError: runtimeRequestErrorClass,
+  startWebVoiceCall: startWebVoiceCallMock,
+  bookVoiceAppointment: vi.fn(),
+  cancelVoiceAppointment: vi.fn(),
+  checkVoiceAvailability: vi.fn(),
+  findVoiceAvailability: vi.fn(),
+  lookupVoiceAppointmentForChange: vi.fn(),
+  rescheduleVoiceAppointment: vi.fn(),
+  searchVoiceKnowledge: vi.fn(),
+  sendVoiceAppointmentChangeOtp: vi.fn(),
+  takeVoiceMessage: vi.fn(),
+  updateVoiceTransferState: vi.fn(),
+  verifyVoiceAppointmentChangeOtp: vi.fn(),
+  verifyVoiceAppointmentForChange: vi.fn(),
+}));
+
+import { createServer } from "../http/server";
+
+describe("web call routes", () => {
+  beforeEach(() => {
+    process.env.DEPLOYMENT_MODE = "development";
+    process.env.VOICE_GATEWAY_BASE_URL = "https://voice.example.com";
+    process.env.CONVEX_SITE_URL = "https://convex.example.com";
+    process.env.INTERNAL_SERVICE_TOKEN = "test-service-token";
+    process.env.TWILIO_AUTH_TOKEN = "twilio-auth-token";
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.WEB_CALL_ALLOWED_ORIGINS = "https://lobbystack.com";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.WEB_CALL_ALLOWED_ORIGINS;
+  });
+
+  it("rejects untrusted origins before starting a web call", async () => {
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://evil.example",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(fetchWebVoiceContextMock).not.toHaveBeenCalled();
+    expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown public widget business slugs", async () => {
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "other-business",
+        sdp: "v=0",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(fetchWebVoiceContextMock).not.toHaveBeenCalled();
+    expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("requires an SDP offer", async () => {
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(fetchWebVoiceContextMock).not.toHaveBeenCalled();
+    expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("returns durable Convex rate limits before starting an OpenAI web call", async () => {
+    fetchWebVoiceContextMock.mockRejectedValueOnce(
+      new runtimeRequestErrorClass({
+        message: "Too many web voice starts. Please try again shortly.",
+        status: 429,
+        code: "web_voice_rate_limited",
+      }),
+    );
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+        "x-forwarded-for": "203.0.113.10",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+        visitorId: "visitor-123",
+        widgetId: "lobbystack-landing",
+      },
+    });
+
+    expect(response.statusCode).toBe(429);
+    expect(response.json()).toEqual({
+      error: "Too many web voice starts. Please try again shortly.",
+    });
+    expect(fetchWebVoiceContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        businessSlug: "lobbystack",
+        origin: "https://lobbystack.com",
+        visitorId: "visitor-123",
+        widgetId: "lobbystack-landing",
+      }),
+    );
+    expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).toHaveLength(64);
+    expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("treats an unknown session end as idempotent", async () => {
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions/session-missing/end",
+      headers: {
+        origin: "https://lobbystack.com",
+      },
+    });
+
+    expect(response.statusCode).toBe(204);
+  });
+});

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -614,6 +614,42 @@ describe("web call routes", () => {
     });
 
     expect(response.statusCode).toBe(204);
+    expect(fetchWebCallRecordingTargetMock).toHaveBeenCalledWith({
+      gatewaySessionId: "session-missing",
+    });
+    expect(completeVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("finalizes durable web calls when the in-memory session is missing", async () => {
+    const startedAtMs = Date.now();
+    fetchWebCallRecordingTargetMock.mockResolvedValueOnce({
+      callId: "call_durable_end",
+      startedAt: new Date(startedAtMs).toISOString(),
+      status: "open",
+    });
+    completeVoiceCallMock.mockResolvedValueOnce(null);
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions/session-durable/end",
+      headers: {
+        origin: "https://lobbystack.com",
+      },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(fetchWebCallRecordingTargetMock).toHaveBeenCalledWith({
+      gatewaySessionId: "session-durable",
+    });
+    expect(completeVoiceCallMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_durable_end",
+        status: "completed",
+        disposition: "caller_finished",
+        providerDurationSeconds: expect.any(Number),
+      }),
+    );
   });
 
   it("hangs up OpenAI and completes the call after the max web call duration", async () => {

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -282,6 +282,27 @@ describe("web call routes", () => {
     expect(startWebVoiceCallMock).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed web call session fields before runtime requests", async () => {
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: 123,
+        sdp: "v=0",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(fetchWebVoiceContextMock).not.toHaveBeenCalled();
+    expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
   it("does not rate limit syntactically invalid start attempts", async () => {
     fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
     startWebVoiceCallMock.mockResolvedValueOnce({
@@ -370,6 +391,39 @@ describe("web call routes", () => {
       }),
     );
     expect(fetchWebVoiceContextMock.mock.calls[0]?.[0].ipHash).toHaveLength(64);
+    expect(startWebVoiceCallMock).not.toHaveBeenCalled();
+  });
+
+  it("returns billing preflight failures before starting an OpenAI web call", async () => {
+    fetchWebVoiceContextMock.mockRejectedValueOnce(
+      new runtimeRequestErrorClass({
+        message: "Voice quota reached for this billing period.",
+        status: 402,
+        code: "voice_limit_reached",
+      }),
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0",
+      },
+    });
+
+    expect(response.statusCode).toBe(402);
+    expect(response.json()).toEqual({
+      error: "Voice quota reached for this billing period.",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(startWebVoiceCallMock).not.toHaveBeenCalled();
   });
 

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -245,6 +245,14 @@ function getWebRecordingDurationMs(
   return Math.min(parsedDurationMs, elapsedDurationMs);
 }
 
+function getWebCallDurationSeconds(
+  startedAtMs: number,
+  endedAtMs: number,
+  maxDurationMs: number,
+): number {
+  return Math.max(0, Math.ceil(Math.min(endedAtMs - startedAtMs, maxDurationMs) / 1_000));
+}
+
 function addCorsHeaders(reply: FastifyReply, origin: string): void {
   reply.header("Access-Control-Allow-Origin", origin);
   reply.header("Access-Control-Allow-Methods", "POST, OPTIONS");
@@ -381,6 +389,47 @@ async function resolveWebCallForRecording(
     startedAtMs,
     ...(completedAtMs !== undefined ? { completedAtMs } : {}),
   };
+}
+
+async function finishDurableWebCallSession(
+  server: FastifyInstance,
+  sessionId: string,
+  disposition: string,
+): Promise<void> {
+  const durable = await fetchWebCallRecordingTarget({ gatewaySessionId: sessionId });
+  if (!durable || durable.endedAt !== undefined) {
+    return;
+  }
+
+  if (durable.status !== "in_progress" && durable.status !== "open") {
+    return;
+  }
+
+  const startedAtMs = Date.parse(durable.startedAt);
+  if (!Number.isFinite(startedAtMs)) {
+    return;
+  }
+
+  const endedAtMs = Date.now();
+  if (durable.providerCallId !== undefined) {
+    await hangupOpenAiRealtimeProviderCall(server, {
+      callId: durable.callId,
+      providerCallId: durable.providerCallId,
+      reason: disposition,
+    });
+  }
+
+  await completeVoiceCall({
+    callId: durable.callId,
+    status: "completed",
+    disposition,
+    endedAt: new Date(endedAtMs).toISOString(),
+    providerDurationSeconds: getWebCallDurationSeconds(
+      startedAtMs,
+      endedAtMs,
+      durable.webCallMaxDurationMs ?? server.runtimeConfig.WEB_CALL_MAX_DURATION_MS,
+    ),
+  });
 }
 
 async function persistWebTranscriptIfNew(
@@ -1404,6 +1453,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
 
     const session = activeWebCalls.get(request.params.sessionId);
     if (!session) {
+      await finishDurableWebCallSession(server, request.params.sessionId, "caller_finished");
       reply.code(204);
       return null;
     }

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -1,0 +1,600 @@
+import { createHash } from "node:crypto";
+
+import { buildVoiceSystemPrompt } from "@lobbystack/ai";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import WebSocket from "ws";
+
+import {
+  completeVoiceCall,
+  fetchWebVoiceContext,
+  recordVoiceAiCost,
+  RuntimeRequestError,
+  startWebVoiceCall,
+} from "../convex/runtimeClient";
+import { capturePostHogException } from "../observability/posthog";
+import { executeVoiceTool } from "../realtime/toolExecutor";
+import { createWebRealtimeToolDefinitions } from "../realtime/toolDefinitions";
+
+type WebCallSessionRequest = {
+  businessSlug?: string;
+  widgetId?: string;
+  sdp?: string;
+  pageUrl?: string;
+  visitorId?: string;
+};
+
+type OpenAiRealtimeMessage = {
+  type?: string;
+  event_id?: string;
+  call_id?: string;
+  name?: string;
+  arguments?: string;
+  item?: {
+    type?: string;
+    name?: string;
+    call_id?: string;
+    arguments?: string;
+  };
+  transcript?: string;
+  response?: {
+    id?: string;
+    status?: string;
+    usage?: {
+      total_tokens?: number;
+      input_tokens?: number;
+      output_tokens?: number;
+      input_token_details?: {
+        cached_tokens?: number;
+        text_tokens?: number;
+        audio_tokens?: number;
+      };
+      output_token_details?: {
+        text_tokens?: number;
+        audio_tokens?: number;
+      };
+    };
+  };
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
+type RealtimeUsageMetrics = NonNullable<OpenAiRealtimeMessage["response"]>["usage"];
+
+type ActiveWebCall = {
+  gatewaySessionId: string;
+  businessSlug: string;
+  businessId: string;
+  callId: string;
+  conversationId: string;
+  providerCallId: string;
+  startedAtMs: number;
+  handledToolCallIds: Set<string>;
+  sidebandSocket: WebSocket | null;
+};
+
+const activeWebCalls = new Map<string, ActiveWebCall>();
+const originStartAttempts = new Map<string, Array<number>>();
+
+function getAllowedOrigins(raw: string): Set<string> {
+  return new Set(
+    raw
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  );
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const origin = request.headers.origin;
+  return typeof origin === "string" && origin ? origin : null;
+}
+
+function isLocalhostOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
+function isAllowedOrigin(server: FastifyInstance, origin: string | null): boolean {
+  if (!origin) {
+    return false;
+  }
+  const allowedOrigins = getAllowedOrigins(server.runtimeConfig.WEB_CALL_ALLOWED_ORIGINS);
+  return allowedOrigins.has(origin) || isLocalhostOrigin(origin);
+}
+
+function addCorsHeaders(reply: FastifyReply, origin: string): void {
+  reply.header("Access-Control-Allow-Origin", origin);
+  reply.header("Access-Control-Allow-Methods", "POST, OPTIONS");
+  reply.header("Access-Control-Allow-Headers", "Content-Type");
+  reply.header("Vary", "Origin");
+}
+
+function isRateLimited(origin: string, nowMs = Date.now()): boolean {
+  const windowMs = 60_000;
+  const maxStarts = 12;
+  const recent = (originStartAttempts.get(origin) ?? []).filter(
+    (timestamp) => nowMs - timestamp < windowMs,
+  );
+  recent.push(nowMs);
+  originStartAttempts.set(origin, recent);
+  return recent.length > maxStarts;
+}
+
+function normalizeOptionalAbuseKey(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.slice(0, 256);
+}
+
+function getClientIp(request: FastifyRequest): string | undefined {
+  const forwardedFor = request.headers["x-forwarded-for"];
+  const forwardedValue = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+  const forwardedIp = forwardedValue?.split(",")[0]?.trim();
+  return forwardedIp || request.ip;
+}
+
+function hashAbuseKey(server: FastifyInstance, value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return createHash("sha256")
+    .update(`${server.runtimeConfig.INTERNAL_SERVICE_TOKEN}:${value}`)
+    .digest("hex");
+}
+
+function replyWithRuntimeRequestError(
+  error: RuntimeRequestError,
+  reply: FastifyReply,
+): { error: string } {
+  reply.code(error.status);
+  return { error: error.message };
+}
+
+async function finishWebCallSession(
+  session: ActiveWebCall,
+  disposition: string,
+): Promise<void> {
+  await completeVoiceCall({
+    callId: session.callId,
+    status: "completed",
+    disposition,
+    endedAt: new Date().toISOString(),
+    providerDurationSeconds: Math.max(
+      0,
+      Math.ceil((Date.now() - session.startedAtMs) / 1000),
+    ),
+  });
+  session.sidebandSocket?.close(1000, "web call ended");
+  activeWebCalls.delete(session.gatewaySessionId);
+}
+
+function parseProviderCallId(response: Response, gatewaySessionId: string): string {
+  const headerCandidates = [
+    response.headers.get("openai-call-id"),
+    response.headers.get("openai-realtime-call-id"),
+    response.headers.get("x-openai-call-id"),
+  ].filter((value): value is string => Boolean(value));
+
+  if (headerCandidates[0]) {
+    return headerCandidates[0];
+  }
+
+  const location = response.headers.get("location");
+  if (location) {
+    const lastSegment = location.split("/").filter(Boolean).at(-1);
+    if (lastSegment) {
+      return lastSegment;
+    }
+  }
+
+  return `webcall_${gatewaySessionId}`;
+}
+
+function postRealtimeEvent(socket: WebSocket, payload: Record<string, unknown>): void {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(payload));
+  }
+}
+
+function priceUsage(
+  server: FastifyInstance,
+  usage: RealtimeUsageMetrics | undefined,
+): number | null {
+  if (!usage) {
+    return null;
+  }
+
+  const textInputTokens = usage.input_token_details?.text_tokens ?? 0;
+  const audioInputTokens = usage.input_token_details?.audio_tokens ?? 0;
+  const cachedInputTokens = usage.input_token_details?.cached_tokens ?? 0;
+  const textOutputTokens = usage.output_token_details?.text_tokens ?? 0;
+  const audioOutputTokens = usage.output_token_details?.audio_tokens ?? 0;
+
+  const fallbackInputPrice = server.runtimeConfig.OPENAI_REALTIME_INPUT_TOKEN_PRICE_USD;
+  const fallbackOutputPrice = server.runtimeConfig.OPENAI_REALTIME_OUTPUT_TOKEN_PRICE_USD;
+  const textInputPrice =
+    server.runtimeConfig.OPENAI_REALTIME_TEXT_INPUT_TOKEN_PRICE_USD ?? fallbackInputPrice;
+  const audioInputPrice =
+    server.runtimeConfig.OPENAI_REALTIME_AUDIO_INPUT_TOKEN_PRICE_USD ?? fallbackInputPrice;
+  const textOutputPrice =
+    server.runtimeConfig.OPENAI_REALTIME_TEXT_OUTPUT_TOKEN_PRICE_USD ?? fallbackOutputPrice;
+  const audioOutputPrice =
+    server.runtimeConfig.OPENAI_REALTIME_AUDIO_OUTPUT_TOKEN_PRICE_USD ?? fallbackOutputPrice;
+  const cachedInputPrice =
+    server.runtimeConfig.OPENAI_REALTIME_CACHED_INPUT_TOKEN_PRICE_USD ?? textInputPrice;
+
+  const pricedBuckets = [
+    [textInputTokens, textInputPrice],
+    [audioInputTokens, audioInputPrice],
+    [cachedInputTokens, cachedInputPrice],
+    [textOutputTokens, textOutputPrice],
+    [audioOutputTokens, audioOutputPrice],
+  ] as const;
+
+  const hasAnyPrice = pricedBuckets.some(([, price]) => price !== undefined);
+  if (!hasAnyPrice) {
+    return null;
+  }
+
+  return pricedBuckets.reduce(
+    (total, [tokens, price]) => total + tokens * (price ?? 0),
+    0,
+  );
+}
+
+async function exchangeWebRtcOffer(input: {
+  apiKey: string;
+  model: string;
+  sdp: string;
+}): Promise<{ answerSdp: string; providerCallId: string }> {
+  const response = await fetch(
+    `https://api.openai.com/v1/realtime/calls?model=${encodeURIComponent(input.model)}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiKey}`,
+        "Content-Type": "application/sdp",
+        Accept: "application/sdp",
+      },
+      body: input.sdp,
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`OpenAI Realtime WebRTC setup failed with ${response.status}.`);
+  }
+
+  return {
+    answerSdp: await response.text(),
+    providerCallId: parseProviderCallId(response, crypto.randomUUID()),
+  };
+}
+
+function createSidebandSocket(input: {
+  server: FastifyInstance;
+  session: ActiveWebCall;
+  snapshot: Awaited<ReturnType<typeof fetchWebVoiceContext>>["snapshot"];
+}): WebSocket {
+  const socket = new WebSocket(
+    `wss://api.openai.com/v1/realtime?model=${encodeURIComponent(
+      input.server.runtimeConfig.OPENAI_REALTIME_MODEL,
+    )}&call_id=${encodeURIComponent(input.session.providerCallId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${input.server.runtimeConfig.OPENAI_API_KEY}`,
+      },
+    },
+  );
+
+  socket.on("open", () => {
+    postRealtimeEvent(socket, {
+      type: "session.update",
+      session: {
+        type: "realtime",
+        instructions: [
+          buildVoiceSystemPrompt(input.snapshot),
+          "You are speaking through a website voice widget, not a phone call.",
+          "Represent LobbyStack and answer questions about the business from the supplied snapshot and tools.",
+          "Ask for a phone number before booking an appointment, taking a callback message, or discussing existing appointments.",
+          "Do not attempt phone transfer from the website widget.",
+          "End the session with endCall when the visitor is clearly finished, abusive, spammy, or repeatedly silent.",
+        ].join("\n\n"),
+        output_modalities: ["audio"],
+        audio: {
+          input: {
+            transcription: {
+              model: input.server.runtimeConfig.OPENAI_TRANSCRIPTION_MODEL,
+            },
+          },
+          output: {
+            voice: input.server.runtimeConfig.OPENAI_REALTIME_VOICE,
+          },
+        },
+        tools: createWebRealtimeToolDefinitions(),
+        tool_choice: "auto",
+      },
+    });
+
+    postRealtimeEvent(socket, {
+      type: "response.create",
+      response: {
+        instructions: [
+          `Begin by greeting the visitor with this exact greeting: "${input.snapshot.greeting}"`,
+          "Then stop speaking and wait for the visitor.",
+        ].join(" "),
+      },
+    });
+  });
+
+  socket.on("message", (rawMessage) => {
+    void handleSidebandMessage(input.server, socket, input.session, rawMessage);
+  });
+
+  socket.on("error", (error) => {
+    capturePostHogException(error, {
+      businessId: input.session.businessId,
+      properties: {
+        operation: "web_call_sideband_socket_error",
+        channel: "web_voice",
+        provider: "openai",
+        callId: input.session.callId,
+      },
+    });
+  });
+
+  socket.on("close", () => {
+    activeWebCalls.delete(input.session.gatewaySessionId);
+  });
+
+  return socket;
+}
+
+async function handleSidebandMessage(
+  server: FastifyInstance,
+  socket: WebSocket,
+  session: ActiveWebCall,
+  rawMessage: WebSocket.RawData,
+): Promise<void> {
+  const payload = JSON.parse(rawMessage.toString()) as OpenAiRealtimeMessage;
+
+  if (
+    payload.type === "response.function_call_arguments.done" &&
+    payload.name &&
+    payload.call_id &&
+    payload.arguments
+  ) {
+    await handleToolCall(server, socket, session, {
+      name: payload.name,
+      callId: payload.call_id,
+      arguments: payload.arguments,
+    });
+    return;
+  }
+
+  if (
+    payload.type === "response.output_item.done" &&
+    payload.item?.type === "function_call" &&
+    payload.item.name &&
+    payload.item.call_id &&
+    payload.item.arguments
+  ) {
+    await handleToolCall(server, socket, session, {
+      name: payload.item.name,
+      callId: payload.item.call_id,
+      arguments: payload.item.arguments,
+    });
+    return;
+  }
+
+  if (payload.type === "response.done" && payload.response?.usage) {
+    const costUsd = priceUsage(server, payload.response.usage);
+    if (costUsd === null) {
+      return;
+    }
+    await recordVoiceAiCost({
+      businessId: session.businessId,
+      callId: session.callId,
+      conversationId: session.conversationId,
+      occurredAt: new Date().toISOString(),
+      eventKey: `web_voice_ai:response:${session.callId}:${payload.response.id ?? payload.event_id ?? crypto.randomUUID()}`,
+      costUsd,
+      provider: "openai",
+      model: server.runtimeConfig.OPENAI_REALTIME_MODEL,
+      operation: "web_voice.response_generation",
+    });
+    return;
+  }
+
+  if (payload.type === "error") {
+    server.log.warn(
+      {
+        callId: session.callId,
+        providerCallId: session.providerCallId,
+        code: payload.error?.code,
+        message: payload.error?.message,
+      },
+      "OpenAI Realtime web call sideband error",
+    );
+  }
+}
+
+async function handleToolCall(
+  server: FastifyInstance,
+  socket: WebSocket,
+  session: ActiveWebCall,
+  toolCall: { name: string; callId: string; arguments: string },
+): Promise<void> {
+  if (session.handledToolCallIds.has(toolCall.callId)) {
+    return;
+  }
+  session.handledToolCallIds.add(toolCall.callId);
+
+  const context = await fetchWebVoiceContext({
+    businessSlug: session.businessSlug,
+  });
+  const executed = await executeVoiceTool({
+    toolName: toolCall.name,
+    rawArguments: toolCall.arguments,
+    snapshot: context.snapshot,
+    businessId: session.businessId,
+    callId: session.callId,
+    conversationId: session.conversationId,
+    callerPhone: "web",
+  });
+
+  postRealtimeEvent(socket, {
+    type: "conversation.item.create",
+    item: {
+      type: "function_call_output",
+      call_id: toolCall.callId,
+      output: JSON.stringify(executed.result),
+    },
+  });
+
+  if (executed.endCall) {
+    await finishWebCallSession(session, executed.endCall.reason);
+    return;
+  }
+
+  postRealtimeEvent(socket, { type: "response.create" });
+}
+
+export function registerWebCallRoutes(server: FastifyInstance): void {
+  const handleCorsPreflight = async (request: FastifyRequest, reply: FastifyReply) => {
+    const origin = getRequestOrigin(request);
+    if (!isAllowedOrigin(server, origin)) {
+      reply.code(403);
+      return "Forbidden";
+    }
+    addCorsHeaders(reply, origin!);
+    return "";
+  };
+
+  server.options("/web-call/sessions", handleCorsPreflight);
+  server.options("/web-call/sessions/:sessionId/end", handleCorsPreflight);
+
+  server.post("/web-call/sessions", async (request, reply) => {
+    const origin = getRequestOrigin(request);
+    if (!isAllowedOrigin(server, origin)) {
+      reply.code(403);
+      return "Forbidden";
+    }
+    addCorsHeaders(reply, origin!);
+
+    if (isRateLimited(origin!)) {
+      reply.code(429);
+      return { error: "Too many web call starts. Please try again shortly." };
+    }
+
+    if (!server.runtimeConfig.OPENAI_API_KEY) {
+      reply.code(503);
+      return { error: "Web voice is not configured." };
+    }
+
+    const body = (request.body ?? {}) as WebCallSessionRequest;
+    const businessSlug = body.businessSlug?.trim() || "";
+    if (businessSlug !== "lobbystack") {
+      reply.code(403);
+      return { error: "Unknown web voice widget." };
+    }
+    if (!body.sdp?.trim()) {
+      reply.code(400);
+      return { error: "Missing SDP offer." };
+    }
+
+    const gatewaySessionId = crypto.randomUUID();
+    const widgetId = normalizeOptionalAbuseKey(body.widgetId);
+    const visitorId = normalizeOptionalAbuseKey(body.visitorId);
+    const ipHash = hashAbuseKey(server, getClientIp(request));
+    let context: Awaited<ReturnType<typeof fetchWebVoiceContext>>;
+    try {
+      context = await fetchWebVoiceContext({
+        businessSlug,
+        origin: origin!,
+        ...(ipHash !== undefined ? { ipHash } : {}),
+        ...(visitorId !== undefined ? { visitorId } : {}),
+        ...(widgetId !== undefined ? { widgetId } : {}),
+      });
+    } catch (error) {
+      if (error instanceof RuntimeRequestError && error.status === 429) {
+        return replyWithRuntimeRequestError(error, reply);
+      }
+      throw error;
+    }
+    const exchange = await exchangeWebRtcOffer({
+      apiKey: server.runtimeConfig.OPENAI_API_KEY,
+      model: server.runtimeConfig.OPENAI_REALTIME_MODEL,
+      sdp: body.sdp,
+    });
+    const providerCallId =
+      exchange.providerCallId.startsWith("webcall_")
+        ? `webcall_${gatewaySessionId}`
+        : exchange.providerCallId;
+
+    const startedAt = new Date().toISOString();
+    const call = await startWebVoiceCall({
+      businessSlug,
+      providerCallId,
+      gatewaySessionId,
+      ...(body.pageUrl !== undefined ? { originUrl: body.pageUrl } : {}),
+      ...(typeof request.headers["user-agent"] === "string"
+        ? { userAgent: request.headers["user-agent"] }
+        : {}),
+      ...(widgetId !== undefined ? { widgetId } : {}),
+      startedAt,
+    });
+
+    const session: ActiveWebCall = {
+      gatewaySessionId,
+      businessSlug,
+      businessId: call.businessId,
+      callId: call.callId,
+      conversationId: call.conversationId,
+      providerCallId,
+      startedAtMs: Date.parse(startedAt),
+      handledToolCallIds: new Set(),
+      sidebandSocket: null,
+    };
+    const sidebandSocket = createSidebandSocket({
+      server,
+      session,
+      snapshot: context.snapshot,
+    });
+    session.sidebandSocket = sidebandSocket;
+    activeWebCalls.set(gatewaySessionId, session);
+
+    return {
+      sessionId: gatewaySessionId,
+      sdp: exchange.answerSdp,
+    };
+  });
+
+  server.post<{
+    Params: { sessionId: string };
+  }>("/web-call/sessions/:sessionId/end", async (request, reply) => {
+    const origin = getRequestOrigin(request);
+    if (!isAllowedOrigin(server, origin)) {
+      reply.code(403);
+      return "Forbidden";
+    }
+    addCorsHeaders(reply, origin!);
+
+    const session = activeWebCalls.get(request.params.sessionId);
+    if (!session) {
+      reply.code(204);
+      return null;
+    }
+
+    await finishWebCallSession(session, "caller_finished");
+    reply.code(204);
+    return null;
+  });
+}

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -463,10 +463,7 @@ function normalizeOptionalAbuseKey(value: string | undefined): string | undefine
 }
 
 function getClientIp(request: FastifyRequest): string | undefined {
-  const forwardedFor = request.headers["x-forwarded-for"];
-  const forwardedValue = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
-  const forwardedIp = forwardedValue?.split(",")[0]?.trim();
-  return forwardedIp || request.ip;
+  return request.ip;
 }
 
 function hashAbuseKey(server: FastifyInstance, value: string | undefined): string | undefined {

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -72,6 +72,7 @@ type ActiveWebCall = {
   startedAtMs: number;
   handledToolCallIds: Set<string>;
   sidebandSocket: WebSocket | null;
+  openingGreetingActive: boolean;
 };
 
 const activeWebCalls = new Map<string, ActiveWebCall>();
@@ -124,6 +125,50 @@ function isRateLimited(origin: string, nowMs = Date.now()): boolean {
   recent.push(nowMs);
   originStartAttempts.set(origin, recent);
   return recent.length > maxStarts;
+}
+
+export function createWebRealtimeTurnDetectionConfig(options: {
+  createResponse?: boolean;
+  interruptResponse?: boolean;
+} = {}): Record<string, unknown> {
+  return {
+    type: "server_vad",
+    create_response: options.createResponse ?? true,
+    interrupt_response: options.interruptResponse ?? true,
+  };
+}
+
+function enableWebRealtimeTurnDetection(
+  server: FastifyInstance,
+  socket: WebSocket,
+  session: ActiveWebCall,
+  reason: string,
+): void {
+  if (!session.openingGreetingActive) {
+    return;
+  }
+
+  session.openingGreetingActive = false;
+  postRealtimeEvent(socket, { type: "input_audio_buffer.clear" });
+  postRealtimeEvent(socket, {
+    type: "session.update",
+    session: {
+      type: "realtime",
+      audio: {
+        input: {
+          turn_detection: createWebRealtimeTurnDetectionConfig(),
+        },
+      },
+    },
+  });
+  server.log.info(
+    {
+      callId: session.callId,
+      providerCallId: session.providerCallId,
+      reason,
+    },
+    "Enabled web voice turn detection after opening greeting",
+  );
 }
 
 function normalizeOptionalAbuseKey(value: string | undefined): string | undefined {
@@ -303,6 +348,7 @@ function createSidebandSocket(input: {
           buildVoiceSystemPrompt(input.snapshot),
           "You are speaking through a website voice widget, not a phone call.",
           "Represent LobbyStack and answer questions about the business from the supplied snapshot and tools.",
+          "Use the configured greeting only once at the start of the session. Never repeat it after the opening greeting, even after interruptions, silence, or filler speech.",
           "Ask for a phone number before booking an appointment, taking a callback message, or discussing existing appointments.",
           "Do not attempt phone transfer from the website widget.",
           "End the session with endCall when the visitor is clearly finished, abusive, spammy, or repeatedly silent.",
@@ -313,6 +359,10 @@ function createSidebandSocket(input: {
             transcription: {
               model: input.server.runtimeConfig.OPENAI_TRANSCRIPTION_MODEL,
             },
+            turn_detection: createWebRealtimeTurnDetectionConfig({
+              createResponse: false,
+              interruptResponse: false,
+            }),
           },
           output: {
             voice: input.server.runtimeConfig.OPENAI_REALTIME_VOICE,
@@ -329,6 +379,7 @@ function createSidebandSocket(input: {
         instructions: [
           `Begin by greeting the visitor with this exact greeting: "${input.snapshot.greeting}"`,
           "Then stop speaking and wait for the visitor.",
+          "Do not repeat this greeting later in the session.",
         ].join(" "),
       },
     });
@@ -394,22 +445,41 @@ async function handleSidebandMessage(
     return;
   }
 
-  if (payload.type === "response.done" && payload.response?.usage) {
-    const costUsd = priceUsage(server, payload.response.usage);
-    if (costUsd === null) {
+  if (payload.type === "response.done") {
+    if (payload.response?.usage) {
+      const costUsd = priceUsage(server, payload.response.usage);
+      if (costUsd !== null) {
+        await recordVoiceAiCost({
+          businessId: session.businessId,
+          callId: session.callId,
+          conversationId: session.conversationId,
+          occurredAt: new Date().toISOString(),
+          eventKey: `web_voice_ai:response:${session.callId}:${payload.response.id ?? payload.event_id ?? crypto.randomUUID()}`,
+          costUsd,
+          provider: "openai",
+          model: server.runtimeConfig.OPENAI_REALTIME_MODEL,
+          operation: "web_voice.response_generation",
+        });
+      }
+    }
+
+    if (session.openingGreetingActive) {
+      enableWebRealtimeTurnDetection(server, socket, session, "response_done");
+    }
+    return;
+  }
+
+  if (payload.type === "input_audio_buffer.speech_started") {
+    if (session.openingGreetingActive) {
+      server.log.info(
+        {
+          callId: session.callId,
+          providerCallId: session.providerCallId,
+        },
+        "Ignored web voice speech detection during opening greeting",
+      );
       return;
     }
-    await recordVoiceAiCost({
-      businessId: session.businessId,
-      callId: session.callId,
-      conversationId: session.conversationId,
-      occurredAt: new Date().toISOString(),
-      eventKey: `web_voice_ai:response:${session.callId}:${payload.response.id ?? payload.event_id ?? crypto.randomUUID()}`,
-      costUsd,
-      provider: "openai",
-      model: server.runtimeConfig.OPENAI_REALTIME_MODEL,
-      operation: "web_voice.response_generation",
-    });
     return;
   }
 
@@ -562,6 +632,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       startedAtMs: Date.parse(startedAt),
       handledToolCallIds: new Set(),
       sidebandSocket: null,
+      openingGreetingActive: true,
     };
     const sidebandSocket = createSidebandSocket({
       server,

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -5,11 +5,13 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import WebSocket from "ws";
 
 import {
+  appendVoiceTranscript,
   completeVoiceCall,
   fetchWebVoiceContext,
   recordVoiceAiCost,
   RuntimeRequestError,
   startWebVoiceCall,
+  uploadVoiceRecording,
 } from "../convex/runtimeClient";
 import { capturePostHogException } from "../observability/posthog";
 import { executeVoiceTool } from "../realtime/toolExecutor";
@@ -35,6 +37,8 @@ type OpenAiRealtimeMessage = {
     call_id?: string;
     arguments?: string;
   };
+  item_id?: string;
+  content_index?: number;
   transcript?: string;
   response?: {
     id?: string;
@@ -76,14 +80,30 @@ type ActiveWebCall = {
   finalized: boolean;
   openingGreetingActive: boolean;
   openingGreetingTurnDetectionTimer: ReturnType<typeof setTimeout> | null;
+  seenTranscriptKeys: Set<string>;
+  transcriptSequence: number;
+  pendingAssistantTranscriptFlushTimer: ReturnType<typeof setTimeout> | null;
+  pendingAssistantTranscripts: Array<{
+    dedupeKey: string;
+    text: string | undefined;
+  }>;
+};
+
+type CompletedWebCall = {
+  callId: string;
+  startedAtMs: number;
+  completedAtMs: number;
 };
 
 const activeWebCalls = new Map<string, ActiveWebCall>();
+const completedWebCalls = new Map<string, CompletedWebCall>();
 const originStartAttempts = new Map<string, Array<number>>();
 const WEB_REALTIME_VAD_THRESHOLD = 0.65;
 const WEB_REALTIME_VAD_PREFIX_PADDING_MS = 300;
 const WEB_REALTIME_VAD_SILENCE_DURATION_MS = 700;
 const WEB_POST_GREETING_INPUT_GRACE_MS = 2_000;
+const WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS = 10 * 60_000;
+const WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS = 1_500;
 
 function getAllowedOrigins(raw: string): Set<string> {
   return new Set(
@@ -121,6 +141,148 @@ function addCorsHeaders(reply: FastifyReply, origin: string): void {
   reply.header("Access-Control-Allow-Methods", "POST, OPTIONS");
   reply.header("Access-Control-Allow-Headers", "Content-Type");
   reply.header("Vary", "Origin");
+}
+
+async function readRequestBodyBuffer(request: FastifyRequest): Promise<Buffer> {
+  if (Buffer.isBuffer(request.body)) {
+    return request.body;
+  }
+  if (request.body instanceof ArrayBuffer) {
+    return Buffer.from(request.body);
+  }
+  if (typeof request.body === "string") {
+    return Buffer.from(request.body);
+  }
+
+  const chunks: Array<Buffer> = [];
+  for await (const chunk of request.raw) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function rememberCompletedWebCall(session: ActiveWebCall): void {
+  completedWebCalls.set(session.gatewaySessionId, {
+    callId: session.callId,
+    startedAtMs: session.startedAtMs,
+    completedAtMs: Date.now(),
+  });
+  setTimeout(() => {
+    const completed = completedWebCalls.get(session.gatewaySessionId);
+    if (completed?.callId === session.callId) {
+      completedWebCalls.delete(session.gatewaySessionId);
+    }
+  }, WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS).unref();
+}
+
+function getWebCallForRecording(sessionId: string): CompletedWebCall | null {
+  const active = activeWebCalls.get(sessionId);
+  if (active) {
+    return {
+      callId: active.callId,
+      startedAtMs: active.startedAtMs,
+      completedAtMs: Date.now(),
+    };
+  }
+
+  const completed = completedWebCalls.get(sessionId);
+  if (!completed) {
+    return null;
+  }
+
+  if (Date.now() - completed.completedAtMs > WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS) {
+    completedWebCalls.delete(sessionId);
+    return null;
+  }
+
+  return completed;
+}
+
+async function persistWebTranscriptIfNew(
+  server: FastifyInstance,
+  session: ActiveWebCall,
+  dedupeKey: string,
+  input: {
+    speaker: string;
+    text: string | undefined;
+  },
+): Promise<void> {
+  const text = input.text?.trim();
+  if (!text || session.seenTranscriptKeys.has(dedupeKey)) {
+    return;
+  }
+
+  session.seenTranscriptKeys.add(dedupeKey);
+  const sequence = session.transcriptSequence;
+  session.transcriptSequence += 1;
+
+  await appendVoiceTranscript({
+    businessId: session.businessId,
+    callId: session.callId,
+    sequence,
+    speaker: input.speaker,
+    text,
+    final: true,
+  }).catch((error: unknown) => {
+    server.log.error(
+      {
+        err: error,
+        businessId: session.businessId,
+        callId: session.callId,
+        sequence,
+        speaker: input.speaker,
+      },
+      "Failed to persist web voice transcript segment",
+    );
+  });
+}
+
+async function flushPendingWebAssistantTranscripts(
+  server: FastifyInstance,
+  session: ActiveWebCall,
+): Promise<void> {
+  if (session.pendingAssistantTranscriptFlushTimer !== null) {
+    clearTimeout(session.pendingAssistantTranscriptFlushTimer);
+    session.pendingAssistantTranscriptFlushTimer = null;
+  }
+
+  const pending = session.pendingAssistantTranscripts.splice(0);
+  for (const transcript of pending) {
+    await persistWebTranscriptIfNew(server, session, transcript.dedupeKey, {
+      speaker: "assistant",
+      text: transcript.text,
+    });
+  }
+}
+
+function queueWebAssistantTranscript(
+  server: FastifyInstance,
+  session: ActiveWebCall,
+  dedupeKey: string,
+  text: string | undefined,
+): void {
+  if (!text?.trim() || session.seenTranscriptKeys.has(dedupeKey)) {
+    return;
+  }
+
+  session.pendingAssistantTranscripts.push({ dedupeKey, text });
+  if (session.pendingAssistantTranscriptFlushTimer !== null) {
+    return;
+  }
+
+  session.pendingAssistantTranscriptFlushTimer = setTimeout(() => {
+    session.pendingAssistantTranscriptFlushTimer = null;
+    void flushPendingWebAssistantTranscripts(server, session).catch((error: unknown) => {
+      server.log.error(
+        {
+          err: error,
+          callId: session.callId,
+          providerCallId: session.providerCallId,
+        },
+        "Failed to flush pending web voice assistant transcripts",
+      );
+    });
+  }, WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS);
 }
 
 function isRateLimited(origin: string, nowMs = Date.now()): boolean {
@@ -267,12 +429,27 @@ async function hangupOpenAiRealtimeCall(
   session: ActiveWebCall,
   reason: string,
 ): Promise<void> {
-  if (session.providerCallId.startsWith("webcall_")) {
+  await hangupOpenAiRealtimeProviderCall(server, {
+    callId: session.callId,
+    providerCallId: session.providerCallId,
+    reason,
+  });
+}
+
+async function hangupOpenAiRealtimeProviderCall(
+  server: FastifyInstance,
+  input: {
+    callId?: string;
+    providerCallId: string;
+    reason: string;
+  },
+): Promise<void> {
+  if (input.providerCallId.startsWith("webcall_")) {
     server.log.warn(
       {
-        callId: session.callId,
-        providerCallId: session.providerCallId,
-        reason,
+        callId: input.callId,
+        providerCallId: input.providerCallId,
+        reason: input.reason,
       },
       "Skipping OpenAI Realtime hangup because no provider call ID was returned",
     );
@@ -282,7 +459,7 @@ async function hangupOpenAiRealtimeCall(
   try {
     const response = await fetch(
       `https://api.openai.com/v1/realtime/calls/${encodeURIComponent(
-        session.providerCallId,
+        input.providerCallId,
       )}/hangup`,
       {
         method: "POST",
@@ -297,9 +474,9 @@ async function hangupOpenAiRealtimeCall(
       const body = await response.text().catch(() => "");
       server.log.warn(
         {
-          callId: session.callId,
-          providerCallId: session.providerCallId,
-          reason,
+          callId: input.callId,
+          providerCallId: input.providerCallId,
+          reason: input.reason,
           status: response.status,
           body: body.slice(0, 500),
         },
@@ -310,9 +487,9 @@ async function hangupOpenAiRealtimeCall(
     server.log.error(
       {
         err: error,
-        callId: session.callId,
-        providerCallId: session.providerCallId,
-        reason,
+        callId: input.callId,
+        providerCallId: input.providerCallId,
+        reason: input.reason,
       },
       "Failed to hang up OpenAI Realtime web call",
     );
@@ -331,6 +508,7 @@ async function finishWebCallSession(
   session.finalized = true;
   clearWebOpeningGreetingTimer(session);
   clearWebMaxDurationTimer(session);
+  await flushPendingWebAssistantTranscripts(server, session);
   await hangupOpenAiRealtimeCall(server, session, disposition);
 
   try {
@@ -345,6 +523,7 @@ async function finishWebCallSession(
       ),
     });
   } finally {
+    rememberCompletedWebCall(session);
     session.sidebandSocket?.close(1000, "web call ended");
     activeWebCalls.delete(session.gatewaySessionId);
   }
@@ -408,40 +587,52 @@ function priceUsage(
     return null;
   }
 
-  const textInputTokens = usage.input_token_details?.text_tokens ?? 0;
-  const audioInputTokens = usage.input_token_details?.audio_tokens ?? 0;
-  const cachedInputTokens = usage.input_token_details?.cached_tokens ?? 0;
-  const textOutputTokens = usage.output_token_details?.text_tokens ?? 0;
-  const audioOutputTokens = usage.output_token_details?.audio_tokens ?? 0;
-
   const fallbackInputPrice = server.runtimeConfig.OPENAI_REALTIME_INPUT_TOKEN_PRICE_USD;
   const fallbackOutputPrice = server.runtimeConfig.OPENAI_REALTIME_OUTPUT_TOKEN_PRICE_USD;
+  const textInputTokens = usage.input_token_details?.text_tokens;
+  const audioInputTokens = usage.input_token_details?.audio_tokens;
+  const cachedInputTokens = usage.input_token_details?.cached_tokens ?? 0;
+  const textOutputTokens = usage.output_token_details?.text_tokens;
+  const audioOutputTokens = usage.output_token_details?.audio_tokens;
   const textInputPrice =
     server.runtimeConfig.OPENAI_REALTIME_TEXT_INPUT_TOKEN_PRICE_USD ?? fallbackInputPrice;
-  const audioInputPrice =
-    server.runtimeConfig.OPENAI_REALTIME_AUDIO_INPUT_TOKEN_PRICE_USD ?? fallbackInputPrice;
+  const audioInputPrice = server.runtimeConfig.OPENAI_REALTIME_AUDIO_INPUT_TOKEN_PRICE_USD;
   const textOutputPrice =
     server.runtimeConfig.OPENAI_REALTIME_TEXT_OUTPUT_TOKEN_PRICE_USD ?? fallbackOutputPrice;
-  const audioOutputPrice =
-    server.runtimeConfig.OPENAI_REALTIME_AUDIO_OUTPUT_TOKEN_PRICE_USD ?? fallbackOutputPrice;
-  const cachedInputPrice =
-    server.runtimeConfig.OPENAI_REALTIME_CACHED_INPUT_TOKEN_PRICE_USD ?? textInputPrice;
+  const audioOutputPrice = server.runtimeConfig.OPENAI_REALTIME_AUDIO_OUTPUT_TOKEN_PRICE_USD;
+  const cachedInputPrice = server.runtimeConfig.OPENAI_REALTIME_CACHED_INPUT_TOKEN_PRICE_USD;
 
-  const pricedBuckets = [
-    [textInputTokens, textInputPrice],
-    [audioInputTokens, audioInputPrice],
-    [cachedInputTokens, cachedInputPrice],
-    [textOutputTokens, textOutputPrice],
-    [audioOutputTokens, audioOutputPrice],
-  ] as const;
+  const hasDetailedInput = textInputTokens !== undefined || audioInputTokens !== undefined;
+  if (hasDetailedInput && cachedInputTokens > 0) {
+    return null;
+  }
 
-  const hasAnyPrice = pricedBuckets.some(([, price]) => price !== undefined);
-  if (!hasAnyPrice) {
+  const inputTokens = usage.input_tokens;
+  const outputTokens = usage.output_tokens;
+  const uncachedInputTokens =
+    inputTokens !== undefined ? Math.max(0, inputTokens - cachedInputTokens) : undefined;
+  const pricedBuckets: Array<readonly [number | undefined, number | undefined]> = hasDetailedInput
+    ? [
+        [textInputTokens, textInputPrice],
+        [audioInputTokens, audioInputPrice],
+        [textOutputTokens, textOutputPrice],
+        [audioOutputTokens, audioOutputPrice],
+      ]
+    : [
+        [uncachedInputTokens, fallbackInputPrice],
+        [cachedInputTokens || undefined, cachedInputPrice],
+        [outputTokens, fallbackOutputPrice],
+      ];
+
+  const hasAnyPricedTokens = pricedBuckets.some(
+    ([tokens, price]) => tokens !== undefined && price !== undefined,
+  );
+  if (!hasAnyPricedTokens) {
     return null;
   }
 
   return pricedBuckets.reduce(
-    (total, [tokens, price]) => total + tokens * (price ?? 0),
+    (total, [tokens, price]) => total + (tokens ?? 0) * (price ?? 0),
     0,
   );
 }
@@ -539,7 +730,27 @@ function createSidebandSocket(input: {
   });
 
   socket.on("message", (rawMessage) => {
-    void handleSidebandMessage(input.server, socket, input.session, rawMessage);
+    void handleSidebandMessage(input.server, socket, input.session, rawMessage).catch(
+      (error: unknown) => {
+        input.server.log.error(
+          {
+            err: error,
+            callId: input.session.callId,
+            providerCallId: input.session.providerCallId,
+          },
+          "Failed to handle OpenAI Realtime web call sideband message",
+        );
+        capturePostHogException(error, {
+          businessId: input.session.businessId,
+          properties: {
+            operation: "web_call_sideband_message",
+            channel: "web_voice",
+            provider: "openai",
+            callId: input.session.callId,
+          },
+        });
+      },
+    );
   });
 
   socket.on("error", (error) => {
@@ -626,6 +837,15 @@ async function handleSidebandMessage(
           provider: "openai",
           model: server.runtimeConfig.OPENAI_REALTIME_MODEL,
           operation: "web_voice.response_generation",
+        }).catch((error: unknown) => {
+          server.log.error(
+            {
+              err: error,
+              businessId: session.businessId,
+              callId: session.callId,
+            },
+            "Failed to persist web voice response AI cost",
+          );
         });
       }
     }
@@ -633,6 +853,51 @@ async function handleSidebandMessage(
     if (session.openingGreetingActive) {
       scheduleWebRealtimeTurnDetectionEnable(server, socket, session, "response_done");
     }
+    return;
+  }
+
+  if (payload.type === "conversation.item.input_audio_transcription.completed") {
+    await persistWebTranscriptIfNew(
+      server,
+      session,
+      `caller-completed:${payload.item_id ?? "unknown"}:${payload.content_index ?? 0}:${payload.transcript ?? ""}`,
+      {
+        speaker: "caller",
+        text: payload.transcript,
+      },
+    );
+    await flushPendingWebAssistantTranscripts(server, session);
+    return;
+  }
+
+  if (
+    payload.type === "response.audio_transcript.done" ||
+    payload.type === "response.output_audio_transcript.done"
+  ) {
+    const dedupeKey = `assistant-output-transcript:${payload.item_id ?? "unknown"}:${payload.content_index ?? 0}:${payload.transcript ?? ""}`;
+    if (session.openingGreetingActive) {
+      await persistWebTranscriptIfNew(server, session, dedupeKey, {
+        speaker: "assistant",
+        text: payload.transcript,
+      });
+      return;
+    }
+
+    queueWebAssistantTranscript(server, session, dedupeKey, payload.transcript);
+    return;
+  }
+
+  if (payload.type === "conversation.item.input_audio_transcription.failed") {
+    server.log.warn(
+      {
+        callId: session.callId,
+        providerCallId: session.providerCallId,
+        itemId: payload.item_id,
+        code: payload.error?.code,
+        message: payload.error?.message,
+      },
+      "OpenAI Realtime web call input audio transcription failed",
+    );
     return;
   }
 
@@ -674,18 +939,44 @@ async function handleToolCall(
   }
   session.handledToolCallIds.add(toolCall.callId);
 
-  const context = await fetchWebVoiceContext({
-    businessSlug: session.businessSlug,
-  });
-  const executed = await executeVoiceTool({
-    toolName: toolCall.name,
-    rawArguments: toolCall.arguments,
-    snapshot: context.snapshot,
-    businessId: session.businessId,
-    callId: session.callId,
-    conversationId: session.conversationId,
-    callerPhone: "web",
-  });
+  let executed: Awaited<ReturnType<typeof executeVoiceTool>>;
+  try {
+    const context = await fetchWebVoiceContext({
+      businessSlug: session.businessSlug,
+    });
+    executed = await executeVoiceTool({
+      toolName: toolCall.name,
+      rawArguments: toolCall.arguments,
+      snapshot: context.snapshot,
+      businessId: session.businessId,
+      callId: session.callId,
+      conversationId: session.conversationId,
+      callerPhone: "web",
+    });
+  } catch (error) {
+    server.log.error(
+      {
+        err: error,
+        callId: session.callId,
+        providerCallId: session.providerCallId,
+        toolName: toolCall.name,
+      },
+      "Failed to execute web voice tool call",
+    );
+    postRealtimeEvent(socket, {
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: toolCall.callId,
+        output: JSON.stringify({
+          ok: false,
+          error: error instanceof Error ? error.message : "Unknown tool error",
+        }),
+      },
+    });
+    postRealtimeEvent(socket, { type: "response.create" });
+    return;
+  }
 
   postRealtimeEvent(socket, {
     type: "conversation.item.create",
@@ -710,6 +1001,17 @@ async function handleToolCall(
 }
 
 export function registerWebCallRoutes(server: FastifyInstance): void {
+  server.addContentTypeParser(
+    /^audio\/.*/,
+    { parseAs: "buffer" },
+    (_request, body, done) => done(null, body),
+  );
+  server.addContentTypeParser(
+    "application/octet-stream",
+    { parseAs: "buffer" },
+    (_request, body, done) => done(null, body),
+  );
+
   const handleCorsPreflight = async (request: FastifyRequest, reply: FastifyReply) => {
     const origin = getRequestOrigin(request);
     if (!isAllowedOrigin(server, origin)) {
@@ -722,6 +1024,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
 
   server.options("/web-call/sessions", handleCorsPreflight);
   server.options("/web-call/sessions/:sessionId/end", handleCorsPreflight);
+  server.options("/web-call/sessions/:sessionId/recording", handleCorsPreflight);
 
   server.post("/web-call/sessions", async (request, reply) => {
     const origin = getRequestOrigin(request);
@@ -782,17 +1085,29 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
         : exchange.providerCallId;
 
     const startedAt = new Date().toISOString();
-    const call = await startWebVoiceCall({
-      businessSlug,
-      providerCallId,
-      gatewaySessionId,
-      ...(body.pageUrl !== undefined ? { originUrl: body.pageUrl } : {}),
-      ...(typeof request.headers["user-agent"] === "string"
-        ? { userAgent: request.headers["user-agent"] }
-        : {}),
-      ...(widgetId !== undefined ? { widgetId } : {}),
-      startedAt,
-    });
+    let call: Awaited<ReturnType<typeof startWebVoiceCall>>;
+    try {
+      call = await startWebVoiceCall({
+        businessSlug,
+        providerCallId,
+        gatewaySessionId,
+        ...(body.pageUrl !== undefined ? { originUrl: body.pageUrl } : {}),
+        ...(typeof request.headers["user-agent"] === "string"
+          ? { userAgent: request.headers["user-agent"] }
+          : {}),
+        ...(widgetId !== undefined ? { widgetId } : {}),
+        startedAt,
+      });
+    } catch (error) {
+      await hangupOpenAiRealtimeProviderCall(server, {
+        providerCallId,
+        reason: "convex_start_failed",
+      });
+      if (error instanceof RuntimeRequestError) {
+        return replyWithRuntimeRequestError(error, reply);
+      }
+      throw error;
+    }
 
     const session: ActiveWebCall = {
       gatewaySessionId,
@@ -808,6 +1123,10 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       finalized: false,
       openingGreetingActive: true,
       openingGreetingTurnDetectionTimer: null,
+      seenTranscriptKeys: new Set(),
+      transcriptSequence: 1,
+      pendingAssistantTranscriptFlushTimer: null,
+      pendingAssistantTranscripts: [],
     };
     const sidebandSocket = createSidebandSocket({
       server,
@@ -841,6 +1160,49 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
     }
 
     await finishWebCallSession(server, session, "caller_finished");
+    reply.code(204);
+    return null;
+  });
+
+  server.post<{
+    Params: { sessionId: string };
+    Querystring: { durationMs?: string };
+  }>("/web-call/sessions/:sessionId/recording", async (request, reply) => {
+    const origin = getRequestOrigin(request);
+    if (!isAllowedOrigin(server, origin)) {
+      reply.code(403);
+      return "Forbidden";
+    }
+    addCorsHeaders(reply, origin!);
+
+    const webCall = getWebCallForRecording(request.params.sessionId);
+    if (!webCall) {
+      reply.code(404);
+      return { error: "Unknown web voice session." };
+    }
+
+    const audio = await readRequestBodyBuffer(request);
+    if (audio.length === 0) {
+      reply.code(400);
+      return { error: "Missing recording audio." };
+    }
+
+    const parsedDurationMs = Number(request.query.durationMs);
+    const durationMs = Number.isFinite(parsedDurationMs) && parsedDurationMs > 0
+      ? parsedDurationMs
+      : Math.max(0, Date.now() - webCall.startedAtMs);
+    const contentTypeHeader = request.headers["content-type"];
+    const contentType = Array.isArray(contentTypeHeader)
+      ? contentTypeHeader[0]
+      : contentTypeHeader;
+
+    await uploadVoiceRecording({
+      callId: webCall.callId,
+      durationMs,
+      audio,
+      ...(contentType ? { contentType } : {}),
+    });
+
     reply.code(204);
     return null;
   });

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -104,6 +104,7 @@ const WEB_REALTIME_VAD_SILENCE_DURATION_MS = 700;
 const WEB_POST_GREETING_INPUT_GRACE_MS = 2_000;
 const WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS = 10 * 60_000;
 const WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS = 1_500;
+const WEB_RECORDING_BYTES_PER_SECOND_LIMIT = 64 * 1024;
 
 function getAllowedOrigins(raw: string): Set<string> {
   return new Set(
@@ -133,7 +134,15 @@ function isAllowedOrigin(server: FastifyInstance, origin: string | null): boolea
     return false;
   }
   const allowedOrigins = getAllowedOrigins(server.runtimeConfig.WEB_CALL_ALLOWED_ORIGINS);
-  return allowedOrigins.has(origin) || isLocalhostOrigin(origin);
+  return (
+    allowedOrigins.has(origin) ||
+    (server.runtimeConfig.DEPLOYMENT_MODE === "development" && isLocalhostOrigin(origin))
+  );
+}
+
+function getWebRecordingBodyLimit(maxDurationMs: number): number {
+  const maxDurationSeconds = Math.ceil(maxDurationMs / 1_000);
+  return Math.max(5 * 1024 * 1024, maxDurationSeconds * WEB_RECORDING_BYTES_PER_SECOND_LIMIT);
 }
 
 function addCorsHeaders(reply: FastifyReply, origin: string): void {
@@ -1001,6 +1010,10 @@ async function handleToolCall(
 }
 
 export function registerWebCallRoutes(server: FastifyInstance): void {
+  const webRecordingBodyLimit = getWebRecordingBodyLimit(
+    server.runtimeConfig.WEB_CALL_MAX_DURATION_MS,
+  );
+
   server.addContentTypeParser(
     /^audio\/.*/,
     { parseAs: "buffer" },
@@ -1167,43 +1180,47 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
   server.post<{
     Params: { sessionId: string };
     Querystring: { durationMs?: string };
-  }>("/web-call/sessions/:sessionId/recording", async (request, reply) => {
-    const origin = getRequestOrigin(request);
-    if (!isAllowedOrigin(server, origin)) {
-      reply.code(403);
-      return "Forbidden";
-    }
-    addCorsHeaders(reply, origin!);
+  }>(
+    "/web-call/sessions/:sessionId/recording",
+    { bodyLimit: webRecordingBodyLimit },
+    async (request, reply) => {
+      const origin = getRequestOrigin(request);
+      if (!isAllowedOrigin(server, origin)) {
+        reply.code(403);
+        return "Forbidden";
+      }
+      addCorsHeaders(reply, origin!);
 
-    const webCall = getWebCallForRecording(request.params.sessionId);
-    if (!webCall) {
-      reply.code(404);
-      return { error: "Unknown web voice session." };
-    }
+      const webCall = getWebCallForRecording(request.params.sessionId);
+      if (!webCall) {
+        reply.code(404);
+        return { error: "Unknown web voice session." };
+      }
 
-    const audio = await readRequestBodyBuffer(request);
-    if (audio.length === 0) {
-      reply.code(400);
-      return { error: "Missing recording audio." };
-    }
+      const audio = await readRequestBodyBuffer(request);
+      if (audio.length === 0) {
+        reply.code(400);
+        return { error: "Missing recording audio." };
+      }
 
-    const parsedDurationMs = Number(request.query.durationMs);
-    const durationMs = Number.isFinite(parsedDurationMs) && parsedDurationMs > 0
-      ? parsedDurationMs
-      : Math.max(0, Date.now() - webCall.startedAtMs);
-    const contentTypeHeader = request.headers["content-type"];
-    const contentType = Array.isArray(contentTypeHeader)
-      ? contentTypeHeader[0]
-      : contentTypeHeader;
+      const parsedDurationMs = Number(request.query.durationMs);
+      const durationMs = Number.isFinite(parsedDurationMs) && parsedDurationMs > 0
+        ? parsedDurationMs
+        : Math.max(0, Date.now() - webCall.startedAtMs);
+      const contentTypeHeader = request.headers["content-type"];
+      const contentType = Array.isArray(contentTypeHeader)
+        ? contentTypeHeader[0]
+        : contentTypeHeader;
 
-    await uploadVoiceRecording({
-      callId: webCall.callId,
-      durationMs,
-      audio,
-      ...(contentType ? { contentType } : {}),
-    });
+      await uploadVoiceRecording({
+        callId: webCall.callId,
+        durationMs,
+        audio,
+        ...(contentType ? { contentType } : {}),
+      });
 
-    reply.code(204);
-    return null;
-  });
+      reply.code(204);
+      return null;
+    },
+  );
 }

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -14,6 +14,7 @@ import {
   uploadVoiceRecording,
 } from "../convex/runtimeClient";
 import { capturePostHogException } from "../observability/posthog";
+import type { EndCallRequest } from "../realtime/callControl";
 import { executeVoiceTool } from "../realtime/toolExecutor";
 import { createWebRealtimeToolDefinitions } from "../realtime/toolDefinitions";
 
@@ -43,6 +44,7 @@ type OpenAiRealtimeMessage = {
   response?: {
     id?: string;
     status?: string;
+    metadata?: Record<string, string | number | boolean | null> | null;
     usage?: {
       total_tokens?: number;
       input_tokens?: number;
@@ -87,6 +89,8 @@ type ActiveWebCall = {
     dedupeKey: string;
     text: string | undefined;
   }>;
+  pendingEndCall: EndCallRequest | null;
+  pendingEndCallFallbackTimer: ReturnType<typeof setTimeout> | null;
 };
 
 type CompletedWebCall = {
@@ -105,6 +109,8 @@ const WEB_POST_GREETING_INPUT_GRACE_MS = 2_000;
 const WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS = 10 * 60_000;
 const WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS = 1_500;
 const WEB_RECORDING_BYTES_PER_SECOND_LIMIT = 64 * 1024;
+const WEB_FINAL_MESSAGE_HANGUP_FALLBACK_MS = 8_000;
+const WEB_FINAL_MESSAGE_METADATA_PURPOSE = "web_final_message";
 
 function getAllowedOrigins(raw: string): Set<string> {
   return new Set(
@@ -401,6 +407,13 @@ function clearWebMaxDurationTimer(session: ActiveWebCall): void {
   }
 }
 
+function clearWebEndCallFallbackTimer(session: ActiveWebCall): void {
+  if (session.pendingEndCallFallbackTimer !== null) {
+    clearTimeout(session.pendingEndCallFallbackTimer);
+    session.pendingEndCallFallbackTimer = null;
+  }
+}
+
 function normalizeOptionalAbuseKey(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   if (!normalized) {
@@ -517,6 +530,7 @@ async function finishWebCallSession(
   session.finalized = true;
   clearWebOpeningGreetingTimer(session);
   clearWebMaxDurationTimer(session);
+  clearWebEndCallFallbackTimer(session);
   await flushPendingWebAssistantTranscripts(server, session);
   await hangupOpenAiRealtimeCall(server, session, disposition);
 
@@ -536,6 +550,49 @@ async function finishWebCallSession(
     session.sidebandSocket?.close(1000, "web call ended");
     activeWebCalls.delete(session.gatewaySessionId);
   }
+}
+
+function requestWebFinalMessageBeforeHangup(
+  server: FastifyInstance,
+  socket: WebSocket,
+  session: ActiveWebCall,
+  endCall: EndCallRequest,
+): void {
+  if (session.finalized || session.pendingEndCall !== null) {
+    return;
+  }
+
+  session.pendingEndCall = endCall;
+  postRealtimeEvent(socket, {
+    type: "response.create",
+    response: {
+      metadata: {
+        lobbystack_purpose: WEB_FINAL_MESSAGE_METADATA_PURPOSE,
+      },
+      instructions: [
+        `Say this exact final message: ${JSON.stringify(endCall.message)}.`,
+        "Then stop speaking. The session will end automatically after your audio finishes.",
+        "Do not call any tools and do not add anything else.",
+      ].join(" "),
+      tool_choice: "none",
+    },
+  });
+
+  session.pendingEndCallFallbackTimer = setTimeout(() => {
+    session.pendingEndCallFallbackTimer = null;
+    void finishWebCallSession(server, session, endCall.reason).catch((error: unknown) => {
+      server.log.error(
+        {
+          err: error,
+          callId: session.callId,
+          providerCallId: session.providerCallId,
+          reason: endCall.reason,
+        },
+        "Failed to finalize web voice session after final-message fallback",
+      );
+    });
+  }, WEB_FINAL_MESSAGE_HANGUP_FALLBACK_MS);
+  session.pendingEndCallFallbackTimer.unref?.();
 }
 
 function scheduleWebMaxDurationTimer(
@@ -859,6 +916,16 @@ async function handleSidebandMessage(
       }
     }
 
+    if (
+      session.pendingEndCall &&
+      payload.response?.metadata?.lobbystack_purpose === WEB_FINAL_MESSAGE_METADATA_PURPOSE
+    ) {
+      const endCall = session.pendingEndCall;
+      session.pendingEndCall = null;
+      await finishWebCallSession(server, session, endCall.reason);
+      return;
+    }
+
     if (session.openingGreetingActive) {
       scheduleWebRealtimeTurnDetectionEnable(server, socket, session, "response_done");
     }
@@ -961,6 +1028,7 @@ async function handleToolCall(
       callId: session.callId,
       conversationId: session.conversationId,
       callerPhone: "web",
+      channel: "web_voice",
     });
   } catch (error) {
     server.log.error(
@@ -1002,7 +1070,7 @@ async function handleToolCall(
   }
 
   if (executed.endCall) {
-    await finishWebCallSession(server, session, executed.endCall.reason);
+    requestWebFinalMessageBeforeHangup(server, socket, session, executed.endCall);
     return;
   }
 
@@ -1140,6 +1208,8 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       transcriptSequence: 1,
       pendingAssistantTranscriptFlushTimer: null,
       pendingAssistantTranscripts: [],
+      pendingEndCall: null,
+      pendingEndCallFallbackTimer: null,
     };
     const sidebandSocket = createSidebandSocket({
       server,

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -7,6 +7,7 @@ import WebSocket from "ws";
 import {
   appendVoiceTranscript,
   completeVoiceCall,
+  fetchWebCallRecordingTarget,
   fetchWebVoiceContext,
   recordVoiceAiCost,
   RuntimeRequestError,
@@ -96,12 +97,11 @@ type ActiveWebCall = {
 type CompletedWebCall = {
   callId: string;
   startedAtMs: number;
-  completedAtMs: number;
+  completedAtMs?: number;
 };
 
 const activeWebCalls = new Map<string, ActiveWebCall>();
 const completedWebCalls = new Map<string, CompletedWebCall>();
-const originStartAttempts = new Map<string, Array<number>>();
 const WEB_REALTIME_VAD_THRESHOLD = 0.65;
 const WEB_REALTIME_VAD_PREFIX_PADDING_MS = 300;
 const WEB_REALTIME_VAD_SILENCE_DURATION_MS = 700;
@@ -111,6 +111,19 @@ const WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS = 1_500;
 const WEB_RECORDING_BYTES_PER_SECOND_LIMIT = 64 * 1024;
 const WEB_FINAL_MESSAGE_HANGUP_FALLBACK_MS = 8_000;
 const WEB_FINAL_MESSAGE_METADATA_PURPOSE = "web_final_message";
+
+export function resetWebCallRouteStateForTests(): void {
+  for (const session of activeWebCalls.values()) {
+    clearWebOpeningGreetingTimer(session);
+    clearWebMaxDurationTimer(session);
+    clearWebEndCallFallbackTimer(session);
+    if (session.pendingAssistantTranscriptFlushTimer !== null) {
+      clearTimeout(session.pendingAssistantTranscriptFlushTimer);
+    }
+  }
+  activeWebCalls.clear();
+  completedWebCalls.clear();
+}
 
 function getAllowedOrigins(raw: string): Set<string> {
   return new Set(
@@ -155,6 +168,7 @@ function addCorsHeaders(reply: FastifyReply, origin: string): void {
   reply.header("Access-Control-Allow-Origin", origin);
   reply.header("Access-Control-Allow-Methods", "POST, OPTIONS");
   reply.header("Access-Control-Allow-Headers", "Content-Type");
+  reply.header("Access-Control-Max-Age", "600");
   reply.header("Vary", "Origin");
 }
 
@@ -196,7 +210,6 @@ function getWebCallForRecording(sessionId: string): CompletedWebCall | null {
     return {
       callId: active.callId,
       startedAtMs: active.startedAtMs,
-      completedAtMs: Date.now(),
     };
   }
 
@@ -205,12 +218,50 @@ function getWebCallForRecording(sessionId: string): CompletedWebCall | null {
     return null;
   }
 
-  if (Date.now() - completed.completedAtMs > WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS) {
+  if (
+    completed.completedAtMs !== undefined &&
+    Date.now() - completed.completedAtMs > WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS
+  ) {
     completedWebCalls.delete(sessionId);
     return null;
   }
 
   return completed;
+}
+
+async function resolveWebCallForRecording(sessionId: string): Promise<CompletedWebCall | null> {
+  const local = getWebCallForRecording(sessionId);
+  if (local) {
+    return local;
+  }
+
+  const durable = await fetchWebCallRecordingTarget({ gatewaySessionId: sessionId });
+  if (!durable) {
+    return null;
+  }
+
+  const startedAtMs = Date.parse(durable.startedAt);
+  if (!Number.isFinite(startedAtMs)) {
+    return null;
+  }
+
+  const completedAtMs = durable.endedAt !== undefined ? Date.parse(durable.endedAt) : undefined;
+  if (completedAtMs !== undefined) {
+    if (!Number.isFinite(completedAtMs)) {
+      return null;
+    }
+    if (Date.now() - completedAtMs > WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS) {
+      return null;
+    }
+  } else if (durable.status !== "in_progress" && durable.status !== "open") {
+    return null;
+  }
+
+  return {
+    callId: durable.callId,
+    startedAtMs,
+    ...(completedAtMs !== undefined ? { completedAtMs } : {}),
+  };
 }
 
 async function persistWebTranscriptIfNew(
@@ -298,17 +349,6 @@ function queueWebAssistantTranscript(
       );
     });
   }, WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS);
-}
-
-function isRateLimited(origin: string, nowMs = Date.now()): boolean {
-  const windowMs = 60_000;
-  const maxStarts = 12;
-  const recent = (originStartAttempts.get(origin) ?? []).filter(
-    (timestamp) => nowMs - timestamp < windowMs,
-  );
-  recent.push(nowMs);
-  originStartAttempts.set(origin, recent);
-  return recent.length > maxStarts;
 }
 
 export function createWebRealtimeTurnDetectionConfig(options: {
@@ -531,10 +571,9 @@ async function finishWebCallSession(
   clearWebOpeningGreetingTimer(session);
   clearWebMaxDurationTimer(session);
   clearWebEndCallFallbackTimer(session);
-  await flushPendingWebAssistantTranscripts(server, session);
-  await hangupOpenAiRealtimeCall(server, session, disposition);
-
   try {
+    await flushPendingWebAssistantTranscripts(server, session);
+    await hangupOpenAiRealtimeCall(server, session, disposition);
     await completeVoiceCall({
       callId: session.callId,
       status: "completed",
@@ -545,11 +584,14 @@ async function finishWebCallSession(
         Math.ceil((Date.now() - session.startedAtMs) / 1000),
       ),
     });
-  } finally {
-    rememberCompletedWebCall(session);
-    session.sidebandSocket?.close(1000, "web call ended");
-    activeWebCalls.delete(session.gatewaySessionId);
+  } catch (error) {
+    session.finalized = false;
+    throw error;
   }
+
+  rememberCompletedWebCall(session);
+  session.sidebandSocket?.close(1000, "web call ended");
+  activeWebCalls.delete(session.gatewaySessionId);
 }
 
 function requestWebFinalMessageBeforeHangup(
@@ -1115,11 +1157,6 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
     }
     addCorsHeaders(reply, origin!);
 
-    if (isRateLimited(origin!)) {
-      reply.code(429);
-      return { error: "Too many web call starts. Please try again shortly." };
-    }
-
     if (!server.runtimeConfig.OPENAI_API_KEY) {
       reply.code(503);
       return { error: "Web voice is not configured." };
@@ -1127,9 +1164,9 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
 
     const body = (request.body ?? {}) as WebCallSessionRequest;
     const businessSlug = body.businessSlug?.trim() || "";
-    if (businessSlug !== "lobbystack") {
-      reply.code(403);
-      return { error: "Unknown web voice widget." };
+    if (!businessSlug) {
+      reply.code(400);
+      return { error: "Missing business slug." };
     }
     if (!body.sdp?.trim()) {
       reply.code(400);
@@ -1150,7 +1187,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
         ...(widgetId !== undefined ? { widgetId } : {}),
       });
     } catch (error) {
-      if (error instanceof RuntimeRequestError && error.status === 429) {
+      if (error instanceof RuntimeRequestError) {
         return replyWithRuntimeRequestError(error, reply);
       }
       throw error;
@@ -1177,6 +1214,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
           ? { userAgent: request.headers["user-agent"] }
           : {}),
         ...(widgetId !== undefined ? { widgetId } : {}),
+        maxDurationMs: server.runtimeConfig.WEB_CALL_MAX_DURATION_MS,
         startedAt,
       });
     } catch (error) {
@@ -1261,7 +1299,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       }
       addCorsHeaders(reply, origin!);
 
-      const webCall = getWebCallForRecording(request.params.sessionId);
+      const webCall = await resolveWebCallForRecording(request.params.sessionId);
       if (!webCall) {
         reply.code(404);
         return { error: "Unknown web voice session." };
@@ -1276,7 +1314,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       const parsedDurationMs = Number(request.query.durationMs);
       const durationMs = Number.isFinite(parsedDurationMs) && parsedDurationMs > 0
         ? parsedDurationMs
-        : Math.max(0, Date.now() - webCall.startedAtMs);
+        : Math.max(0, (webCall.completedAtMs ?? Date.now()) - webCall.startedAtMs);
       const contentTypeHeader = request.headers["content-type"];
       const contentType = Array.isArray(contentTypeHeader)
         ? contentTypeHeader[0]

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -20,9 +20,9 @@ import { executeVoiceTool } from "../realtime/toolExecutor";
 import { createWebRealtimeToolDefinitions } from "../realtime/toolDefinitions";
 
 type WebCallSessionRequest = {
-  businessSlug?: string;
+  businessSlug: string;
   widgetId?: string;
-  sdp?: string;
+  sdp: string;
   pageUrl?: string;
   visitorId?: string;
 };
@@ -137,6 +137,67 @@ function getAllowedOrigins(raw: string): Set<string> {
 function getRequestOrigin(request: FastifyRequest): string | null {
   const origin = request.headers.origin;
   return typeof origin === "string" && origin ? origin : null;
+}
+
+function getStringProperty(
+  body: Record<string, unknown>,
+  key: string,
+): string | undefined | null {
+  const value = body[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  return typeof value === "string" ? value : null;
+}
+
+function parseWebCallSessionRequest(body: unknown):
+  | { ok: true; data: WebCallSessionRequest }
+  | { ok: false; message: string } {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, message: "Invalid web call request." };
+  }
+
+  const input = body as Record<string, unknown>;
+  const rawBusinessSlug = getStringProperty(input, "businessSlug");
+  const rawSdp = getStringProperty(input, "sdp");
+  const rawPageUrl = getStringProperty(input, "pageUrl");
+  const rawVisitorId = getStringProperty(input, "visitorId");
+  const rawWidgetId = getStringProperty(input, "widgetId");
+
+  if (rawBusinessSlug === null) {
+    return { ok: false, message: "Invalid business slug." };
+  }
+  if (rawSdp === null) {
+    return { ok: false, message: "Invalid SDP offer." };
+  }
+  if (rawPageUrl === null || rawVisitorId === null || rawWidgetId === null) {
+    return { ok: false, message: "Invalid web call request." };
+  }
+
+  const businessSlug = rawBusinessSlug?.trim() ?? "";
+  if (!businessSlug) {
+    return { ok: false, message: "Missing business slug." };
+  }
+
+  const sdp = rawSdp?.trim() ?? "";
+  if (!sdp) {
+    return { ok: false, message: "Missing SDP offer." };
+  }
+
+  const pageUrl = rawPageUrl?.trim();
+  const visitorId = rawVisitorId?.trim();
+  const widgetId = rawWidgetId?.trim();
+
+  return {
+    ok: true,
+    data: {
+      businessSlug,
+      sdp,
+      ...(pageUrl ? { pageUrl } : {}),
+      ...(visitorId ? { visitorId } : {}),
+      ...(widgetId ? { widgetId } : {}),
+    },
+  };
 }
 
 function isLocalhostOrigin(origin: string): boolean {
@@ -1159,16 +1220,13 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       return { error: "Web voice is not configured." };
     }
 
-    const body = (request.body ?? {}) as WebCallSessionRequest;
-    const businessSlug = body.businessSlug?.trim() || "";
-    if (!businessSlug) {
+    const parsedBody = parseWebCallSessionRequest(request.body ?? {});
+    if (!parsedBody.ok) {
       reply.code(400);
-      return { error: "Missing business slug." };
+      return { error: parsedBody.message };
     }
-    if (!body.sdp?.trim()) {
-      reply.code(400);
-      return { error: "Missing SDP offer." };
-    }
+    const body = parsedBody.data;
+    const businessSlug = body.businessSlug;
 
     const gatewaySessionId = crypto.randomUUID();
     const widgetId = normalizeOptionalAbuseKey(body.widgetId);

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -72,11 +72,18 @@ type ActiveWebCall = {
   startedAtMs: number;
   handledToolCallIds: Set<string>;
   sidebandSocket: WebSocket | null;
+  maxDurationTimer: ReturnType<typeof setTimeout> | null;
+  finalized: boolean;
   openingGreetingActive: boolean;
+  openingGreetingTurnDetectionTimer: ReturnType<typeof setTimeout> | null;
 };
 
 const activeWebCalls = new Map<string, ActiveWebCall>();
 const originStartAttempts = new Map<string, Array<number>>();
+const WEB_REALTIME_VAD_THRESHOLD = 0.65;
+const WEB_REALTIME_VAD_PREFIX_PADDING_MS = 300;
+const WEB_REALTIME_VAD_SILENCE_DURATION_MS = 700;
+const WEB_POST_GREETING_INPUT_GRACE_MS = 2_000;
 
 function getAllowedOrigins(raw: string): Set<string> {
   return new Set(
@@ -133,6 +140,9 @@ export function createWebRealtimeTurnDetectionConfig(options: {
 } = {}): Record<string, unknown> {
   return {
     type: "server_vad",
+    threshold: WEB_REALTIME_VAD_THRESHOLD,
+    prefix_padding_ms: WEB_REALTIME_VAD_PREFIX_PADDING_MS,
+    silence_duration_ms: WEB_REALTIME_VAD_SILENCE_DURATION_MS,
     create_response: options.createResponse ?? true,
     interrupt_response: options.interruptResponse ?? true,
   };
@@ -144,10 +154,14 @@ function enableWebRealtimeTurnDetection(
   session: ActiveWebCall,
   reason: string,
 ): void {
-  if (!session.openingGreetingActive) {
+  if (!session.openingGreetingActive || session.finalized) {
     return;
   }
 
+  if (session.openingGreetingTurnDetectionTimer !== null) {
+    clearTimeout(session.openingGreetingTurnDetectionTimer);
+    session.openingGreetingTurnDetectionTimer = null;
+  }
   session.openingGreetingActive = false;
   postRealtimeEvent(socket, { type: "input_audio_buffer.clear" });
   postRealtimeEvent(socket, {
@@ -169,6 +183,51 @@ function enableWebRealtimeTurnDetection(
     },
     "Enabled web voice turn detection after opening greeting",
   );
+}
+
+function scheduleWebRealtimeTurnDetectionEnable(
+  server: FastifyInstance,
+  socket: WebSocket,
+  session: ActiveWebCall,
+  reason: string,
+): void {
+  if (
+    !session.openingGreetingActive ||
+    session.finalized ||
+    session.openingGreetingTurnDetectionTimer !== null
+  ) {
+    return;
+  }
+
+  postRealtimeEvent(socket, { type: "input_audio_buffer.clear" });
+  session.openingGreetingTurnDetectionTimer = setTimeout(() => {
+    session.openingGreetingTurnDetectionTimer = null;
+    enableWebRealtimeTurnDetection(server, socket, session, reason);
+  }, WEB_POST_GREETING_INPUT_GRACE_MS);
+
+  server.log.info(
+    {
+      callId: session.callId,
+      providerCallId: session.providerCallId,
+      reason,
+      graceMs: WEB_POST_GREETING_INPUT_GRACE_MS,
+    },
+    "Waiting briefly before enabling web voice turn detection after opening greeting",
+  );
+}
+
+function clearWebOpeningGreetingTimer(session: ActiveWebCall): void {
+  if (session.openingGreetingTurnDetectionTimer !== null) {
+    clearTimeout(session.openingGreetingTurnDetectionTimer);
+    session.openingGreetingTurnDetectionTimer = null;
+  }
+}
+
+function clearWebMaxDurationTimer(session: ActiveWebCall): void {
+  if (session.maxDurationTimer !== null) {
+    clearTimeout(session.maxDurationTimer);
+    session.maxDurationTimer = null;
+  }
 }
 
 function normalizeOptionalAbuseKey(value: string | undefined): string | undefined {
@@ -203,22 +262,114 @@ function replyWithRuntimeRequestError(
   return { error: error.message };
 }
 
+async function hangupOpenAiRealtimeCall(
+  server: FastifyInstance,
+  session: ActiveWebCall,
+  reason: string,
+): Promise<void> {
+  if (session.providerCallId.startsWith("webcall_")) {
+    server.log.warn(
+      {
+        callId: session.callId,
+        providerCallId: session.providerCallId,
+        reason,
+      },
+      "Skipping OpenAI Realtime hangup because no provider call ID was returned",
+    );
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.openai.com/v1/realtime/calls/${encodeURIComponent(
+        session.providerCallId,
+      )}/hangup`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${server.runtimeConfig.OPENAI_API_KEY}`,
+        },
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      server.log.warn(
+        {
+          callId: session.callId,
+          providerCallId: session.providerCallId,
+          reason,
+          status: response.status,
+          body: body.slice(0, 500),
+        },
+        "OpenAI Realtime web call hangup failed",
+      );
+    }
+  } catch (error) {
+    server.log.error(
+      {
+        err: error,
+        callId: session.callId,
+        providerCallId: session.providerCallId,
+        reason,
+      },
+      "Failed to hang up OpenAI Realtime web call",
+    );
+  }
+}
+
 async function finishWebCallSession(
+  server: FastifyInstance,
   session: ActiveWebCall,
   disposition: string,
 ): Promise<void> {
-  await completeVoiceCall({
-    callId: session.callId,
-    status: "completed",
-    disposition,
-    endedAt: new Date().toISOString(),
-    providerDurationSeconds: Math.max(
-      0,
-      Math.ceil((Date.now() - session.startedAtMs) / 1000),
-    ),
-  });
-  session.sidebandSocket?.close(1000, "web call ended");
-  activeWebCalls.delete(session.gatewaySessionId);
+  if (session.finalized) {
+    return;
+  }
+
+  session.finalized = true;
+  clearWebOpeningGreetingTimer(session);
+  clearWebMaxDurationTimer(session);
+  await hangupOpenAiRealtimeCall(server, session, disposition);
+
+  try {
+    await completeVoiceCall({
+      callId: session.callId,
+      status: "completed",
+      disposition,
+      endedAt: new Date().toISOString(),
+      providerDurationSeconds: Math.max(
+        0,
+        Math.ceil((Date.now() - session.startedAtMs) / 1000),
+      ),
+    });
+  } finally {
+    session.sidebandSocket?.close(1000, "web call ended");
+    activeWebCalls.delete(session.gatewaySessionId);
+  }
+}
+
+function scheduleWebMaxDurationTimer(
+  server: FastifyInstance,
+  session: ActiveWebCall,
+): void {
+  clearWebMaxDurationTimer(session);
+  session.maxDurationTimer = setTimeout(() => {
+    session.maxDurationTimer = null;
+    void finishWebCallSession(server, session, "duration_limit").catch(
+      (error: unknown) => {
+        server.log.error(
+          {
+            err: error,
+            callId: session.callId,
+            providerCallId: session.providerCallId,
+          },
+          "Failed to enforce web voice max duration",
+        );
+      },
+    );
+  }, server.runtimeConfig.WEB_CALL_MAX_DURATION_MS);
 }
 
 function parseProviderCallId(response: Response, gatewaySessionId: string): string {
@@ -349,6 +500,7 @@ function createSidebandSocket(input: {
           "You are speaking through a website voice widget, not a phone call.",
           "Represent LobbyStack and answer questions about the business from the supplied snapshot and tools.",
           "Use the configured greeting only once at the start of the session. Never repeat it after the opening greeting, even after interruptions, silence, or filler speech.",
+          "If the latest audio is silence, background noise, echo of your own previous audio, hold music, TV audio, side conversation, or speech not addressed to you, call waitForUser and do not speak.",
           "Ask for a phone number before booking an appointment, taking a callback message, or discussing existing appointments.",
           "Do not attempt phone transfer from the website widget.",
           "End the session with endCall when the visitor is clearly finished, abusive, spammy, or repeatedly silent.",
@@ -356,6 +508,7 @@ function createSidebandSocket(input: {
         output_modalities: ["audio"],
         audio: {
           input: {
+            noise_reduction: { type: "far_field" },
             transcription: {
               model: input.server.runtimeConfig.OPENAI_TRANSCRIPTION_MODEL,
             },
@@ -402,7 +555,21 @@ function createSidebandSocket(input: {
   });
 
   socket.on("close", () => {
-    activeWebCalls.delete(input.session.gatewaySessionId);
+    clearWebOpeningGreetingTimer(input.session);
+    void finishWebCallSession(
+      input.server,
+      input.session,
+      "provider_socket_closed",
+    ).catch((error: unknown) => {
+      input.server.log.error(
+        {
+          err: error,
+          callId: input.session.callId,
+          providerCallId: input.session.providerCallId,
+        },
+        "Failed to finalize web voice session after sideband close",
+      );
+    });
   });
 
   return socket;
@@ -464,7 +631,7 @@ async function handleSidebandMessage(
     }
 
     if (session.openingGreetingActive) {
-      enableWebRealtimeTurnDetection(server, socket, session, "response_done");
+      scheduleWebRealtimeTurnDetectionEnable(server, socket, session, "response_done");
     }
     return;
   }
@@ -529,8 +696,13 @@ async function handleToolCall(
     },
   });
 
+  if (executed.suppressResponse) {
+    postRealtimeEvent(socket, { type: "input_audio_buffer.clear" });
+    return;
+  }
+
   if (executed.endCall) {
-    await finishWebCallSession(session, executed.endCall.reason);
+    await finishWebCallSession(server, session, executed.endCall.reason);
     return;
   }
 
@@ -632,7 +804,10 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       startedAtMs: Date.parse(startedAt),
       handledToolCallIds: new Set(),
       sidebandSocket: null,
+      maxDurationTimer: null,
+      finalized: false,
       openingGreetingActive: true,
+      openingGreetingTurnDetectionTimer: null,
     };
     const sidebandSocket = createSidebandSocket({
       server,
@@ -641,6 +816,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
     });
     session.sidebandSocket = sidebandSocket;
     activeWebCalls.set(gatewaySessionId, session);
+    scheduleWebMaxDurationTimer(server, session);
 
     return {
       sessionId: gatewaySessionId,
@@ -664,7 +840,7 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       return null;
     }
 
-    await finishWebCallSession(session, "caller_finished");
+    await finishWebCallSession(server, session, "caller_finished");
     reply.code(204);
     return null;
   });

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { buildVoiceSystemPrompt } from "@lobbystack/ai";
+import { WEB_CALL_STALE_GRACE_MS } from "@lobbystack/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import WebSocket from "ws";
 
@@ -110,6 +111,8 @@ const WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS = 10 * 60_000;
 const WEB_ASSISTANT_TRANSCRIPT_REORDER_GRACE_MS = 1_500;
 const WEB_RECORDING_BYTES_PER_SECOND_LIMIT = 64 * 1024;
 const WEB_FINAL_MESSAGE_HANGUP_FALLBACK_MS = 8_000;
+const WEB_FINAL_MESSAGE_MIN_PLAYBACK_GRACE_MS = 1_500;
+const WEB_FINAL_MESSAGE_MAX_PLAYBACK_GRACE_MS = 8_000;
 const WEB_FINAL_MESSAGE_METADATA_PURPOSE = "web_final_message";
 
 export function resetWebCallRouteStateForTests(): void {
@@ -265,9 +268,34 @@ function rememberCompletedWebCall(session: ActiveWebCall): void {
   }, WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS).unref();
 }
 
-function getWebCallForRecording(sessionId: string): CompletedWebCall | null {
+function isActiveWebRecordingUploadAllowed(
+  startedAtMs: number,
+  maxDurationMs: number,
+): boolean {
+  return (
+    Number.isFinite(startedAtMs) &&
+    Date.now() - startedAtMs <= maxDurationMs + WEB_CALL_STALE_GRACE_MS
+  );
+}
+
+function getWebFinalMessagePlaybackGraceMs(message: string): number {
+  const wordCount = message.trim().split(/\s+/u).filter(Boolean).length;
+  const estimatedSpeechMs = Math.ceil((wordCount / 2.5) * 1_000);
+  return Math.min(
+    WEB_FINAL_MESSAGE_MAX_PLAYBACK_GRACE_MS,
+    Math.max(WEB_FINAL_MESSAGE_MIN_PLAYBACK_GRACE_MS, estimatedSpeechMs),
+  );
+}
+
+function getWebCallForRecording(
+  sessionId: string,
+  maxDurationMs: number,
+): CompletedWebCall | null {
   const active = activeWebCalls.get(sessionId);
   if (active) {
+    if (!isActiveWebRecordingUploadAllowed(active.startedAtMs, maxDurationMs)) {
+      return null;
+    }
     return {
       callId: active.callId,
       startedAtMs: active.startedAtMs,
@@ -290,8 +318,11 @@ function getWebCallForRecording(sessionId: string): CompletedWebCall | null {
   return completed;
 }
 
-async function resolveWebCallForRecording(sessionId: string): Promise<CompletedWebCall | null> {
-  const local = getWebCallForRecording(sessionId);
+async function resolveWebCallForRecording(
+  sessionId: string,
+  maxDurationMs: number,
+): Promise<CompletedWebCall | null> {
+  const local = getWebCallForRecording(sessionId, maxDurationMs);
   if (local) {
     return local;
   }
@@ -314,8 +345,18 @@ async function resolveWebCallForRecording(sessionId: string): Promise<CompletedW
     if (Date.now() - completedAtMs > WEB_COMPLETED_SESSION_UPLOAD_GRACE_MS) {
       return null;
     }
-  } else if (durable.status !== "in_progress" && durable.status !== "open") {
-    return null;
+  } else {
+    if (durable.status !== "in_progress" && durable.status !== "open") {
+      return null;
+    }
+    if (
+      !isActiveWebRecordingUploadAllowed(
+        startedAtMs,
+        durable.webCallMaxDurationMs ?? maxDurationMs,
+      )
+    ) {
+      return null;
+    }
   }
 
   return {
@@ -1021,8 +1062,23 @@ async function handleSidebandMessage(
       payload.response?.metadata?.lobbystack_purpose === WEB_FINAL_MESSAGE_METADATA_PURPOSE
     ) {
       const endCall = session.pendingEndCall;
-      session.pendingEndCall = null;
-      await finishWebCallSession(server, session, endCall.reason);
+      clearWebEndCallFallbackTimer(session);
+      session.pendingEndCallFallbackTimer = setTimeout(() => {
+        session.pendingEndCall = null;
+        session.pendingEndCallFallbackTimer = null;
+        void finishWebCallSession(server, session, endCall.reason).catch((error: unknown) => {
+          server.log.error(
+            {
+              err: error,
+              callId: session.callId,
+              providerCallId: session.providerCallId,
+              reason: endCall.reason,
+            },
+            "Failed to finalize web voice session after final-message playback grace",
+          );
+        });
+      }, getWebFinalMessagePlaybackGraceMs(endCall.message));
+      session.pendingEndCallFallbackTimer.unref?.();
       return;
     }
 
@@ -1354,7 +1410,10 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
       }
       addCorsHeaders(reply, origin!);
 
-      const webCall = await resolveWebCallForRecording(request.params.sessionId);
+      const webCall = await resolveWebCallForRecording(
+        request.params.sessionId,
+        server.runtimeConfig.WEB_CALL_MAX_DURATION_MS,
+      );
       if (!webCall) {
         reply.code(404);
         return { error: "Unknown web voice session." };

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -228,6 +228,23 @@ function getWebRecordingBodyLimit(maxDurationMs: number): number {
   return Math.max(5 * 1024 * 1024, maxDurationSeconds * WEB_RECORDING_BYTES_PER_SECOND_LIMIT);
 }
 
+function getWebRecordingDurationMs(
+  webCall: CompletedWebCall,
+  reportedDurationMs: unknown,
+  maxDurationMs: number,
+): number {
+  const elapsedDurationMs = Math.max(
+    0,
+    Math.min((webCall.completedAtMs ?? Date.now()) - webCall.startedAtMs, maxDurationMs),
+  );
+  const parsedDurationMs = Number(reportedDurationMs);
+  if (!Number.isFinite(parsedDurationMs) || parsedDurationMs <= 0) {
+    return elapsedDurationMs;
+  }
+
+  return Math.min(parsedDurationMs, elapsedDurationMs);
+}
+
 function addCorsHeaders(reply: FastifyReply, origin: string): void {
   reply.header("Access-Control-Allow-Origin", origin);
   reply.header("Access-Control-Allow-Methods", "POST, OPTIONS");
@@ -1425,10 +1442,11 @@ export function registerWebCallRoutes(server: FastifyInstance): void {
         return { error: "Missing recording audio." };
       }
 
-      const parsedDurationMs = Number(request.query.durationMs);
-      const durationMs = Number.isFinite(parsedDurationMs) && parsedDurationMs > 0
-        ? parsedDurationMs
-        : Math.max(0, (webCall.completedAtMs ?? Date.now()) - webCall.startedAtMs);
+      const durationMs = getWebRecordingDurationMs(
+        webCall,
+        request.query.durationMs,
+        server.runtimeConfig.WEB_CALL_MAX_DURATION_MS,
+      );
       const contentTypeHeader = request.headers["content-type"];
       const contentType = Array.isArray(contentTypeHeader)
         ? contentTypeHeader[0]

--- a/apps/web/src/features/calls/CallsPage.test.ts
+++ b/apps/web/src/features/calls/CallsPage.test.ts
@@ -44,6 +44,16 @@ describe("getCallRecordingAvailability", () => {
     ).toBe("pending");
   });
 
+  it("does not show web calls without uploaded recordings as pending", () => {
+    expect(
+      getCallRecordingAvailability({
+        recordingUrl: null,
+        disposition: "caller_finished",
+        transport: "webrtc",
+      }),
+    ).toBe("unavailable");
+  });
+
   it("marks expired retained recordings as unavailable", () => {
     expect(
       getCallRecordingAvailability({

--- a/apps/web/src/features/calls/CallsPage.tsx
+++ b/apps/web/src/features/calls/CallsPage.tsx
@@ -113,6 +113,7 @@ export function getCallRecordingAvailability(call: {
   recordingStorageId?: unknown;
   recordingRetentionStatus?: string;
   disposition?: string;
+  transport?: string;
 }): "ready" | "pending" | "unavailable" {
   if (call.recordingUrl) {
     return "ready";
@@ -124,6 +125,10 @@ export function getCallRecordingAvailability(call: {
 
   if (call.recordingStorageId) {
     return "pending";
+  }
+
+  if (call.transport === "webrtc") {
+    return "unavailable";
   }
 
   const disposition = call.disposition?.trim().toLowerCase() ?? "";

--- a/convex/conversations/sessions.ts
+++ b/convex/conversations/sessions.ts
@@ -526,6 +526,7 @@ export async function ensureVoiceSessionForCall(
     conversationId: Id<"conversations">;
     callId: Id<"calls">;
     startedAt: number;
+    channel?: string;
   },
 ): Promise<Id<"conversation_sessions">> {
   const existing = await ctx.db
@@ -541,7 +542,7 @@ export async function ensureVoiceSessionForCall(
   return await ctx.db.insert("conversation_sessions", {
     businessId: input.businessId,
     conversationId: input.conversationId,
-    channel: "voice",
+    channel: input.channel ?? "voice",
     callId: input.callId,
     status: "active",
     startedAt,

--- a/convex/conversations/sessions.ts
+++ b/convex/conversations/sessions.ts
@@ -339,7 +339,7 @@ async function buildSessionSummary(
   }
 
   const normalizedConversationSummary = normalizeSummary(conversation.summary);
-  if (session.channel === "voice" && conversation.currentIntent === "message_taking") {
+  if (session.channel.includes("voice") && conversation.currentIntent === "message_taking") {
     return {
       kind: "message_taking",
       ...(normalizedConversationSummary ? { summary: normalizedConversationSummary } : {}),
@@ -353,7 +353,7 @@ async function buildSessionSummary(
     };
   }
 
-  if (normalizedConversationSummary && session.channel === "voice") {
+  if (normalizedConversationSummary && session.channel.includes("voice")) {
     return {
       kind: "summary",
       summary: normalizedConversationSummary,
@@ -428,7 +428,7 @@ export async function ensureSessionForStoredMessage(
 
   const messageTimestamp = message._creationTime;
 
-  if (input.channel === "voice") {
+  if (input.channel.includes("voice")) {
     if (!input.callId) {
       throw new Error("Voice messages must belong to a call session.");
     }

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -1,4 +1,8 @@
 import { v } from "convex/values";
+import {
+  DEFAULT_WEB_CALL_MAX_DURATION_MS,
+  WEB_CALL_STALE_GRACE_MS,
+} from "../../packages/shared/src/index";
 
 import { query, type QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
@@ -323,10 +327,10 @@ function categorizeCallOutcome(call: Doc<"calls">): "completed" | "live" | "miss
   return "missed";
 }
 
-export const WEBRTC_LIVE_CALL_GRACE_MS = 30 * 60 * 1000;
+export const WEBRTC_LIVE_CALL_GRACE_MS = DEFAULT_WEB_CALL_MAX_DURATION_MS + WEB_CALL_STALE_GRACE_MS;
 
 export function isCallLiveForDashboard(
-  call: Pick<Doc<"calls">, "status" | "transport" | "startedAt">,
+  call: Pick<Doc<"calls">, "status" | "transport" | "startedAt" | "webCallMaxDurationMs">,
   nowMs = Date.now(),
 ): boolean {
   if (call.status !== "in_progress" && call.status !== "open") {
@@ -338,7 +342,9 @@ export function isCallLiveForDashboard(
   }
 
   const startedAtMs = Date.parse(call.startedAt);
-  return Number.isFinite(startedAtMs) && nowMs - startedAtMs <= WEBRTC_LIVE_CALL_GRACE_MS;
+  const liveGraceMs = (call.webCallMaxDurationMs ?? DEFAULT_WEB_CALL_MAX_DURATION_MS) +
+    WEB_CALL_STALE_GRACE_MS;
+  return Number.isFinite(startedAtMs) && nowMs - startedAtMs <= liveGraceMs;
 }
 
 function categorizeConversationChannel(channel: string): "voice" | "sms" | "other" {

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -323,6 +323,24 @@ function categorizeCallOutcome(call: Doc<"calls">): "completed" | "live" | "miss
   return "missed";
 }
 
+export const WEBRTC_LIVE_CALL_GRACE_MS = 30 * 60 * 1000;
+
+export function isCallLiveForDashboard(
+  call: Pick<Doc<"calls">, "status" | "transport" | "startedAt">,
+  nowMs = Date.now(),
+): boolean {
+  if (call.status !== "in_progress" && call.status !== "open") {
+    return false;
+  }
+
+  if (call.transport !== "webrtc") {
+    return true;
+  }
+
+  const startedAtMs = Date.parse(call.startedAt);
+  return Number.isFinite(startedAtMs) && nowMs - startedAtMs <= WEBRTC_LIVE_CALL_GRACE_MS;
+}
+
 function categorizeConversationChannel(channel: string): "voice" | "sms" | "other" {
   const normalized = channel.toLowerCase();
   if (normalized.includes("voice") || normalized.includes("call")) {
@@ -514,9 +532,8 @@ export const getHomeSummary = query({
         }),
     );
 
-    const liveCalls = calls.filter(
-      (call) => call.status === "in_progress" || call.status === "open",
-    ).length;
+    const nowMs = now.getTime();
+    const liveCalls = calls.filter((call) => isCallLiveForDashboard(call, nowMs)).length;
 
     const actionRequiredFromVoice = dedupeVoiceFollowUpItems(
       openVoiceFollowUpItems.slice().sort((left, right) => right._creationTime - left._creationTime),

--- a/convex/dashboard/overview.ts
+++ b/convex/dashboard/overview.ts
@@ -293,12 +293,15 @@ function incrementCount(map: Map<string, number>, key: string): void {
   map.set(key, (map.get(key) ?? 0) + 1);
 }
 
-function categorizeCallOutcome(call: Doc<"calls">): "completed" | "live" | "missed" | "transferred" {
+function categorizeCallOutcome(
+  call: Doc<"calls">,
+  nowMs = Date.now(),
+): "completed" | "live" | "missed" | "transferred" {
   if (call.transferState && call.transferState !== "idle") {
     return "transferred";
   }
 
-  if (call.status === "open" || call.status === "in_progress") {
+  if (isCallLiveForDashboard(call, nowMs)) {
     return "live";
   }
 
@@ -841,8 +844,9 @@ export const getAnalyticsSummary = query({
       missed: 0,
       transferred: 0,
     };
+    const nowMs = now.getTime();
     for (const call of currentWeekCalls) {
-      outcomes[categorizeCallOutcome(call)] += 1;
+      outcomes[categorizeCallOutcome(call, nowMs)] += 1;
     }
 
     const conversationChannels = new Map(

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -161,6 +161,7 @@ const bookAppointmentSchema = z.object({
   serviceName: z.string().min(1),
   startsAt: z.string().min(1),
   timezone: z.string().min(1),
+  channel: z.enum(["voice", "web_voice"]).optional(),
   preferredStaffId: z.string().min(1).optional(),
   conversationId: z.string().min(1).optional(),
   contactName: z.string().min(1).optional(),
@@ -1275,6 +1276,7 @@ http.route({
       serviceName: body.data.serviceName,
       startsAt: body.data.startsAt,
       timezone: body.data.timezone,
+      ...(body.data.channel !== undefined ? { channel: body.data.channel } : {}),
       ...(body.data.preferredStaffId !== undefined
         ? { preferredStaffId: asId("staff", body.data.preferredStaffId) }
         : {}),

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -791,6 +791,26 @@ http.route({
       }
     }
 
+    try {
+      await ctx.runQuery(internal.voice.runtime.assertWebVoiceBillingCanStart, {
+        businessId: business._id,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === billingErrorCodes.voiceLimitReached
+      ) {
+        return Response.json(
+          {
+            code: billingErrorCodes.voiceLimitReached,
+            message: "Voice quota reached for this billing period.",
+          },
+          { status: 402 },
+        );
+      }
+      throw error;
+    }
+
     const snapshot = await ctx.runQuery(internal.ai.context.snapshots.getByBusinessId, {
       businessId: business._id,
     });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,7 @@
 import { httpRouter } from "convex/server";
 import { z } from "zod";
 import { billingErrorCodes } from "../packages/shared/src/billing";
+import { MAX_WEB_CALL_MAX_DURATION_MS } from "../packages/shared/src/index";
 import {
   normalizeTwilioFormFields,
 } from "./lib/twilioSecurity";
@@ -48,6 +49,10 @@ const voiceContextBySlugSchema = z.object({
   widgetId: z.string().min(1).optional(),
 });
 
+const webCallRecordingTargetSchema = z.object({
+  gatewaySessionId: z.string().min(1),
+});
+
 const startCallSchema = z.object({
   businessId: z.string().min(1),
   twilioCallSid: z.string().min(1),
@@ -64,6 +69,7 @@ const startWebCallSchema = z.object({
   originUrl: z.string().min(1).optional(),
   userAgent: z.string().min(1).optional(),
   widgetId: z.string().min(1).optional(),
+  maxDurationMs: z.number().positive().max(MAX_WEB_CALL_MAX_DURATION_MS).optional(),
   startedAt: z.string().min(1),
 });
 
@@ -800,6 +806,32 @@ http.route({
 });
 
 http.route({
+  path: "/voice/call/web-recording-target",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const unauthorized = requireServiceToken(request);
+    if (unauthorized) {
+      return unauthorized;
+    }
+
+    const body = await parseJsonBody(request, webCallRecordingTargetSchema);
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const target = await ctx.runQuery(internal.voice.runtime.getWebCallRecordingTarget, {
+      gatewaySessionId: body.data.gatewaySessionId,
+    });
+
+    if (!target) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    return Response.json(target);
+  }),
+});
+
+http.route({
   path: "/voice/call/start",
   method: "POST",
   handler: httpAction(async (ctx, request) => {
@@ -870,6 +902,9 @@ http.route({
         ...(body.data.originUrl !== undefined ? { originUrl: body.data.originUrl } : {}),
         ...(body.data.userAgent !== undefined ? { userAgent: body.data.userAgent } : {}),
         ...(body.data.widgetId !== undefined ? { widgetId: body.data.widgetId } : {}),
+        ...(body.data.maxDurationMs !== undefined
+          ? { maxDurationMs: body.data.maxDurationMs }
+          : {}),
         startedAt: body.data.startedAt,
       });
     } catch (error) {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -207,6 +207,7 @@ const takeMessageSchema = z.object({
   businessId: z.string().min(1),
   callId: z.string().min(1),
   conversationId: z.string().min(1).optional(),
+  channel: z.enum(["voice", "web_voice"]).optional(),
   callerName: z.string().min(1).optional(),
   callbackPhone: z.string().min(1).optional(),
   message: z.string().min(1),
@@ -1504,6 +1505,7 @@ http.route({
       ...(body.data.conversationId !== undefined
         ? { conversationId: asId("conversations", body.data.conversationId) }
         : {}),
+      ...(body.data.channel !== undefined ? { channel: body.data.channel } : {}),
       ...(body.data.callerName !== undefined ? { callerName: body.data.callerName } : {}),
       ...(body.data.callbackPhone !== undefined
         ? { callbackPhone: body.data.callbackPhone }

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -40,12 +40,30 @@ const voiceContextSchema = z.object({
   channel: z.enum(["voice", "sms"]).optional(),
 });
 
+const voiceContextBySlugSchema = z.object({
+  businessSlug: z.string().min(1),
+  origin: z.string().min(1).optional(),
+  ipHash: z.string().min(1).optional(),
+  visitorId: z.string().min(1).optional(),
+  widgetId: z.string().min(1).optional(),
+});
+
 const startCallSchema = z.object({
   businessId: z.string().min(1),
   twilioCallSid: z.string().min(1),
   gatewaySessionId: z.string().min(1).optional(),
   from: z.string().min(1),
   to: z.string().min(1),
+  startedAt: z.string().min(1),
+});
+
+const startWebCallSchema = z.object({
+  businessSlug: z.string().min(1),
+  providerCallId: z.string().min(1),
+  gatewaySessionId: z.string().min(1).optional(),
+  originUrl: z.string().min(1).optional(),
+  userAgent: z.string().min(1).optional(),
+  widgetId: z.string().min(1).optional(),
   startedAt: z.string().min(1),
 });
 
@@ -718,6 +736,69 @@ http.route({
 });
 
 http.route({
+  path: "/voice/context/by-slug",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const unauthorized = requireServiceToken(request);
+    if (unauthorized) {
+      return unauthorized;
+    }
+
+    const body = await parseJsonBody(request, voiceContextBySlugSchema);
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const business = await ctx.runQuery(internal.voice.runtime.getActiveBusinessBySlug, {
+      businessSlug: body.data.businessSlug,
+    });
+
+    if (!business) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    if (body.data.origin !== undefined) {
+      try {
+        await ctx.runMutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+          businessId: business._id,
+          origin: body.data.origin,
+          ...(body.data.ipHash !== undefined ? { ipHash: body.data.ipHash } : {}),
+          ...(body.data.visitorId !== undefined ? { visitorId: body.data.visitorId } : {}),
+          ...(body.data.widgetId !== undefined ? { widgetId: body.data.widgetId } : {}),
+        });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "web_voice_rate_limited"
+        ) {
+          return Response.json(
+            {
+              code: "web_voice_rate_limited",
+              message: "Too many web voice starts. Please try again shortly.",
+            },
+            { status: 429 },
+          );
+        }
+        throw error;
+      }
+    }
+
+    const snapshot = await ctx.runQuery(internal.ai.context.snapshots.getByBusinessId, {
+      businessId: business._id,
+    });
+
+    if (!snapshot) {
+      return new Response("Snapshot not ready", { status: 404 });
+    }
+
+    return Response.json({
+      businessId: business._id,
+      snapshot,
+    });
+  }),
+});
+
+http.route({
   path: "/voice/call/start",
   method: "POST",
   handler: httpAction(async (ctx, request) => {
@@ -741,6 +822,53 @@ http.route({
           : {}),
         from: body.data.from,
         to: body.data.to,
+        startedAt: body.data.startedAt,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === billingErrorCodes.voiceLimitReached
+      ) {
+        return Response.json(
+          {
+            code: billingErrorCodes.voiceLimitReached,
+            message: "Voice quota reached for this billing period.",
+          },
+          { status: 402 },
+        );
+      }
+      throw error;
+    }
+
+    return Response.json(result);
+  }),
+});
+
+http.route({
+  path: "/voice/call/start-web",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const unauthorized = requireServiceToken(request);
+    if (unauthorized) {
+      return unauthorized;
+    }
+
+    const body = await parseJsonBody(request, startWebCallSchema);
+    if (!body.ok) {
+      return body.response;
+    }
+
+    let result;
+    try {
+      result = await ctx.runMutation(internal.voice.runtime.startWebCall, {
+        businessSlug: body.data.businessSlug,
+        providerCallId: body.data.providerCallId,
+        ...(body.data.gatewaySessionId !== undefined
+          ? { gatewaySessionId: body.data.gatewaySessionId }
+          : {}),
+        ...(body.data.originUrl !== undefined ? { originUrl: body.data.originUrl } : {}),
+        ...(body.data.userAgent !== undefined ? { userAgent: body.data.userAgent } : {}),
+        ...(body.data.widgetId !== undefined ? { widgetId: body.data.widgetId } : {}),
         startedAt: body.data.startedAt,
       });
     } catch (error) {

--- a/convex/lib/components.ts
+++ b/convex/lib/components.ts
@@ -122,3 +122,36 @@ export const dashboardAbuseRateLimiter = new RateLimiter(components.rateLimiter,
     period: HOUR,
   },
 });
+
+export const webVoiceAbuseRateLimiter = new RateLimiter(components.rateLimiter, {
+  webVoiceStartGlobalPerMinute: {
+    kind: "fixed window",
+    rate: 120,
+    period: MINUTE,
+  },
+  webVoiceStartPerBusinessPerHour: {
+    kind: "fixed window",
+    rate: 60,
+    period: HOUR,
+  },
+  webVoiceStartPerBusinessPerDay: {
+    kind: "fixed window",
+    rate: 300,
+    period: DAY,
+  },
+  webVoiceStartPerOriginPerTenMinutes: {
+    kind: "fixed window",
+    rate: 30,
+    period: 10 * MINUTE,
+  },
+  webVoiceStartPerIpPerTenMinutes: {
+    kind: "fixed window",
+    rate: 5,
+    period: 10 * MINUTE,
+  },
+  webVoiceStartPerVisitorPerTenMinutes: {
+    kind: "fixed window",
+    rate: 5,
+    period: 10 * MINUTE,
+  },
+});

--- a/convex/lib/components.ts
+++ b/convex/lib/components.ts
@@ -144,14 +144,24 @@ export const webVoiceAbuseRateLimiter = new RateLimiter(components.rateLimiter, 
     rate: 30,
     period: 10 * MINUTE,
   },
-  webVoiceStartPerIpPerTenMinutes: {
+  webVoiceStartPerIpPerHour: {
     kind: "fixed window",
     rate: 5,
-    period: 10 * MINUTE,
+    period: HOUR,
   },
-  webVoiceStartPerVisitorPerTenMinutes: {
+  webVoiceStartPerIpPerDay: {
+    kind: "fixed window",
+    rate: 10,
+    period: DAY,
+  },
+  webVoiceStartPerVisitorPerHour: {
     kind: "fixed window",
     rate: 5,
-    period: 10 * MINUTE,
+    period: HOUR,
+  },
+  webVoiceStartPerVisitorPerDay: {
+    kind: "fixed window",
+    rate: 10,
+    period: DAY,
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -713,7 +713,13 @@ export default defineSchema({
     businessId: v.id("businesses"),
     conversationId: v.optional(v.id("conversations")),
     contactId: v.optional(v.id("contacts")),
-    twilioCallSid: v.string(),
+    twilioCallSid: v.optional(v.string()),
+    provider: v.optional(v.string()),
+    providerCallId: v.optional(v.string()),
+    transport: v.optional(v.string()),
+    originUrl: v.optional(v.string()),
+    userAgent: v.optional(v.string()),
+    widgetId: v.optional(v.string()),
     gatewaySessionId: v.optional(v.string()),
     status: v.string(),
     transferState: v.optional(v.string()),
@@ -736,6 +742,7 @@ export default defineSchema({
     recordingExpiresAt: v.optional(v.string()),
   })
     .index("by_twilio_call_sid", ["twilioCallSid"])
+    .index("by_provider_and_provider_call_id", ["provider", "providerCallId"])
     .index("by_business_id_and_started_at", ["businessId", "startedAt"])
     .index("by_conversation_id", ["conversationId"])
     .index("by_recording_retention_status_and_recording_expires_at", [

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -721,6 +721,7 @@ export default defineSchema({
     userAgent: v.optional(v.string()),
     widgetId: v.optional(v.string()),
     gatewaySessionId: v.optional(v.string()),
+    webCallMaxDurationMs: v.optional(v.number()),
     status: v.string(),
     transferState: v.optional(v.string()),
     disposition: v.optional(v.string()),
@@ -743,6 +744,7 @@ export default defineSchema({
   })
     .index("by_twilio_call_sid", ["twilioCallSid"])
     .index("by_provider_and_provider_call_id", ["provider", "providerCallId"])
+    .index("by_gateway_session_id", ["gatewaySessionId"])
     .index("by_business_id_and_started_at", ["businessId", "startedAt"])
     .index("by_conversation_id", ["conversationId"])
     .index("by_recording_retention_status_and_recording_expires_at", [

--- a/convex/tests/dashboardHomeSummary.test.ts
+++ b/convex/tests/dashboardHomeSummary.test.ts
@@ -93,6 +93,14 @@ describe("Dashboard home summary", () => {
     });
 
     expect(summary.liveCalls).toBe(2);
+
+    const analytics = await authed.query(api.dashboard.overview.getAnalyticsSummary, {
+      businessId,
+      rangeStartMs: nowMs - 60 * 60 * 1000,
+      rangeEndMs: nowMs + 60 * 60 * 1000,
+    });
+    expect(analytics.outcomes.find((outcome) => outcome.key === "live")?.value).toBe(2);
+    expect(analytics.outcomes.find((outcome) => outcome.key === "missed")?.value).toBe(1);
   });
 
   it("includes average call duration in the KPI summary", async () => {

--- a/convex/tests/dashboardHomeSummary.test.ts
+++ b/convex/tests/dashboardHomeSummary.test.ts
@@ -55,6 +55,46 @@ async function insertContact(
 }
 
 describe("Dashboard home summary", () => {
+  it("does not count stale WebRTC calls as live", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, authed } = await seedBusinessMember(t, "dashboard-home-stale-webrtc");
+    const nowMs = Date.now();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("calls", {
+        businessId,
+        provider: "openai",
+        providerCallId: "call_stale_webrtc",
+        transport: "webrtc",
+        status: "in_progress",
+        startedAt: new Date(nowMs - 31 * 60 * 1000).toISOString(),
+      });
+      await ctx.db.insert("calls", {
+        businessId,
+        provider: "openai",
+        providerCallId: "call_fresh_webrtc",
+        transport: "webrtc",
+        status: "in_progress",
+        startedAt: new Date(nowMs - 5 * 60 * 1000).toISOString(),
+      });
+      await ctx.db.insert("calls", {
+        businessId,
+        provider: "twilio",
+        providerCallId: "CA-live-twilio",
+        transport: "twilio_media_stream",
+        status: "in_progress",
+        startedAt: new Date(nowMs - 31 * 60 * 1000).toISOString(),
+      });
+    });
+
+    const summary = await authed.query(api.dashboard.overview.getHomeSummary, {
+      businessId,
+      locale: HOME_SUMMARY_LOCALE,
+    });
+
+    expect(summary.liveCalls).toBe(2);
+  });
+
   it("includes average call duration in the KPI summary", async () => {
     const t = convexTest(schema, convexModules);
     const { businessId, authed } = await seedBusinessMember(t, "dashboard-home-average-duration");

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -176,6 +176,7 @@ describe("web voice calls", () => {
 
     expect(target).toEqual({
       callId: result.callId,
+      providerCallId: "call_openai_recording_target",
       startedAt: "2026-05-20T12:00:00.000Z",
       status: "in_progress",
       webCallMaxDurationMs: 300000,

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -205,6 +205,40 @@ describe("web voice calls", () => {
     ).rejects.toThrow("web_voice_rate_limited");
   });
 
+  it("does not consume shared buckets when a specific web voice limiter rejects", async () => {
+    const { t, businessId } = await seedBusiness("web-voice-no-partial-consume");
+
+    for (let index = 0; index < 5; index += 1) {
+      await t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: "client-ip-hash",
+        visitorId: `visitor-${index}`,
+        widgetId: "lobbystack-landing",
+      });
+    }
+
+    await expect(
+      t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://alternate.example",
+        ipHash: "client-ip-hash",
+        visitorId: "visitor-over-limit",
+        widgetId: "lobbystack-landing",
+      }),
+    ).rejects.toThrow("web_voice_rate_limited");
+
+    for (let index = 0; index < 30; index += 1) {
+      await t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://alternate.example",
+        ipHash: `alternate-ip-${index}`,
+        visitorId: `alternate-visitor-${index}`,
+        widgetId: "lobbystack-landing",
+      });
+    }
+  });
+
   it("rate limits repeated web voice starts for the same IP hash per day", async () => {
     const { t, businessId } = await seedBusiness("web-voice-ip-day");
     const ipKey = `${String(businessId)}:ip:client-ip-hash`;

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -3,6 +3,7 @@ import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 
 import { internal } from "../_generated/api";
+import { webVoiceAbuseRateLimiter } from "../lib/components";
 import schema from "../schema";
 import { modules } from "../test.setup";
 
@@ -76,7 +77,7 @@ describe("web voice calls", () => {
     });
   });
 
-  it("rate limits repeated web voice starts for the same IP hash", async () => {
+  it("rate limits repeated web voice starts for the same IP hash per hour", async () => {
     const { t, businessId } = await seedBusiness();
 
     for (let index = 0; index < 5; index += 1) {
@@ -95,6 +96,69 @@ describe("web voice calls", () => {
         origin: "https://lobbystack.com",
         ipHash: "client-ip-hash",
         visitorId: "visitor-over-limit",
+        widgetId: "lobbystack-landing",
+      }),
+    ).rejects.toThrow("web_voice_rate_limited");
+  });
+
+  it("rate limits repeated web voice starts for the same IP hash per day", async () => {
+    const { t, businessId } = await seedBusiness("web-voice-ip-day");
+    const ipKey = `${String(businessId)}:ip:client-ip-hash`;
+
+    for (let index = 0; index < 10; index += 1) {
+      if (index > 0 && index % 5 === 0) {
+        await t.run(async (ctx) => {
+          await webVoiceAbuseRateLimiter.reset(ctx, "webVoiceStartPerIpPerHour", {
+            key: ipKey,
+          });
+        });
+      }
+
+      await t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: "client-ip-hash",
+        visitorId: `visitor-${index}`,
+        widgetId: "lobbystack-landing",
+      });
+    }
+
+    await t.run(async (ctx) => {
+      await webVoiceAbuseRateLimiter.reset(ctx, "webVoiceStartPerIpPerHour", {
+        key: ipKey,
+      });
+    });
+
+    await expect(
+      t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: "client-ip-hash",
+        visitorId: "visitor-over-limit",
+        widgetId: "lobbystack-landing",
+      }),
+    ).rejects.toThrow("web_voice_rate_limited");
+  });
+
+  it("rate limits repeated web voice starts for the same visitor per hour", async () => {
+    const { t, businessId } = await seedBusiness("web-voice-visitor-hour");
+
+    for (let index = 0; index < 5; index += 1) {
+      await t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: `client-ip-hash-${index}`,
+        visitorId: "visitor-123",
+        widgetId: "lobbystack-landing",
+      });
+    }
+
+    await expect(
+      t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: "client-ip-hash-over-limit",
+        visitorId: "visitor-123",
         widgetId: "lobbystack-landing",
       }),
     ).rejects.toThrow("web_voice_rate_limited");

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -1,6 +1,6 @@
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { internal } from "../_generated/api";
 import { webVoiceAbuseRateLimiter } from "../lib/components";
@@ -26,6 +26,10 @@ async function seedBusiness(slug = "lobbystack") {
 }
 
 describe("web voice calls", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("starts provider-neutral web calls without a contact or Twilio SID", async () => {
     const { t, businessId } = await seedBusiness();
 
@@ -73,6 +77,43 @@ describe("web voice calls", () => {
         callId: result.callId,
         channel: "web_voice",
         status: "active",
+      });
+    });
+  });
+
+  it("expires stale web calls that missed normal browser cleanup", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T13:00:00.000Z"));
+    const { t } = await seedBusiness("stale-web-call-cleanup");
+
+    const result = await t.mutation(internal.voice.runtime.startWebCall, {
+      businessSlug: "stale-web-call-cleanup",
+      providerCallId: "call_openai_stale_web",
+      gatewaySessionId: "gateway-session-stale",
+      startedAt: "2026-05-20T12:00:00.000Z",
+    });
+
+    await t.mutation(internal.voice.runtime.expireStaleWebCall, {
+      callId: result.callId,
+    });
+
+    await t.run(async (ctx) => {
+      const call = await ctx.db.get(result.callId);
+      const conversation = await ctx.db.get(result.conversationId);
+      const session = await ctx.db
+        .query("conversation_sessions")
+        .withIndex("by_call_id", (q) => q.eq("callId", result.callId))
+        .unique();
+
+      expect(call).toMatchObject({
+        status: "completed",
+        disposition: "web_call_stale_timeout",
+        endedAt: "2026-05-20T13:00:00.000Z",
+      });
+      expect(conversation?.status).toBe("closed");
+      expect(session).toMatchObject({
+        status: "closed",
+        closedAt: Date.parse("2026-05-20T13:00:00.000Z"),
       });
     });
   });

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -115,7 +115,7 @@ describe("web voice calls", () => {
         status: "completed",
         disposition: "web_call_stale_timeout",
         endedAt: "2026-05-20T13:00:00.000Z",
-        providerCallDurationSeconds: 3600,
+        providerCallDurationSeconds: 300,
       });
       expect(conversation?.status).toBe("closed");
       expect(session).toMatchObject({
@@ -123,9 +123,61 @@ describe("web voice calls", () => {
         closedAt: Date.parse("2026-05-20T13:00:00.000Z"),
       });
       expect(usageEvent).toMatchObject({
-        quantity: 3600,
+        quantity: 300,
         recordedAt: "2026-05-20T13:00:00.000Z",
       });
+    });
+  });
+
+  it("rejects idempotent web-call starts when provider call IDs cross businesses", async () => {
+    const { t } = await seedBusiness("web-voice-business-a");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("businesses", {
+        slug: "web-voice-business-b",
+        name: "Business B",
+        timezone: "America/Toronto",
+        businessType: "clinic",
+        defaultLocale: "en",
+        deploymentMode: "cloud",
+        status: "active",
+      });
+    });
+
+    await t.mutation(internal.voice.runtime.startWebCall, {
+      businessSlug: "web-voice-business-a",
+      providerCallId: "call_openai_cross_business",
+      gatewaySessionId: "gateway-session-a",
+      startedAt: "2026-05-20T12:00:00.000Z",
+    });
+
+    await expect(
+      t.mutation(internal.voice.runtime.startWebCall, {
+        businessSlug: "web-voice-business-b",
+        providerCallId: "call_openai_cross_business",
+        gatewaySessionId: "gateway-session-b",
+        startedAt: "2026-05-20T12:01:00.000Z",
+      }),
+    ).rejects.toThrow("different business");
+  });
+
+  it("resolves web recording targets by durable gateway session ID", async () => {
+    const { t } = await seedBusiness("web-voice-recording-target");
+
+    const result = await t.mutation(internal.voice.runtime.startWebCall, {
+      businessSlug: "web-voice-recording-target",
+      providerCallId: "call_openai_recording_target",
+      gatewaySessionId: "gateway-session-recording-target",
+      startedAt: "2026-05-20T12:00:00.000Z",
+    });
+
+    const target = await t.query(internal.voice.runtime.getWebCallRecordingTarget, {
+      gatewaySessionId: "gateway-session-recording-target",
+    });
+
+    expect(target).toEqual({
+      callId: result.callId,
+      startedAt: "2026-05-20T12:00:00.000Z",
+      status: "in_progress",
     });
   });
 

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -178,6 +178,7 @@ describe("web voice calls", () => {
       callId: result.callId,
       startedAt: "2026-05-20T12:00:00.000Z",
       status: "in_progress",
+      webCallMaxDurationMs: 300000,
     });
   });
 

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -216,6 +216,58 @@ describe("web voice calls", () => {
     ).rejects.toThrow("web_voice_rate_limited");
   });
 
+  it("stores web voice callback messages on the web voice call session", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00.000Z"));
+    const { t } = await seedBusiness("web-voice-message");
+
+    const result = await t.mutation(internal.voice.runtime.startWebCall, {
+      businessSlug: "web-voice-message",
+      providerCallId: "call_openai_web_message",
+      gatewaySessionId: "gateway-session-message",
+      startedAt: "2026-05-20T12:00:00.000Z",
+    });
+
+    await t.mutation(internal.voice.runtime.takeMessageForVoice, {
+      businessId: result.businessId,
+      callId: result.callId,
+      conversationId: result.conversationId,
+      channel: "web_voice",
+      callbackPhone: "+14165550123",
+      message: "Please call me tomorrow about pricing.",
+    });
+    await t.mutation(internal.voice.runtime.completeCall, {
+      callId: result.callId,
+      status: "completed",
+      endedAt: "2026-05-20T12:05:00.000Z",
+      disposition: "caller_finished",
+      providerDurationSeconds: 300,
+    });
+
+    await t.run(async (ctx) => {
+      const messages = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation_id", (q) => q.eq("conversationId", result.conversationId))
+        .collect();
+      const session = await ctx.db
+        .query("conversation_sessions")
+        .withIndex("by_call_id", (q) => q.eq("callId", result.callId))
+        .unique();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        channel: "web_voice",
+        body: "Please call me tomorrow about pricing.",
+      });
+      expect(messages[0]?.conversationSessionId).toBe(session?._id);
+      expect(session).toMatchObject({
+        channel: "web_voice",
+        status: "closed",
+        summaryKind: "message_taking",
+      });
+    });
+  });
+
   it("keeps Twilio starts compatible while adding provider metadata", async () => {
     const { t, businessId } = await seedBusiness("twilio-compatible");
 

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -104,16 +104,27 @@ describe("web voice calls", () => {
         .query("conversation_sessions")
         .withIndex("by_call_id", (q) => q.eq("callId", result.callId))
         .unique();
+      const usageEvent = await ctx.db
+        .query("billing_usage_events")
+        .withIndex("by_business_id_and_source_key", (q) =>
+          q.eq("businessId", result.businessId).eq("sourceKey", `voice:${String(result.callId)}`),
+        )
+        .unique();
 
       expect(call).toMatchObject({
         status: "completed",
         disposition: "web_call_stale_timeout",
         endedAt: "2026-05-20T13:00:00.000Z",
+        providerCallDurationSeconds: 3600,
       });
       expect(conversation?.status).toBe("closed");
       expect(session).toMatchObject({
         status: "closed",
         closedAt: Date.parse("2026-05-20T13:00:00.000Z"),
+      });
+      expect(usageEvent).toMatchObject({
+        quantity: 3600,
+        recordedAt: "2026-05-20T13:00:00.000Z",
       });
     });
   });

--- a/convex/tests/webVoiceCalls.test.ts
+++ b/convex/tests/webVoiceCalls.test.ts
@@ -1,0 +1,126 @@
+import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+import { internal } from "../_generated/api";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+async function seedBusiness(slug = "lobbystack") {
+  const t = convexTest(schema, modules);
+  registerRateLimiter(t as unknown as Parameters<typeof registerRateLimiter>[0]);
+  const businessId = await t.run(async (ctx) => {
+    return await ctx.db.insert("businesses", {
+      slug,
+      name: "LobbyStack",
+      timezone: "America/Toronto",
+      businessType: "software",
+      defaultLocale: "en",
+      deploymentMode: "cloud",
+      status: "active",
+    });
+  });
+
+  return { t, businessId };
+}
+
+describe("web voice calls", () => {
+  it("starts provider-neutral web calls without a contact or Twilio SID", async () => {
+    const { t, businessId } = await seedBusiness();
+
+    const result = await t.mutation(internal.voice.runtime.startWebCall, {
+      businessSlug: "lobbystack",
+      providerCallId: "call_openai_web_123",
+      gatewaySessionId: "gateway-session-123",
+      originUrl: "https://lobbystack.com/",
+      userAgent: "vitest",
+      widgetId: "lobbystack-landing",
+      startedAt: "2026-05-19T18:00:00.000Z",
+    });
+
+    await t.run(async (ctx) => {
+      const call = await ctx.db.get(result.callId);
+      const conversation = await ctx.db.get(result.conversationId);
+      const session = await ctx.db
+        .query("conversation_sessions")
+        .withIndex("by_call_id", (q) => q.eq("callId", result.callId))
+        .unique();
+
+      expect(result.businessId).toBe(businessId);
+      expect(call).toMatchObject({
+        businessId,
+        conversationId: result.conversationId,
+        provider: "openai",
+        providerCallId: "call_openai_web_123",
+        transport: "webrtc",
+        originUrl: "https://lobbystack.com/",
+        userAgent: "vitest",
+        widgetId: "lobbystack-landing",
+        status: "in_progress",
+      });
+      expect(call?.twilioCallSid).toBeUndefined();
+      expect(call?.contactId).toBeUndefined();
+      expect(conversation).toMatchObject({
+        businessId,
+        channel: "web_voice",
+        status: "open",
+      });
+      expect(conversation?.contactId).toBeUndefined();
+      expect(session).toMatchObject({
+        businessId,
+        conversationId: result.conversationId,
+        callId: result.callId,
+        channel: "web_voice",
+        status: "active",
+      });
+    });
+  });
+
+  it("rate limits repeated web voice starts for the same IP hash", async () => {
+    const { t, businessId } = await seedBusiness();
+
+    for (let index = 0; index < 5; index += 1) {
+      await t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: "client-ip-hash",
+        visitorId: `visitor-${index}`,
+        widgetId: "lobbystack-landing",
+      });
+    }
+
+    await expect(
+      t.mutation(internal.voice.runtime.assertWebVoiceStartAllowed, {
+        businessId,
+        origin: "https://lobbystack.com",
+        ipHash: "client-ip-hash",
+        visitorId: "visitor-over-limit",
+        widgetId: "lobbystack-landing",
+      }),
+    ).rejects.toThrow("web_voice_rate_limited");
+  });
+
+  it("keeps Twilio starts compatible while adding provider metadata", async () => {
+    const { t, businessId } = await seedBusiness("twilio-compatible");
+
+    const result = await t.mutation(internal.voice.runtime.startCall, {
+      businessId,
+      twilioCallSid: "CA-web-voice-compatible",
+      from: "+14165550123",
+      to: "+14165550999",
+      startedAt: "2026-05-19T18:05:00.000Z",
+    });
+
+    await t.run(async (ctx) => {
+      const call = await ctx.db.get(result.callId);
+
+      expect(call).toMatchObject({
+        twilioCallSid: "CA-web-voice-compatible",
+        provider: "twilio",
+        providerCallId: "CA-web-voice-compatible",
+        transport: "twilio_media_stream",
+        status: "in_progress",
+      });
+    });
+  });
+});

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -117,8 +117,10 @@ async function consumeWebVoiceStartLimit(
       | "webVoiceStartPerBusinessPerHour"
       | "webVoiceStartPerBusinessPerDay"
       | "webVoiceStartPerOriginPerTenMinutes"
-      | "webVoiceStartPerIpPerTenMinutes"
-      | "webVoiceStartPerVisitorPerTenMinutes";
+      | "webVoiceStartPerIpPerHour"
+      | "webVoiceStartPerIpPerDay"
+      | "webVoiceStartPerVisitorPerHour"
+      | "webVoiceStartPerVisitorPerDay";
     key: string;
     reason: string;
     businessId: Id<"businesses">;
@@ -640,18 +642,30 @@ export const assertWebVoiceStartAllowed = internalMutation({
 
     if (args.ipHash !== undefined) {
       await consumeWebVoiceStartLimit(ctx, {
-        limiterName: "webVoiceStartPerIpPerTenMinutes",
+        limiterName: "webVoiceStartPerIpPerHour",
         key: `${businessKey}:ip:${args.ipHash}`,
-        reason: "rate_limit_ip",
+        reason: "rate_limit_ip_hour",
+        ...logContext,
+      });
+      await consumeWebVoiceStartLimit(ctx, {
+        limiterName: "webVoiceStartPerIpPerDay",
+        key: `${businessKey}:ip:${args.ipHash}`,
+        reason: "rate_limit_ip_day",
         ...logContext,
       });
     }
 
     if (args.visitorId !== undefined) {
       await consumeWebVoiceStartLimit(ctx, {
-        limiterName: "webVoiceStartPerVisitorPerTenMinutes",
+        limiterName: "webVoiceStartPerVisitorPerHour",
         key: `${businessKey}:visitor:${args.visitorId}`,
-        reason: "rate_limit_visitor",
+        reason: "rate_limit_visitor_hour",
+        ...logContext,
+      });
+      await consumeWebVoiceStartLimit(ctx, {
+        limiterName: "webVoiceStartPerVisitorPerDay",
+        key: `${businessKey}:visitor:${args.visitorId}`,
+        reason: "rate_limit_visitor_day",
         ...logContext,
       });
     }

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -199,6 +199,7 @@ type TakeMessageForVoiceArgs = {
   businessId: Id<"businesses">;
   callId: Id<"calls">;
   conversationId?: Id<"conversations">;
+  channel?: "voice" | "web_voice";
   callerName?: string;
   callbackPhone?: string;
   message: string;
@@ -1366,6 +1367,7 @@ export const takeMessageForVoice = internalMutation({
     businessId: v.id("businesses"),
     callId: v.id("calls"),
     conversationId: v.optional(v.id("conversations")),
+    channel: v.optional(v.union(v.literal("voice"), v.literal("web_voice"))),
     callerName: v.optional(v.string()),
     callbackPhone: v.optional(v.string()),
     message: v.string(),
@@ -1389,6 +1391,7 @@ export const takeMessageForVoice = internalMutation({
       .filter((line): line is string => Boolean(line))
       .join("\n");
     const contentExpiresAt = getMessageContentExpiresAt();
+    const channel = args.channel ?? "voice";
 
     const inboxItemId = await ctx.db.insert("inbox_items", {
       businessId: args.businessId,
@@ -1407,7 +1410,7 @@ export const takeMessageForVoice = internalMutation({
         businessId: args.businessId,
         conversationId: args.conversationId,
         direction: "inbound",
-        channel: "voice",
+        channel,
         body: args.message,
         status: "captured",
         aiGenerated: false,
@@ -1418,7 +1421,7 @@ export const takeMessageForVoice = internalMutation({
       await ensureSessionForStoredMessage(ctx, {
         businessId: args.businessId,
         conversationId: args.conversationId,
-        channel: "voice",
+        channel,
         messageId,
         callId: args.callId,
       });

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -92,6 +92,7 @@ type StartWebCallResult = {
 };
 
 export const WEB_VOICE_RATE_LIMIT_ERROR = "web_voice_rate_limited";
+const WEB_CALL_STALE_TIMEOUT_MS = 30 * 60 * 1000;
 
 function logWebVoiceRateLimitBlocked(input: {
   limiter: string;
@@ -1046,6 +1047,14 @@ export const startWebCall = internalMutation({
       channel: "web_voice",
     });
 
+    await ctx.scheduler.runAfter(
+      WEB_CALL_STALE_TIMEOUT_MS,
+      internal.voice.runtime.expireStaleWebCall,
+      {
+        callId,
+      },
+    );
+
     await enqueuePostHogOutboxRecord(
       ctx,
       serializePostHogEvent({
@@ -1072,6 +1081,50 @@ export const startWebCall = internalMutation({
       callId,
       conversationId,
     };
+  },
+});
+
+export const expireStaleWebCall = internalMutation({
+  args: {
+    callId: v.id("calls"),
+  },
+  handler: async (ctx, args) => {
+    const call = await ctx.db.get(args.callId);
+    if (!call || call.transport !== "webrtc") {
+      return null;
+    }
+
+    if (call.status !== "in_progress" && call.status !== "open") {
+      return null;
+    }
+
+    const startedAtMs = Date.parse(call.startedAt);
+    if (
+      !Number.isFinite(startedAtMs) ||
+      Date.now() - startedAtMs < WEB_CALL_STALE_TIMEOUT_MS
+    ) {
+      return null;
+    }
+
+    const endedAt = new Date().toISOString();
+    await ctx.db.patch(call._id, {
+      status: "completed",
+      endedAt,
+      disposition: call.disposition ?? "web_call_stale_timeout",
+    });
+
+    if (call.conversationId) {
+      await ctx.db.patch(call.conversationId, {
+        status: "closed",
+      });
+    }
+
+    await finalizeVoiceSessionForCall(ctx, {
+      callId: call._id,
+      endedAt: Date.parse(endedAt),
+    });
+
+    return null;
   },
 });
 

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -30,6 +30,7 @@ import { getOpenConversationForContact } from "../lib/indexedQueries";
 import { buildCallRecordingDownloadUrl } from "../lib/messageAttachmentUrls";
 import { ATTACHMENT_DOWNLOAD_TOKEN_TTL_MS } from "../lib/messageAttachments";
 import { getServiceNameCandidates } from "../lib/serviceNames";
+import { webVoiceAbuseRateLimiter } from "../lib/components";
 import { normalizeRuntimeLocale, type RuntimeLocale } from "../lib/runtimeLocale";
 import {
   CONTACT_BLOCKED_CALL_DISPOSITION,
@@ -75,6 +76,99 @@ type StartCallResult = {
   conversationId?: Id<"conversations">;
   contactId: Id<"contacts">;
 };
+type StartWebCallArgs = {
+  businessSlug: string;
+  providerCallId: string;
+  gatewaySessionId?: string;
+  originUrl?: string;
+  userAgent?: string;
+  widgetId?: string;
+  startedAt: string;
+};
+type StartWebCallResult = {
+  businessId: Id<"businesses">;
+  callId: Id<"calls">;
+  conversationId: Id<"conversations">;
+};
+
+export const WEB_VOICE_RATE_LIMIT_ERROR = "web_voice_rate_limited";
+
+function logWebVoiceRateLimitBlocked(input: {
+  limiter: string;
+  reason: string;
+  businessId: Id<"businesses">;
+  origin?: string;
+  widgetId?: string;
+}) {
+  console.warn(
+    JSON.stringify({
+      scope: "web_voice_abuse_control",
+      decision: "blocked",
+      ...input,
+    }),
+  );
+}
+
+async function consumeWebVoiceStartLimit(
+  ctx: MutationCtx,
+  input: {
+    limiterName:
+      | "webVoiceStartGlobalPerMinute"
+      | "webVoiceStartPerBusinessPerHour"
+      | "webVoiceStartPerBusinessPerDay"
+      | "webVoiceStartPerOriginPerTenMinutes"
+      | "webVoiceStartPerIpPerTenMinutes"
+      | "webVoiceStartPerVisitorPerTenMinutes";
+    key: string;
+    reason: string;
+    businessId: Id<"businesses">;
+    origin?: string;
+    widgetId?: string;
+  },
+): Promise<void> {
+  const result = await webVoiceAbuseRateLimiter.limit(ctx, input.limiterName, {
+    key: input.key,
+  });
+
+  if (!result.ok) {
+    logWebVoiceRateLimitBlocked({
+      limiter: input.limiterName,
+      reason: input.reason,
+      businessId: input.businessId,
+      ...(input.origin !== undefined ? { origin: input.origin } : {}),
+      ...(input.widgetId !== undefined ? { widgetId: input.widgetId } : {}),
+    });
+    throw new Error(WEB_VOICE_RATE_LIMIT_ERROR);
+  }
+}
+
+async function resolveActiveBusinessByPublicSlug(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  businessSlug: string,
+): Promise<Doc<"businesses"> | null> {
+  const business = await ctx.db
+    .query("businesses")
+    .withIndex("by_slug", (q) => q.eq("slug", businessSlug))
+    .unique();
+
+  if (business?.status === "active") {
+    return business;
+  }
+
+  if (businessSlug !== "lobbystack") {
+    return null;
+  }
+
+  const lobbystackBusinesses = await ctx.db
+    .query("businesses")
+    .filter((q) => q.eq(q.field("name"), "LobbyStack"))
+    .collect();
+  return (
+    lobbystackBusinesses
+      .filter((candidate) => candidate.status === "active")
+      .sort((a, b) => b._creationTime - a._creationTime)[0] ?? null
+  );
+}
 type AppendTranscriptArgs = {
   businessId: Id<"businesses">;
   callId: Id<"calls">;
@@ -494,6 +588,78 @@ export const getBusinessDefaultLocale = internalQuery({
   },
 });
 
+export const getActiveBusinessBySlug = internalQuery({
+  args: {
+    businessSlug: v.string(),
+  },
+  handler: async (ctx: QueryCtx, args) => {
+    return await resolveActiveBusinessByPublicSlug(ctx, args.businessSlug);
+  },
+});
+
+export const assertWebVoiceStartAllowed = internalMutation({
+  args: {
+    businessId: v.id("businesses"),
+    origin: v.string(),
+    ipHash: v.optional(v.string()),
+    visitorId: v.optional(v.string()),
+    widgetId: v.optional(v.string()),
+  },
+  handler: async (ctx: MutationCtx, args): Promise<null> => {
+    const businessKey = String(args.businessId);
+    const logContext = {
+      businessId: args.businessId,
+      origin: args.origin,
+      ...(args.widgetId !== undefined ? { widgetId: args.widgetId } : {}),
+    };
+
+    await consumeWebVoiceStartLimit(ctx, {
+      limiterName: "webVoiceStartGlobalPerMinute",
+      key: "global",
+      reason: "rate_limit_global",
+      ...logContext,
+    });
+    await consumeWebVoiceStartLimit(ctx, {
+      limiterName: "webVoiceStartPerBusinessPerHour",
+      key: businessKey,
+      reason: "rate_limit_business_hour",
+      ...logContext,
+    });
+    await consumeWebVoiceStartLimit(ctx, {
+      limiterName: "webVoiceStartPerBusinessPerDay",
+      key: businessKey,
+      reason: "rate_limit_business_day",
+      ...logContext,
+    });
+    await consumeWebVoiceStartLimit(ctx, {
+      limiterName: "webVoiceStartPerOriginPerTenMinutes",
+      key: args.origin,
+      reason: "rate_limit_origin",
+      ...logContext,
+    });
+
+    if (args.ipHash !== undefined) {
+      await consumeWebVoiceStartLimit(ctx, {
+        limiterName: "webVoiceStartPerIpPerTenMinutes",
+        key: `${businessKey}:ip:${args.ipHash}`,
+        reason: "rate_limit_ip",
+        ...logContext,
+      });
+    }
+
+    if (args.visitorId !== undefined) {
+      await consumeWebVoiceStartLimit(ctx, {
+        limiterName: "webVoiceStartPerVisitorPerTenMinutes",
+        key: `${businessKey}:visitor:${args.visitorId}`,
+        reason: "rate_limit_visitor",
+        ...logContext,
+      });
+    }
+
+    return null;
+  },
+});
+
 export const getActiveStaffAssignmentsForService = internalQuery({
   args: {
     businessId: v.id("businesses"),
@@ -619,6 +785,9 @@ export const startCall = internalMutation({
           businessId: args.businessId,
           contactId: contact._id,
           twilioCallSid: args.twilioCallSid,
+          provider: "twilio",
+          providerCallId: args.twilioCallSid,
+          transport: "twilio_media_stream",
           ...(args.gatewaySessionId !== undefined
             ? { gatewaySessionId: args.gatewaySessionId }
             : {}),
@@ -684,6 +853,9 @@ export const startCall = internalMutation({
         conversationId,
         contactId: contact._id,
         twilioCallSid: args.twilioCallSid,
+        provider: "twilio",
+        providerCallId: args.twilioCallSid,
+        transport: "twilio_media_stream",
         ...(args.gatewaySessionId !== undefined
           ? { gatewaySessionId: args.gatewaySessionId }
           : {}),
@@ -744,6 +916,147 @@ export const startCall = internalMutation({
       conversationId,
       blocked: false,
       contactId: contact._id,
+    };
+  },
+});
+
+export const startWebCall = internalMutation({
+  args: {
+    businessSlug: v.string(),
+    providerCallId: v.string(),
+    gatewaySessionId: v.optional(v.string()),
+    originUrl: v.optional(v.string()),
+    userAgent: v.optional(v.string()),
+    widgetId: v.optional(v.string()),
+    startedAt: v.string(),
+  },
+  handler: async (
+    ctx: MutationCtx,
+    args: StartWebCallArgs,
+  ): Promise<StartWebCallResult> => {
+    const business = await resolveActiveBusinessByPublicSlug(ctx, args.businessSlug);
+
+    if (!business) {
+      throw new Error("Web voice business not found.");
+    }
+
+    const existingCall: Doc<"calls"> | null = await ctx.db
+      .query("calls")
+      .withIndex("by_provider_and_provider_call_id", (q) =>
+        q.eq("provider", "openai").eq("providerCallId", args.providerCallId),
+      )
+      .unique();
+
+    if (existingCall?.conversationId) {
+      return {
+        businessId: business._id,
+        callId: existingCall._id,
+        conversationId: existingCall.conversationId,
+      };
+    }
+
+    const voicePolicy: {
+      allowed: boolean;
+      errorCode: BillingErrorCode | null;
+    } = await ctx.runQuery(internal.billing.assertVoiceCanStart, {
+      businessId: business._id,
+    });
+    if (!voicePolicy.allowed) {
+      throw new Error(voicePolicy.errorCode ?? billingErrorCodes.voiceLimitReached);
+    }
+
+    const conversationId = await ctx.db.insert("conversations", {
+      businessId: business._id,
+      channel: "web_voice",
+      status: "open",
+    });
+
+    const callId =
+      existingCall?._id ??
+      (await ctx.db.insert("calls", {
+        businessId: business._id,
+        conversationId,
+        provider: "openai",
+        providerCallId: args.providerCallId,
+        transport: "webrtc",
+        ...(args.originUrl !== undefined ? { originUrl: args.originUrl } : {}),
+        ...(args.userAgent !== undefined ? { userAgent: args.userAgent } : {}),
+        ...(args.widgetId !== undefined ? { widgetId: args.widgetId } : {}),
+        ...(args.gatewaySessionId !== undefined
+          ? { gatewaySessionId: args.gatewaySessionId }
+          : {}),
+        status: "in_progress",
+        startedAt: args.startedAt,
+      }));
+
+    if (existingCall) {
+      await ctx.db.patch(existingCall._id, {
+        conversationId,
+        status: "in_progress",
+        ...(args.originUrl !== undefined ? { originUrl: args.originUrl } : {}),
+        ...(args.userAgent !== undefined ? { userAgent: args.userAgent } : {}),
+        ...(args.widgetId !== undefined ? { widgetId: args.widgetId } : {}),
+        ...(args.gatewaySessionId !== undefined
+          ? { gatewaySessionId: args.gatewaySessionId }
+          : {}),
+      });
+    }
+
+    const reservation = await ctx.runMutation(internal.billing.reserveVoiceUsageAtCallStart, {
+      businessId: business._id,
+      callId,
+      recordedAt: args.startedAt,
+    });
+    if (!reservation.allowed) {
+      await ctx.db.patch(callId, {
+        status: "completed",
+        endedAt: args.startedAt,
+        disposition: reservation.errorCode ?? billingErrorCodes.voiceLimitReached,
+      });
+      await ctx.db.patch(conversationId, {
+        status: "closed",
+      });
+      throw new Error(reservation.errorCode ?? billingErrorCodes.voiceLimitReached);
+    }
+    if (reservation.syncNeeded && reservation.usageEventId) {
+      await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+        usageEventId: reservation.usageEventId,
+      });
+    }
+
+    await ensureVoiceSessionForCall(ctx, {
+      businessId: business._id,
+      conversationId,
+      callId,
+      startedAt: Date.parse(args.startedAt),
+      channel: "web_voice",
+    });
+
+    await enqueuePostHogOutboxRecord(
+      ctx,
+      serializePostHogEvent({
+        eventName: "voice.call_started",
+        businessId: business._id,
+        distinctId: getPostHogDistinctIdForBusinessSystem(String(business._id)),
+        groupKey: getPostHogBusinessGroupKey(String(business._id)),
+        conversationId: String(conversationId),
+        callId: String(callId),
+        channel: "web_voice",
+        provider: "openai",
+        properties: {
+          status: "in_progress",
+          transport: "webrtc",
+          gatewaySessionId: args.gatewaySessionId,
+          originUrl: args.originUrl,
+          widgetId: args.widgetId,
+        },
+      }),
+    );
+
+    return {
+      businessId: business._id,
+      callId,
+      conversationId,
     };
   },
 });
@@ -1182,11 +1495,12 @@ export const completeCall = internalMutation({
         groupKey: getPostHogBusinessGroupKey(String(call.businessId)),
         ...(call.conversationId ? { conversationId: String(call.conversationId) } : {}),
         callId: String(args.callId),
-        channel: "voice",
-        provider: "twilio",
+        channel: call.transport === "webrtc" ? "web_voice" : "voice",
+        provider: call.provider ?? (call.twilioCallSid ? "twilio" : "openai"),
         properties: {
           status: args.status,
           disposition,
+          ...(call.transport !== undefined ? { transport: call.transport } : {}),
         },
       }),
     );
@@ -1367,6 +1681,10 @@ export const reconcileTwilioCallStatus = internalMutation({
     if (!call) {
       return { ignored: true, reason: "unknown_call" } as const;
     }
+    if (!call.twilioCallSid) {
+      return { ignored: true, reason: "unknown_call" } as const;
+    }
+    const twilioCallSid = call.twilioCallSid;
 
     if (
       call.providerCallStatusSequence !== undefined &&
@@ -1458,7 +1776,7 @@ export const reconcileTwilioCallStatus = internalMutation({
         businessId: call.businessId,
         ...(call.conversationId ? { conversationId: call.conversationId } : {}),
         callId: call._id,
-        twilioCallSid: call.twilioCallSid,
+        twilioCallSid,
         providerCostUsd: estimatedProviderCostUsd,
         providerUpdatedAt: args.providerUpdatedAt,
         providerPriceUnit: "usd",
@@ -1488,7 +1806,7 @@ export const reconcileTwilioCallStatus = internalMutation({
           0,
           internal.integrations.twilioVoice.syncCallPriceFromProvider,
           {
-            twilioCallSid: call.twilioCallSid,
+            twilioCallSid,
             providerCallStatus: args.callStatus,
           },
         );

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -350,6 +350,7 @@ type BookAppointmentForVoiceArgs = {
   serviceName: string;
   startsAt: string;
   timezone: string;
+  channel?: "voice" | "web_voice";
   preferredStaffId?: Id<"staff">;
   conversationId?: Id<"conversations">;
   contactName?: string;
@@ -2116,6 +2117,7 @@ export const bookAppointmentForVoice = internalAction({
     serviceName: v.string(),
     startsAt: v.string(),
     timezone: v.string(),
+    channel: v.optional(v.union(v.literal("voice"), v.literal("web_voice"))),
     preferredStaffId: v.optional(v.id("staff")),
     conversationId: v.optional(v.id("conversations")),
     contactName: v.optional(v.string()),
@@ -2151,7 +2153,7 @@ export const bookAppointmentForVoice = internalAction({
           : {}),
         ...(args.contactName !== undefined ? { contactName: args.contactName } : {}),
         contactPhone: args.contactPhone,
-        sourceChannel: "voice",
+        sourceChannel: args.channel ?? "voice",
       },
     );
 

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -105,6 +105,25 @@ type WebCallRecordingTarget = {
 
 export const WEB_VOICE_RATE_LIMIT_ERROR = "web_voice_rate_limited";
 
+type WebVoiceStartLimiterName =
+  | "webVoiceStartGlobalPerMinute"
+  | "webVoiceStartPerBusinessPerHour"
+  | "webVoiceStartPerBusinessPerDay"
+  | "webVoiceStartPerOriginPerTenMinutes"
+  | "webVoiceStartPerIpPerHour"
+  | "webVoiceStartPerIpPerDay"
+  | "webVoiceStartPerVisitorPerHour"
+  | "webVoiceStartPerVisitorPerDay";
+
+type WebVoiceStartLimit = {
+  limiterName: WebVoiceStartLimiterName;
+  key: string;
+  reason: string;
+  businessId: Id<"businesses">;
+  origin?: string;
+  widgetId?: string;
+};
+
 function getWebCallMaxDurationMs(maxDurationMs: number | undefined): number {
   if (maxDurationMs === undefined || !Number.isFinite(maxDurationMs) || maxDurationMs <= 0) {
     return DEFAULT_WEB_CALL_MAX_DURATION_MS;
@@ -134,22 +153,7 @@ function logWebVoiceRateLimitBlocked(input: {
 
 async function consumeWebVoiceStartLimit(
   ctx: MutationCtx,
-  input: {
-    limiterName:
-      | "webVoiceStartGlobalPerMinute"
-      | "webVoiceStartPerBusinessPerHour"
-      | "webVoiceStartPerBusinessPerDay"
-      | "webVoiceStartPerOriginPerTenMinutes"
-      | "webVoiceStartPerIpPerHour"
-      | "webVoiceStartPerIpPerDay"
-      | "webVoiceStartPerVisitorPerHour"
-      | "webVoiceStartPerVisitorPerDay";
-    key: string;
-    reason: string;
-    businessId: Id<"businesses">;
-    origin?: string;
-    widgetId?: string;
-  },
+  input: WebVoiceStartLimit,
 ): Promise<void> {
   const result = await webVoiceAbuseRateLimiter.limit(ctx, input.limiterName, {
     key: input.key,
@@ -164,6 +168,106 @@ async function consumeWebVoiceStartLimit(
       ...(input.widgetId !== undefined ? { widgetId: input.widgetId } : {}),
     });
     throw new Error(WEB_VOICE_RATE_LIMIT_ERROR);
+  }
+}
+
+function buildWebVoiceStartLimits(input: {
+  businessId: Id<"businesses">;
+  origin: string;
+  ipHash?: string;
+  visitorId?: string;
+  widgetId?: string;
+}): Array<WebVoiceStartLimit> {
+  const businessKey = String(input.businessId);
+  const logContext = {
+    businessId: input.businessId,
+    origin: input.origin,
+    ...(input.widgetId !== undefined ? { widgetId: input.widgetId } : {}),
+  };
+  const limits: Array<WebVoiceStartLimit> = [];
+
+  if (input.ipHash !== undefined) {
+    limits.push(
+      {
+        limiterName: "webVoiceStartPerIpPerHour",
+        key: `${businessKey}:ip:${input.ipHash}`,
+        reason: "rate_limit_ip_hour",
+        ...logContext,
+      },
+      {
+        limiterName: "webVoiceStartPerIpPerDay",
+        key: `${businessKey}:ip:${input.ipHash}`,
+        reason: "rate_limit_ip_day",
+        ...logContext,
+      },
+    );
+  }
+
+  if (input.visitorId !== undefined) {
+    limits.push(
+      {
+        limiterName: "webVoiceStartPerVisitorPerHour",
+        key: `${businessKey}:visitor:${input.visitorId}`,
+        reason: "rate_limit_visitor_hour",
+        ...logContext,
+      },
+      {
+        limiterName: "webVoiceStartPerVisitorPerDay",
+        key: `${businessKey}:visitor:${input.visitorId}`,
+        reason: "rate_limit_visitor_day",
+        ...logContext,
+      },
+    );
+  }
+
+  limits.push(
+    {
+      limiterName: "webVoiceStartPerOriginPerTenMinutes",
+      key: input.origin,
+      reason: "rate_limit_origin",
+      ...logContext,
+    },
+    {
+      limiterName: "webVoiceStartPerBusinessPerHour",
+      key: businessKey,
+      reason: "rate_limit_business_hour",
+      ...logContext,
+    },
+    {
+      limiterName: "webVoiceStartPerBusinessPerDay",
+      key: businessKey,
+      reason: "rate_limit_business_day",
+      ...logContext,
+    },
+    {
+      limiterName: "webVoiceStartGlobalPerMinute",
+      key: "global",
+      reason: "rate_limit_global",
+      ...logContext,
+    },
+  );
+
+  return limits;
+}
+
+async function assertWebVoiceStartLimitsAvailable(
+  ctx: MutationCtx,
+  limits: Array<WebVoiceStartLimit>,
+): Promise<void> {
+  for (const limit of limits) {
+    const result = await webVoiceAbuseRateLimiter.check(ctx, limit.limiterName, {
+      key: limit.key,
+    });
+    if (!result.ok) {
+      logWebVoiceRateLimitBlocked({
+        limiter: limit.limiterName,
+        reason: limit.reason,
+        businessId: limit.businessId,
+        ...(limit.origin !== undefined ? { origin: limit.origin } : {}),
+        ...(limit.widgetId !== undefined ? { widgetId: limit.widgetId } : {}),
+      });
+      throw new Error(WEB_VOICE_RATE_LIMIT_ERROR);
+    }
   }
 }
 
@@ -617,66 +721,30 @@ export const assertWebVoiceStartAllowed = internalMutation({
     widgetId: v.optional(v.string()),
   },
   handler: async (ctx: MutationCtx, args): Promise<null> => {
-    const businessKey = String(args.businessId);
-    const logContext = {
-      businessId: args.businessId,
-      origin: args.origin,
-      ...(args.widgetId !== undefined ? { widgetId: args.widgetId } : {}),
-    };
+    const limits = buildWebVoiceStartLimits(args);
 
-    await consumeWebVoiceStartLimit(ctx, {
-      limiterName: "webVoiceStartGlobalPerMinute",
-      key: "global",
-      reason: "rate_limit_global",
-      ...logContext,
-    });
-    await consumeWebVoiceStartLimit(ctx, {
-      limiterName: "webVoiceStartPerBusinessPerHour",
-      key: businessKey,
-      reason: "rate_limit_business_hour",
-      ...logContext,
-    });
-    await consumeWebVoiceStartLimit(ctx, {
-      limiterName: "webVoiceStartPerBusinessPerDay",
-      key: businessKey,
-      reason: "rate_limit_business_day",
-      ...logContext,
-    });
-    await consumeWebVoiceStartLimit(ctx, {
-      limiterName: "webVoiceStartPerOriginPerTenMinutes",
-      key: args.origin,
-      reason: "rate_limit_origin",
-      ...logContext,
-    });
-
-    if (args.ipHash !== undefined) {
-      await consumeWebVoiceStartLimit(ctx, {
-        limiterName: "webVoiceStartPerIpPerHour",
-        key: `${businessKey}:ip:${args.ipHash}`,
-        reason: "rate_limit_ip_hour",
-        ...logContext,
-      });
-      await consumeWebVoiceStartLimit(ctx, {
-        limiterName: "webVoiceStartPerIpPerDay",
-        key: `${businessKey}:ip:${args.ipHash}`,
-        reason: "rate_limit_ip_day",
-        ...logContext,
-      });
+    await assertWebVoiceStartLimitsAvailable(ctx, limits);
+    for (const limit of limits) {
+      await consumeWebVoiceStartLimit(ctx, limit);
     }
 
-    if (args.visitorId !== undefined) {
-      await consumeWebVoiceStartLimit(ctx, {
-        limiterName: "webVoiceStartPerVisitorPerHour",
-        key: `${businessKey}:visitor:${args.visitorId}`,
-        reason: "rate_limit_visitor_hour",
-        ...logContext,
-      });
-      await consumeWebVoiceStartLimit(ctx, {
-        limiterName: "webVoiceStartPerVisitorPerDay",
-        key: `${businessKey}:visitor:${args.visitorId}`,
-        reason: "rate_limit_visitor_day",
-        ...logContext,
-      });
+    return null;
+  },
+});
+
+export const assertWebVoiceBillingCanStart = internalQuery({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  handler: async (ctx: QueryCtx, args): Promise<null> => {
+    const voicePolicy: {
+      allowed: boolean;
+      errorCode: BillingErrorCode | null;
+    } = await ctx.runQuery(internal.billing.assertVoiceCanStart, {
+      businessId: args.businessId,
+    });
+    if (!voicePolicy.allowed) {
+      throw new Error(voicePolicy.errorCode ?? billingErrorCodes.voiceLimitReached);
     }
 
     return null;

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -98,6 +98,7 @@ type StartWebCallResult = {
 };
 type WebCallRecordingTarget = {
   callId: Id<"calls">;
+  providerCallId?: string;
   startedAt: string;
   endedAt?: string;
   status: string;
@@ -767,6 +768,7 @@ export const getWebCallRecordingTarget = internalQuery({
 
     return {
       callId: call._id,
+      ...(call.providerCallId !== undefined ? { providerCallId: call.providerCallId } : {}),
       startedAt: call.startedAt,
       ...(call.endedAt !== undefined ? { endedAt: call.endedAt } : {}),
       status: call.status,

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -6,6 +6,11 @@ import { observedInternalMutation as internalMutation, observedMutation as mutat
 import type { BillingErrorCode } from "../../packages/shared/src/billing";
 import { billingErrorCodes } from "../../packages/shared/src/billing";
 import {
+  DEFAULT_WEB_CALL_MAX_DURATION_MS,
+  MAX_WEB_CALL_MAX_DURATION_MS,
+  WEB_CALL_STALE_GRACE_MS,
+} from "../../packages/shared/src/index";
+import {
   getPostHogBusinessGroupKey,
   getPostHogDistinctIdForBusinessSystem,
   } from "../telemetry/shared";
@@ -83,6 +88,7 @@ type StartWebCallArgs = {
   originUrl?: string;
   userAgent?: string;
   widgetId?: string;
+  maxDurationMs?: number;
   startedAt: string;
 };
 type StartWebCallResult = {
@@ -90,9 +96,25 @@ type StartWebCallResult = {
   callId: Id<"calls">;
   conversationId: Id<"conversations">;
 };
+type WebCallRecordingTarget = {
+  callId: Id<"calls">;
+  startedAt: string;
+  endedAt?: string;
+  status: string;
+};
 
 export const WEB_VOICE_RATE_LIMIT_ERROR = "web_voice_rate_limited";
-const WEB_CALL_STALE_TIMEOUT_MS = 30 * 60 * 1000;
+
+function getWebCallMaxDurationMs(maxDurationMs: number | undefined): number {
+  if (maxDurationMs === undefined || !Number.isFinite(maxDurationMs) || maxDurationMs <= 0) {
+    return DEFAULT_WEB_CALL_MAX_DURATION_MS;
+  }
+  return Math.min(maxDurationMs, MAX_WEB_CALL_MAX_DURATION_MS);
+}
+
+function getWebCallStaleTimeoutMs(maxDurationMs: number | undefined): number {
+  return getWebCallMaxDurationMs(maxDurationMs) + WEB_CALL_STALE_GRACE_MS;
+}
 
 function logWebVoiceRateLimitBlocked(input: {
   limiter: string;
@@ -149,28 +171,12 @@ async function resolveActiveBusinessByPublicSlug(
   ctx: Pick<QueryCtx | MutationCtx, "db">,
   businessSlug: string,
 ): Promise<Doc<"businesses"> | null> {
-  const business = await ctx.db
+  const businesses = await ctx.db
     .query("businesses")
     .withIndex("by_slug", (q) => q.eq("slug", businessSlug))
-    .unique();
+    .take(10);
 
-  if (business?.status === "active") {
-    return business;
-  }
-
-  if (businessSlug !== "lobbystack") {
-    return null;
-  }
-
-  const lobbystackBusinesses = await ctx.db
-    .query("businesses")
-    .filter((q) => q.eq(q.field("name"), "LobbyStack"))
-    .collect();
-  return (
-    lobbystackBusinesses
-      .filter((candidate) => candidate.status === "active")
-      .sort((a, b) => b._creationTime - a._creationTime)[0] ?? null
-  );
+  return businesses.find((business) => business.status === "active") ?? null;
 }
 type AppendTranscriptArgs = {
   businessId: Id<"businesses">;
@@ -676,6 +682,28 @@ export const assertWebVoiceStartAllowed = internalMutation({
   },
 });
 
+export const getWebCallRecordingTarget = internalQuery({
+  args: {
+    gatewaySessionId: v.string(),
+  },
+  handler: async (ctx: QueryCtx, args): Promise<WebCallRecordingTarget | null> => {
+    const call = await ctx.db
+      .query("calls")
+      .withIndex("by_gateway_session_id", (q) => q.eq("gatewaySessionId", args.gatewaySessionId))
+      .unique();
+    if (!call || call.transport !== "webrtc") {
+      return null;
+    }
+
+    return {
+      callId: call._id,
+      startedAt: call.startedAt,
+      ...(call.endedAt !== undefined ? { endedAt: call.endedAt } : {}),
+      status: call.status,
+    };
+  },
+});
+
 export const getActiveStaffAssignmentsForService = internalQuery({
   args: {
     businessId: v.id("businesses"),
@@ -944,6 +972,7 @@ export const startWebCall = internalMutation({
     originUrl: v.optional(v.string()),
     userAgent: v.optional(v.string()),
     widgetId: v.optional(v.string()),
+    maxDurationMs: v.optional(v.number()),
     startedAt: v.string(),
   },
   handler: async (
@@ -964,11 +993,18 @@ export const startWebCall = internalMutation({
       .unique();
 
     if (existingCall?.conversationId) {
+      if (existingCall.businessId !== business._id) {
+        throw new Error("Web voice provider call belongs to a different business.");
+      }
       return {
-        businessId: business._id,
+        businessId: existingCall.businessId,
         callId: existingCall._id,
         conversationId: existingCall.conversationId,
       };
+    }
+
+    if (existingCall && existingCall.businessId !== business._id) {
+      throw new Error("Web voice provider call belongs to a different business.");
     }
 
     const voicePolicy: {
@@ -1001,6 +1037,7 @@ export const startWebCall = internalMutation({
         ...(args.gatewaySessionId !== undefined
           ? { gatewaySessionId: args.gatewaySessionId }
           : {}),
+        webCallMaxDurationMs: getWebCallMaxDurationMs(args.maxDurationMs),
         status: "in_progress",
         startedAt: args.startedAt,
       }));
@@ -1015,6 +1052,7 @@ export const startWebCall = internalMutation({
         ...(args.gatewaySessionId !== undefined
           ? { gatewaySessionId: args.gatewaySessionId }
           : {}),
+        webCallMaxDurationMs: getWebCallMaxDurationMs(args.maxDurationMs),
       });
     }
 
@@ -1049,7 +1087,7 @@ export const startWebCall = internalMutation({
     });
 
     await ctx.scheduler.runAfter(
-      WEB_CALL_STALE_TIMEOUT_MS,
+      getWebCallStaleTimeoutMs(args.maxDurationMs),
       internal.voice.runtime.expireStaleWebCall,
       {
         callId,
@@ -1071,6 +1109,7 @@ export const startWebCall = internalMutation({
           status: "in_progress",
           transport: "webrtc",
           gatewaySessionId: args.gatewaySessionId,
+          webCallMaxDurationMs: getWebCallMaxDurationMs(args.maxDurationMs),
           originUrl: args.originUrl,
           widgetId: args.widgetId,
         },
@@ -1100,16 +1139,19 @@ export const expireStaleWebCall = internalMutation({
     }
 
     const startedAtMs = Date.parse(call.startedAt);
+    const maxDurationMs = getWebCallMaxDurationMs(call.webCallMaxDurationMs);
     if (
       !Number.isFinite(startedAtMs) ||
-      Date.now() - startedAtMs < WEB_CALL_STALE_TIMEOUT_MS
+      Date.now() - startedAtMs < getWebCallStaleTimeoutMs(maxDurationMs)
     ) {
       return null;
     }
 
     const endedAtMs = Date.now();
     const endedAt = new Date(endedAtMs).toISOString();
-    const providerDurationSeconds = Math.ceil((endedAtMs - startedAtMs) / 1000);
+    const providerDurationSeconds = Math.ceil(
+      Math.min(endedAtMs - startedAtMs, maxDurationMs) / 1000,
+    );
     await ctx.db.patch(call._id, {
       status: "completed",
       endedAt,

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -1106,11 +1106,16 @@ export const expireStaleWebCall = internalMutation({
       return null;
     }
 
-    const endedAt = new Date().toISOString();
+    const endedAtMs = Date.now();
+    const endedAt = new Date(endedAtMs).toISOString();
+    const providerDurationSeconds = Math.ceil((endedAtMs - startedAtMs) / 1000);
     await ctx.db.patch(call._id, {
       status: "completed",
       endedAt,
       disposition: call.disposition ?? "web_call_stale_timeout",
+      ...(call.providerCallDurationSeconds === undefined
+        ? { providerCallDurationSeconds: providerDurationSeconds }
+        : {}),
     });
 
     if (call.conversationId) {
@@ -1121,8 +1126,23 @@ export const expireStaleWebCall = internalMutation({
 
     await finalizeVoiceSessionForCall(ctx, {
       callId: call._id,
-      endedAt: Date.parse(endedAt),
+      endedAt: endedAtMs,
     });
+
+    if (call.providerCallDurationSeconds === undefined) {
+      const usageResult = await ctx.runMutation(internal.billing.recordVoiceUsage, {
+        businessId: call.businessId,
+        callId: call._id,
+        quantity: providerDurationSeconds,
+        recordedAt: endedAt,
+      });
+
+      if (usageResult.syncNeeded) {
+        await ctx.scheduler.runAfter(0, internal.billing.syncUsageEventToPolar, {
+          usageEventId: usageResult.usageEventId,
+        });
+      }
+    }
 
     return null;
   },

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -101,6 +101,7 @@ type WebCallRecordingTarget = {
   startedAt: string;
   endedAt?: string;
   status: string;
+  webCallMaxDurationMs?: number;
 };
 
 export const WEB_VOICE_RATE_LIMIT_ERROR = "web_voice_rate_limited";
@@ -769,6 +770,9 @@ export const getWebCallRecordingTarget = internalQuery({
       startedAt: call.startedAt,
       ...(call.endedAt !== undefined ? { endedAt: call.endedAt } : {}),
       status: call.status,
+      ...(call.webCallMaxDurationMs !== undefined
+        ? { webCallMaxDurationMs: call.webCallMaxDurationMs }
+        : {}),
     };
   },
 });

--- a/docs/deployment/fly-voice-gateway.md
+++ b/docs/deployment/fly-voice-gateway.md
@@ -38,6 +38,7 @@ fly apps create <your-app-name>
 ```bash
 fly secrets set -a <your-app-name> \
   DEPLOYMENT_MODE=development \
+  VOICE_GATEWAY_TRUST_PROXY=true \
   VOICE_GATEWAY_BASE_URL=https://<your-app-name>.fly.dev \
   CONVEX_SITE_URL=<your-convex-site-url> \
   INTERNAL_SERVICE_TOKEN=<your-internal-service-token> \
@@ -89,6 +90,7 @@ POST https://<your-app-name>.fly.dev/twilio/voice/inbound
 ## Notes
 
 - `DEPLOYMENT_MODE=development` is intentional for the first validation pass. It keeps the current development-only fallbacks while we finish provider validation.
+- `VOICE_GATEWAY_TRUST_PROXY=true` is required on Fly so web voice abuse limits use the visitor IP from Fly's trusted proxy headers instead of the Fly proxy address.
 - If PostHog does not auto-price your configured `OPENAI_REALTIME_MODEL`, set the optional `OPENAI_REALTIME_*_TOKEN_PRICE_USD` secrets so the gateway can emit `$ai_total_cost_usd` from token usage.
 - For voice calls, prefer the explicit text/audio token price secrets over the legacy generic input/output ones so the gateway can price Realtime audio and text buckets accurately.
 - If `input_audio_transcription` is enabled, set the optional `OPENAI_TRANSCRIPTION_*_TOKEN_PRICE_USD` secrets too so the gateway can include separate transcription usage in the per-call OpenAI cost.

--- a/docs/deployment/fly-voice-gateway.md
+++ b/docs/deployment/fly-voice-gateway.md
@@ -90,7 +90,7 @@ POST https://<your-app-name>.fly.dev/twilio/voice/inbound
 ## Notes
 
 - `DEPLOYMENT_MODE=development` is intentional for the first validation pass. It keeps the current development-only fallbacks while we finish provider validation.
-- `VOICE_GATEWAY_TRUST_PROXY=true` is required on Fly so web voice abuse limits use the visitor IP from Fly's trusted proxy headers instead of the Fly proxy address.
+- `VOICE_GATEWAY_TRUST_PROXY=true` trusts only loopback/link-local/private proxy ranges for client IP derivation. Use an explicit comma-separated CIDR list if your ingress proxy uses public source ranges.
 - If PostHog does not auto-price your configured `OPENAI_REALTIME_MODEL`, set the optional `OPENAI_REALTIME_*_TOKEN_PRICE_USD` secrets so the gateway can emit `$ai_total_cost_usd` from token usage.
 - For voice calls, prefer the explicit text/audio token price secrets over the legacy generic input/output ones so the gateway can price Realtime audio and text buckets accurately.
 - If `input_audio_transcription` is enabled, set the optional `OPENAI_TRANSCRIPTION_*_TOKEN_PRICE_USD` secrets too so the gateway can include separate transcription usage in the per-call OpenAI cost.

--- a/fly.voice-gateway.production.toml
+++ b/fly.voice-gateway.production.toml
@@ -10,6 +10,7 @@ primary_region = "iad"
 [env]
   DEPLOYMENT_MODE = "cloud"
   PORT = "3001"
+  VOICE_GATEWAY_TRUST_PROXY = "true"
 
 [http_service]
   internal_port = 3001

--- a/fly.voice-gateway.toml
+++ b/fly.voice-gateway.toml
@@ -8,6 +8,7 @@ primary_region = "iad"
 
 [env]
   PORT = "3001"
+  VOICE_GATEWAY_TRUST_PROXY = "true"
 
 [http_service]
   internal_port = 3001

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -28,4 +28,15 @@ describe("loadVoiceGatewayEnv", () => {
       }).DEPLOYMENT_MODE,
     ).toBe("development");
   });
+
+  it("defaults web call allowed origins to production-safe origins", () => {
+    const env = loadVoiceGatewayEnv({
+      ...baseVoiceGatewayEnv,
+      DEPLOYMENT_MODE: "cloud",
+    });
+
+    expect(env.WEB_CALL_ALLOWED_ORIGINS).toBe("https://lobbystack.com");
+    expect(env.WEB_CALL_ALLOWED_ORIGINS).not.toContain("localhost");
+    expect(env.WEB_CALL_ALLOWED_ORIGINS).not.toContain("127.0.0.1");
+  });
 });

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -47,7 +47,13 @@ describe("loadVoiceGatewayEnv", () => {
         ...baseVoiceGatewayEnv,
         VOICE_GATEWAY_TRUST_PROXY: "true",
       }).VOICE_GATEWAY_TRUST_PROXY,
-    ).toBe(true);
+    ).toEqual(["loopback", "linklocal", "uniquelocal"]);
+    expect(
+      loadVoiceGatewayEnv({
+        ...baseVoiceGatewayEnv,
+        VOICE_GATEWAY_TRUST_PROXY: "10.0.0.0/8, 192.168.0.0/16",
+      }).VOICE_GATEWAY_TRUST_PROXY,
+    ).toEqual(["10.0.0.0/8", "192.168.0.0/16"]);
   });
 
   it("rejects web call max durations above the Convex stale timeout window", () => {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -40,6 +40,16 @@ describe("loadVoiceGatewayEnv", () => {
     expect(env.WEB_CALL_ALLOWED_ORIGINS).not.toContain("127.0.0.1");
   });
 
+  it("does not trust proxy headers unless explicitly enabled", () => {
+    expect(loadVoiceGatewayEnv(baseVoiceGatewayEnv).VOICE_GATEWAY_TRUST_PROXY).toBe(false);
+    expect(
+      loadVoiceGatewayEnv({
+        ...baseVoiceGatewayEnv,
+        VOICE_GATEWAY_TRUST_PROXY: "true",
+      }).VOICE_GATEWAY_TRUST_PROXY,
+    ).toBe(true);
+  });
+
   it("rejects web call max durations above the Convex stale timeout window", () => {
     expect(() =>
       loadVoiceGatewayEnv({

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -39,4 +39,13 @@ describe("loadVoiceGatewayEnv", () => {
     expect(env.WEB_CALL_ALLOWED_ORIGINS).not.toContain("localhost");
     expect(env.WEB_CALL_ALLOWED_ORIGINS).not.toContain("127.0.0.1");
   });
+
+  it("rejects web call max durations above the Convex stale timeout window", () => {
+    expect(() =>
+      loadVoiceGatewayEnv({
+        ...baseVoiceGatewayEnv,
+        WEB_CALL_MAX_DURATION_MS: String(31 * 60 * 1000),
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -96,6 +96,7 @@ const voiceGatewayEnvSchema = z.object({
   WEB_CALL_ALLOWED_ORIGINS: z
     .string()
     .default("https://lobbystack.com,http://localhost:4321,http://127.0.0.1:4321"),
+  WEB_CALL_MAX_DURATION_MS: z.coerce.number().int().positive().default(5 * 60 * 1000),
   TWILIO_ACCOUNT_SID: z.string().optional(),
   TWILIO_AUTH_TOKEN: z.string().optional(),
   POSTHOG_KEY: z.string().optional(),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -80,6 +80,7 @@ const voiceGatewayEnvSchema = z.object({
   NODE_ENV: z.string().default("development"),
   DEPLOYMENT_MODE: deploymentModeSchema.default("development"),
   PORT: z.coerce.number().default(3001),
+  VOICE_GATEWAY_TRUST_PROXY: booleanEnvSchema.default("false"),
   VOICE_GATEWAY_BASE_URL: z.string().url(),
   CONVEX_SITE_URL: z.string().url(),
   INTERNAL_SERVICE_TOKEN: z.string().min(1),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -93,9 +93,7 @@ const voiceGatewayEnvSchema = z.object({
   OPENAI_TRANSCRIPTION_MODEL: z.string().default("gpt-4o-mini-transcribe"),
   OPENAI_TRANSCRIPTION_INPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
   OPENAI_TRANSCRIPTION_OUTPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
-  WEB_CALL_ALLOWED_ORIGINS: z
-    .string()
-    .default("https://lobbystack.com,http://localhost:4321,http://127.0.0.1:4321"),
+  WEB_CALL_ALLOWED_ORIGINS: z.string().default("https://lobbystack.com"),
   WEB_CALL_MAX_DURATION_MS: z.coerce.number().int().positive().default(5 * 60 * 1000),
   TWILIO_ACCOUNT_SID: z.string().optional(),
   TWILIO_AUTH_TOKEN: z.string().optional(),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -93,6 +93,9 @@ const voiceGatewayEnvSchema = z.object({
   OPENAI_TRANSCRIPTION_MODEL: z.string().default("gpt-4o-mini-transcribe"),
   OPENAI_TRANSCRIPTION_INPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
   OPENAI_TRANSCRIPTION_OUTPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
+  WEB_CALL_ALLOWED_ORIGINS: z
+    .string()
+    .default("https://lobbystack.com,http://localhost:4321,http://127.0.0.1:4321"),
   TWILIO_ACCOUNT_SID: z.string().optional(),
   TWILIO_AUTH_TOKEN: z.string().optional(),
   POSTHOG_KEY: z.string().optional(),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 
 import type { DeploymentMode } from "@lobbystack/shared";
 
+const DEFAULT_WEB_CALL_MAX_DURATION_MS = 5 * 60 * 1000;
+const MAX_WEB_CALL_MAX_DURATION_MS = 30 * 60 * 1000;
+
 const deploymentModeSchema = z.enum([
   "cloud",
   "self_hosted_standard",
@@ -94,7 +97,12 @@ const voiceGatewayEnvSchema = z.object({
   OPENAI_TRANSCRIPTION_INPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
   OPENAI_TRANSCRIPTION_OUTPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
   WEB_CALL_ALLOWED_ORIGINS: z.string().default("https://lobbystack.com"),
-  WEB_CALL_MAX_DURATION_MS: z.coerce.number().int().positive().default(5 * 60 * 1000),
+  WEB_CALL_MAX_DURATION_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_WEB_CALL_MAX_DURATION_MS)
+    .default(DEFAULT_WEB_CALL_MAX_DURATION_MS),
   TWILIO_ACCOUNT_SID: z.string().optional(),
   TWILIO_AUTH_TOKEN: z.string().optional(),
   POSTHOG_KEY: z.string().optional(),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -16,6 +16,25 @@ const booleanEnvSchema = z
   .default("true")
   .transform((value) => value === "true");
 
+const trustProxyEnvSchema = z
+  .string()
+  .default("false")
+  .transform((value) => {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "false" || normalized === "") {
+      return false;
+    }
+
+    if (normalized === "true") {
+      return ["loopback", "linklocal", "uniquelocal"];
+    }
+
+    return value
+      .split(",")
+      .map((proxy) => proxy.trim())
+      .filter(Boolean);
+  });
+
 const serverEnvSchema = z.object({
   NODE_ENV: z.string().default("development"),
   DEPLOYMENT_MODE: deploymentModeSchema.default("development"),
@@ -80,7 +99,7 @@ const voiceGatewayEnvSchema = z.object({
   NODE_ENV: z.string().default("development"),
   DEPLOYMENT_MODE: deploymentModeSchema.default("development"),
   PORT: z.coerce.number().default(3001),
-  VOICE_GATEWAY_TRUST_PROXY: booleanEnvSchema.default("false"),
+  VOICE_GATEWAY_TRUST_PROXY: trustProxyEnvSchema,
   VOICE_GATEWAY_BASE_URL: z.string().url(),
   CONVEX_SITE_URL: z.string().url(),
   INTERNAL_SERVICE_TOKEN: z.string().min(1),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,10 @@ export const deploymentModes = [
   "development",
 ] as const satisfies ReadonlyArray<DeploymentMode>;
 
+export const DEFAULT_WEB_CALL_MAX_DURATION_MS = 5 * 60 * 1000;
+export const MAX_WEB_CALL_MAX_DURATION_MS = 30 * 60 * 1000;
+export const WEB_CALL_STALE_GRACE_MS = 60 * 1000;
+
 export type BusinessType =
   | "clinic"
   | "repair_shop"


### PR DESCRIPTION
## Summary

Implements a reusable web voice widget that brings AI receptionist capabilities directly to web browsers, complementing the existing phone/SIP telephony channels.

## Changes

### Web Voice Gateway (`apps/voice-gateway/`)
- **New web call routes** with full CRUD for web-originated voice calls
- **Two-phase rate limiting** and abuse control for web call admission
- **Stale call cleanup** and enforced cutoff on recording uploads
- Input validation, billing preflight checks, and origin allowlisting

### Convex Backend (`convex/`)
- **Schema updates** to support web call sessions and recordings
- **Web call recording** with transcript ordering and stale cleanup
- **Final-message playback** before web call hangup
- Dashboard overview and conversation session helpers updated for web calls

### Config & Shared
- Configurable web voice settings (max duration, origin allowlist, recording limits)
- Shared types for web call state management

### Tests
- Test coverage for web call routes, tool execution, media streaming, dashboard home summary, and web voice calls

Closes #—