### PR TITLE
fix: enforce SMS consent for alerts

### DIFF
--- a/apps/voice-gateway/src/convex/runtimeClient.ts
+++ b/apps/voice-gateway/src/convex/runtimeClient.ts
@@ -399,6 +399,7 @@ export async function bookVoiceAppointment(input: {
   conversationId?: string;
   contactName?: string;
   contactPhone: string;
+  smsConsentGranted: boolean;
 }): Promise<BookAppointmentResponse> {
   return await postJson<BookAppointmentResponse>("/voice/tool/book-appointment", input);
 }

--- a/apps/voice-gateway/src/realtime/toolDefinitions.ts
+++ b/apps/voice-gateway/src/realtime/toolDefinitions.ts
@@ -100,8 +100,13 @@ export function createWebRealtimeToolDefinitions() {
           preferredStaffId: { type: "string" },
           contactName: { type: "string" },
           contactPhone: { type: "string" },
+          smsConsentGranted: {
+            type: "boolean",
+            description:
+              "Whether the caller explicitly agreed to receive appointment confirmation and reminder SMS after the required disclosure.",
+          },
         },
-        required: ["serviceName", "startsAt", "contactPhone"],
+        required: ["serviceName", "startsAt", "contactPhone", "smsConsentGranted"],
         additionalProperties: false,
       },
     },

--- a/apps/voice-gateway/src/realtime/toolExecutor.test.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.test.ts
@@ -432,6 +432,7 @@ describe("executeVoiceTool bookings", () => {
       rawArguments: JSON.stringify({
         serviceName: "Consultation",
         startsAt: "2030-05-15T14:00:00.000Z",
+        smsConsentGranted: false,
       }),
       snapshot: demoSnapshot,
       businessId: "business_123",
@@ -456,6 +457,7 @@ describe("executeVoiceTool bookings", () => {
         serviceName: "Consultation",
         startsAt: "2030-05-15T14:00:00.000Z",
         contactPhone: " +14165550123 ",
+        smsConsentGranted: true,
       }),
       snapshot: demoSnapshot,
       businessId: "business_123",
@@ -480,6 +482,7 @@ describe("executeVoiceTool bookings", () => {
         serviceName: "Consultation",
         startsAt: "2030-05-15T14:00:00.000Z",
         contactPhone: "+14165550123",
+        smsConsentGranted: true,
       }),
       snapshot: demoSnapshot,
       businessId: "business_123",

--- a/apps/voice-gateway/src/realtime/toolExecutor.ts
+++ b/apps/voice-gateway/src/realtime/toolExecutor.ts
@@ -152,6 +152,7 @@ const bookAppointmentSchema = z.object({
   preferredStaffId: z.string().optional(),
   contactName: z.string().optional(),
   contactPhone: z.string().optional(),
+  smsConsentGranted: z.boolean(),
 });
 
 const verifyAppointmentForChangeSchema = z.object({
@@ -402,6 +403,7 @@ export async function executeVoiceTool(input: {
             : {}),
           ...(parsed.contactName !== undefined ? { contactName: parsed.contactName } : {}),
           contactPhone: contactPhone ?? input.callerPhone,
+          smsConsentGranted: parsed.smsConsentGranted,
         });
         return {
           result,

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -746,8 +746,13 @@ function createRealtimeToolDefinitions() {
           preferredStaffId: { type: "string" },
           contactName: { type: "string" },
           contactPhone: { type: "string" },
+          smsConsentGranted: {
+            type: "boolean",
+            description:
+              "Whether the caller explicitly agreed to receive appointment confirmation and reminder SMS after the required disclosure.",
+          },
         },
-        required: ["serviceName", "startsAt"],
+        required: ["serviceName", "startsAt", "smsConsentGranted"],
         additionalProperties: false,
       },
     },
@@ -2220,6 +2225,7 @@ async function configureOpenAiSession(
         "If the caller gives a day/date or a rough time like '4' or 'afternoon', use findAvailability before trying to book.",
         "Offer one or a few specific candidate slots from findAvailability and wait for the caller to confirm one exact slot.",
         "Only call bookAppointment after the caller confirms a specific offered time.",
+        "Before calling bookAppointment, ask exactly: Can I text this number with your appointment confirmation and reminder? Message and data rates may apply. Reply STOP to opt out or HELP for help. Pass smsConsentGranted true only if the caller says yes. If the caller says no, still book the appointment and pass smsConsentGranted false.",
         "For cancellation or rescheduling requests, use lookupAppointmentForChange first. If appointments exist, ask the caller for the name on the appointment and either the existing appointment time or service; do not claim to know those facts from lookup.",
         "Before cancelling or rescheduling, use verifyAppointmentForChange with the caller's name and an appointment fact they provided, such as the existing time or service.",
         "If verifyAppointmentForChange says OTP is required, send the code and verify it before attempting the change.",

--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -1332,6 +1332,7 @@ describe("web call routes", () => {
             serviceName: "Consultation",
             startsAt: "2030-05-15T14:00:00.000Z",
             contactPhone: "+14165550123",
+            smsConsentGranted: true,
           }),
         }),
       ),

--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -634,6 +634,12 @@
         "title": "Send time",
         "description": "The time of day your daily summary will be sent."
       }
+    },
+    "smsConsent": {
+      "title": "Enable SMS alerts",
+      "description": "Confirm that you want LobbyStack to send workspace alerts to your verified phone number.",
+      "cancel": "Cancel",
+      "accept": "I agree, enable SMS"
     }
   }
 }

--- a/apps/web/public/locales/fr/settings.json
+++ b/apps/web/public/locales/fr/settings.json
@@ -633,6 +633,12 @@
         "title": "Heure d'envoi",
         "description": "L'heure à laquelle votre résumé quotidien sera envoyé."
       }
+    },
+    "smsConsent": {
+      "title": "Activer les alertes SMS",
+      "description": "Confirmez que vous voulez que LobbyStack envoie des alertes de l'espace de travail à votre numéro de téléphone vérifié.",
+      "cancel": "Annuler",
+      "accept": "J'accepte, activer les SMS"
     }
   }
 }

--- a/apps/web/src/features/settings/SettingsNotificationsPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsNotificationsPage.test.tsx
@@ -56,6 +56,10 @@ function buildPreferences(overrides: Record<string, unknown> = {}) {
     phoneVerified: true,
     canUseSms: true,
     smsUnavailableReason: null,
+    smsConsentGranted: false,
+    smsConsentDisclosureVersion: "operator-alerts-2026-05-22",
+    smsConsentDisclosureText:
+      "I agree to receive SMS alerts from LobbyStack about missed calls, new messages, appointment activity, and workspace notifications at my verified phone number. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out or HELP for help. SMS alerts are optional.",
     ...overrides,
   };
 }
@@ -181,5 +185,31 @@ describe("SettingsNotificationsPage", () => {
 
     expect(screen.queryByText("settings:notifications.actions.testEmail")).toBeNull();
     expect(screen.queryByText("settings:notifications.actions.testSms")).toBeNull();
+  });
+
+  it("requires consent before enabling SMS alerts", async () => {
+    const user = userEvent.setup();
+    renderNotificationsPage();
+
+    await user.click(
+      await screen.findByRole("switch", {
+        name: "settings:notifications.sources.sms.title",
+      }),
+    );
+
+    expect(await screen.findByText("settings:notifications.smsConsent.title")).toBeTruthy();
+    expect(updateNotificationPreferencesMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByText("settings:notifications.smsConsent.accept"));
+
+    await waitFor(() => {
+      expect(updateNotificationPreferencesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessId,
+          smsEnabled: true,
+          smsConsentAccepted: true,
+        }),
+      );
+    });
   });
 });

--- a/apps/web/src/features/settings/SettingsNotificationsPage.tsx
+++ b/apps/web/src/features/settings/SettingsNotificationsPage.tsx
@@ -5,7 +5,16 @@ import { toast } from "sonner";
 
 import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Item,
   ItemActions,
@@ -55,6 +64,9 @@ type NotificationPreferencesState = {
   eventPreferences: NotificationEventPreferences;
   dailySummaryEnabled: boolean;
   dailySummarySendTime: string;
+  smsConsentGranted: boolean;
+  smsConsentDisclosureVersion: string;
+  smsConsentDisclosureText: string;
 };
 
 type SmsUnavailableReason = "phone_unverified" | "sender_missing" | null;
@@ -78,6 +90,9 @@ function toPreferenceState(input: NotificationPreferencesState): NotificationPre
     eventPreferences: input.eventPreferences,
     dailySummaryEnabled: input.dailySummaryEnabled,
     dailySummarySendTime: input.dailySummarySendTime,
+    smsConsentGranted: input.smsConsentGranted,
+    smsConsentDisclosureVersion: input.smsConsentDisclosureVersion,
+    smsConsentDisclosureText: input.smsConsentDisclosureText,
   };
 }
 
@@ -94,6 +109,8 @@ export function SettingsNotificationsPage({
   );
   const saveVersionRef = useRef(0);
   const [draft, setDraft] = useState<NotificationPreferencesState | null>(null);
+  const [pendingSmsConsent, setPendingSmsConsent] =
+    useState<NotificationPreferencesState | null>(null);
 
   useEffect(() => {
     if (remotePreferences) {
@@ -116,7 +133,10 @@ export function SettingsNotificationsPage({
     );
   }
 
-  function persistPreferences(next: NotificationPreferencesState): void {
+  function persistPreferences(
+    next: NotificationPreferencesState,
+    options: { smsConsentAccepted?: boolean } = {},
+  ): void {
     const previous = draft;
     if (!previous) {
       return;
@@ -130,10 +150,19 @@ export function SettingsNotificationsPage({
     setDraft(next);
     const saveVersion = saveVersionRef.current + 1;
     saveVersionRef.current = saveVersion;
+    const {
+      smsConsentGranted: _smsConsentGranted,
+      smsConsentDisclosureText: _smsConsentDisclosureText,
+      smsConsentDisclosureVersion: _smsConsentDisclosureVersion,
+      ...persistedPreferences
+    } = next;
 
     void updateNotificationPreferences({
       businessId,
-      ...next,
+      ...persistedPreferences,
+      ...(options.smsConsentAccepted !== undefined
+        ? { smsConsentAccepted: options.smsConsentAccepted }
+        : {}),
     }).catch((error) => {
       if (saveVersionRef.current === saveVersion) {
         setDraft(previous);
@@ -153,10 +182,31 @@ export function SettingsNotificationsPage({
       return;
     }
 
-    persistPreferences({
+    const next = {
       ...draft,
       [channel === "email" ? "emailEnabled" : "smsEnabled"]: checked,
-    });
+    };
+
+    if (channel === "sms" && checked && !draft.smsConsentGranted) {
+      setPendingSmsConsent(next);
+      return;
+    }
+
+    persistPreferences(next);
+  }
+
+  function acceptSmsConsent(): void {
+    if (!pendingSmsConsent) {
+      return;
+    }
+    persistPreferences(
+      {
+        ...pendingSmsConsent,
+        smsConsentGranted: true,
+      },
+      { smsConsentAccepted: true },
+    );
+    setPendingSmsConsent(null);
   }
 
   function handlePrefChange(
@@ -210,7 +260,7 @@ export function SettingsNotificationsPage({
     descriptionKey: string,
   ) => {
     return (
-      <TableRow className="border-b border-border last:border-b-0 hover:bg-transparent">
+      <TableRow key={eventKey} className="border-b border-border last:border-b-0 hover:bg-transparent">
         <TableCell className="whitespace-normal px-6 py-5">
           <div className="flex flex-col gap-1 pr-4">
             <span className="text-sm font-medium text-foreground">{t(titleKey)}</span>
@@ -291,6 +341,7 @@ export function SettingsNotificationsPage({
   }
 
   return (
+    <>
     <div className="w-full overflow-y-auto pb-12">
       <div className="flex w-full flex-col gap-12">
         <div className="flex flex-col gap-4">
@@ -429,5 +480,34 @@ export function SettingsNotificationsPage({
         </div>
       </div>
     </div>
+    <Dialog
+      open={pendingSmsConsent !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          setPendingSmsConsent(null);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("settings:notifications.smsConsent.title")}</DialogTitle>
+          <DialogDescription>
+            {t("settings:notifications.smsConsent.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <p className="rounded-xl border border-border bg-muted/40 p-4 text-sm text-foreground">
+          {draft.smsConsentDisclosureText}
+        </p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setPendingSmsConsent(null)}>
+            {t("settings:notifications.smsConsent.cancel")}
+          </Button>
+          <Button onClick={acceptSmsConsent}>
+            {t("settings:notifications.smsConsent.accept")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    </>
   );
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -76,6 +76,8 @@ import type * as lib_runtimeLocale from "../lib/runtimeLocale.js";
 import type * as lib_serviceNameGeneration from "../lib/serviceNameGeneration.js";
 import type * as lib_serviceNames from "../lib/serviceNames.js";
 import type * as lib_smsCompliance from "../lib/smsCompliance.js";
+import type * as lib_smsConsent from "../lib/smsConsent.js";
+import type * as lib_smsConsentState from "../lib/smsConsentState.js";
 import type * as lib_smsPhoneNumbers from "../lib/smsPhoneNumbers.js";
 import type * as lib_snapshot from "../lib/snapshot.js";
 import type * as lib_turnstile from "../lib/turnstile.js";
@@ -185,6 +187,8 @@ declare const fullApi: ApiFromModules<{
   "lib/serviceNameGeneration": typeof lib_serviceNameGeneration;
   "lib/serviceNames": typeof lib_serviceNames;
   "lib/smsCompliance": typeof lib_smsCompliance;
+  "lib/smsConsent": typeof lib_smsConsent;
+  "lib/smsConsentState": typeof lib_smsConsentState;
   "lib/smsPhoneNumbers": typeof lib_smsPhoneNumbers;
   "lib/snapshot": typeof lib_snapshot;
   "lib/turnstile": typeof lib_turnstile;

--- a/convex/appointments/booking.ts
+++ b/convex/appointments/booking.ts
@@ -15,6 +15,14 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { ensureCurrentUser, requireMembership } from "../lib/auth";
 import { workflowManager } from "../lib/components";
+import {
+  CUSTOMER_APPOINTMENT_SMS_DISCLOSURE_TEXT,
+  CUSTOMER_APPOINTMENT_SMS_DISCLOSURE_VERSION,
+} from "../lib/smsConsent";
+import {
+  isPlatformAlertSmsOptedOut,
+  recordSmsConsentEvent,
+} from "../lib/smsConsentState";
 import { selectDefaultStaffForBusiness } from "../lib/defaultStaff";
 import { computeAvailability } from "../lib/availability";
 import {
@@ -226,6 +234,7 @@ async function bookAppointmentWithSource(
     contactName?: string;
     contactPhone: string;
     sourceChannel: string;
+    smsConsentGranted?: boolean;
   },
 ): Promise<{ appointmentId: Id<"appointments">; contactId: Id<"contacts"> }> {
   try {
@@ -268,6 +277,38 @@ async function bookAppointmentWithSource(
 
     if (!contact) {
       throw new Error("Failed to create contact.");
+    }
+
+    if (args.smsConsentGranted !== undefined) {
+      const now = new Date().toISOString();
+      const source =
+        args.sourceChannel === "web_voice" ? "web_voice_booking" : "voice_booking";
+      const globallyOptedOut = await isPlatformAlertSmsOptedOut(ctx, contact.phone);
+      const hardOptedOut = globallyOptedOut || contact.smsConsentStatus === "opted_out";
+      await recordSmsConsentEvent(ctx, {
+        businessId: args.businessId,
+        contactId: contact._id,
+        recipientType: "contact",
+        phone: contact.phone,
+        action: args.smsConsentGranted ? "granted" : "declined",
+        source,
+        disclosureVersion: CUSTOMER_APPOINTMENT_SMS_DISCLOSURE_VERSION,
+        disclosureText: CUSTOMER_APPOINTMENT_SMS_DISCLOSURE_TEXT,
+        createdAt: now,
+      });
+      await ctx.db.patch(contact._id, {
+        smsConsentStatus: args.smsConsentGranted && !hardOptedOut
+          ? "subscribed"
+          : args.smsConsentGranted
+            ? "opted_out"
+            : "declined",
+        smsConsentUpdatedAt: now,
+        smsConsentSource: hardOptedOut && args.smsConsentGranted
+          ? contact.smsConsentStatus === "opted_out"
+            ? contact.smsConsentSource ?? "contact_opt_out"
+            : "platform_alert_opt_out"
+          : source,
+      });
     }
 
     const selected = availability[0];
@@ -542,6 +583,7 @@ export const bookAppointmentForBusiness = internalMutation({
     contactName: v.optional(v.string()),
     contactPhone: v.string(),
     sourceChannel: v.string(),
+    smsConsentGranted: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     return await bookAppointmentWithSource(ctx, args);

--- a/convex/conversations/webhooks.ts
+++ b/convex/conversations/webhooks.ts
@@ -22,6 +22,11 @@ import {
 import { selectSmsSenderPhoneNumber } from "../lib/smsPhoneNumbers";
 import { mapTwilioStatusToMessageStatus } from "../lib/twilioMessageStatus";
 import { buildTwilioSmsStatusCallbackUrl } from "../lib/twilioUrls";
+import { PLATFORM_ALERT_SMS_SCOPE } from "../lib/smsConsent";
+import {
+  recordPlatformAlertSmsConsentState,
+  recordSmsConsentEvent,
+} from "../lib/smsConsentState";
 import {
   enqueuePostHogProviderExceptionBestEffort,
   enqueuePostHogOutboxRecord,
@@ -156,8 +161,8 @@ type HandleTwilioSmsInboundArgs = {
   media?: Array<MessageMediaAttachment>;
 };
 type HandleTwilioSmsInboundResult = {
-  businessId: Id<"businesses">;
-  conversationId: Id<"conversations">;
+  businessId?: Id<"businesses">;
+  conversationId?: Id<"conversations">;
   reply: string | null;
 };
 type SmsConsentUpdate = {
@@ -190,7 +195,7 @@ const SMS_STOP_KEYWORDS = new Set(["STOP", "STOPALL", "UNSUBSCRIBE", "END", "QUI
 const SMS_START_KEYWORDS = new Set(["START", "UNSTOP", "SUBSCRIBE"]);
 const SMS_HELP_KEYWORDS = new Set(["HELP"]);
 const SMS_HELP_REPLY =
-  "LobbyStack: For help, contact support@lobbystack.com. Reply STOP to opt out.";
+  "LobbyStack: For help, contact hello@lobbystack.com or visit https://lobbystack.com. Reply STOP to opt out.";
 const SMS_START_REPLY =
   "LobbyStack: You are subscribed again. Reply HELP for help or STOP to opt out.";
 
@@ -364,6 +369,48 @@ export const getConversationById = internalQuery({
   },
   handler: async (ctx: QueryCtx, args: ConversationIdArgs) => {
     return await ctx.db.get(args.conversationId);
+  },
+});
+
+export const isPlatformAlertSmsSender = internalQuery({
+  args: {
+    e164: v.string(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const sender = await ctx.db
+      .query("platform_sms_senders")
+      .withIndex("by_e164", (q) => q.eq("e164", args.e164))
+      .unique();
+    const envSender = process.env.TWILIO_ALERT_SMS_FROM?.trim();
+    return Boolean(
+      (sender && sender.role === PLATFORM_ALERT_SMS_SCOPE && sender.status === "active" && sender.smsEnabled) ||
+        (envSender && envSender === args.e164),
+    );
+  },
+});
+
+export const recordPlatformAlertKeywordConsent = internalMutation({
+  args: {
+    phone: v.string(),
+    action: v.union(v.literal("opted_out"), v.literal("resubscribed")),
+    source: v.string(),
+    createdAt: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await recordSmsConsentEvent(ctx, {
+      recipientType: "platform_phone",
+      phone: args.phone,
+      action: args.action,
+      source: args.source,
+      createdAt: args.createdAt,
+    });
+    await recordPlatformAlertSmsConsentState(ctx, {
+      phone: args.phone,
+      status: args.action === "opted_out" ? "opted_out" : "subscribed",
+      source: args.source,
+      createdAt: args.createdAt,
+    });
+    return null;
   },
 });
 
@@ -1278,6 +1325,47 @@ export const handleTwilioSmsInbound = internalAction({
     ctx: ActionCtx,
     args: HandleTwilioSmsInboundArgs,
   ): Promise<HandleTwilioSmsInboundResult> => {
+    const isPlatformAlertSender: boolean = await ctx.runQuery(
+      internal.conversations.webhooks.isPlatformAlertSmsSender,
+      { e164: args.to },
+    );
+    if (isPlatformAlertSender) {
+      const consentUpdate = classifySmsConsentUpdate({
+        body: args.body,
+        ...(args.optOutType !== undefined ? { optOutType: args.optOutType } : {}),
+      });
+      if (consentUpdate) {
+        await ctx.runMutation(
+          internal.conversations.webhooks.recordPlatformAlertKeywordConsent,
+          {
+            phone: args.from,
+            action: consentUpdate.status === "opted_out" ? "opted_out" : "resubscribed",
+            source: consentUpdate.source,
+            createdAt: new Date().toISOString(),
+          },
+        );
+      }
+
+      const keywordReply = classifySmsKeywordReply({
+        body: args.body,
+        ...(args.optOutType !== undefined ? { optOutType: args.optOutType } : {}),
+      });
+      if (keywordReply && consentUpdate?.status !== "opted_out") {
+        const sent: { providerMessageSid: string; providerStatus: string } = await ctx.runAction(
+          internal.integrations.twilioSms.sendMessage,
+          {
+            to: args.from,
+            from: args.to,
+            body: keywordReply.body,
+            statusCallbackUrl: buildTwilioSmsStatusCallbackUrl(),
+          },
+        );
+        return { reply: sent.providerMessageSid };
+      }
+
+      return { reply: null };
+    }
+
     const phoneNumber: Doc<"phone_numbers"> | null = await ctx.runQuery(
       internal.businesses.catalog.resolveBusinessByPhoneNumber,
       { e164: args.to, channel: "sms" },

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -166,6 +166,7 @@ const bookAppointmentSchema = z.object({
   conversationId: z.string().min(1).optional(),
   contactName: z.string().min(1).optional(),
   contactPhone: z.string().min(1),
+  smsConsentGranted: z.boolean(),
 });
 
 const lookupAppointmentForChangeSchema = z.object({
@@ -1305,6 +1306,7 @@ http.route({
         : {}),
       ...(body.data.contactName !== undefined ? { contactName: body.data.contactName } : {}),
       contactPhone: body.data.contactPhone,
+      smsConsentGranted: body.data.smsConsentGranted,
     });
 
     return Response.json(result);

--- a/convex/lib/runtimeLocale.ts
+++ b/convex/lib/runtimeLocale.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { ALERT_SMS_COMPLIANCE_FOOTER } from "./smsConsent";
 
 export type RuntimeLocale = "en" | "fr";
 export type RuntimeLocaleDetection = RuntimeLocale | "unknown";
@@ -405,6 +406,7 @@ export function formatRuntimeTimeList(times: Array<string>, locale: RuntimeLocal
 
 export function buildLocalizedAppointmentNotificationBody(input: {
   kind: "appointment_reminder" | "booking_confirmation";
+  businessName?: string;
   serviceName: string;
   startsAt: string;
   timezone: string;
@@ -415,14 +417,17 @@ export function buildLocalizedAppointmentNotificationBody(input: {
     input.timezone,
     input.locale,
   );
+  const prefix = input.businessName ? `${input.businessName}: ` : "";
 
   if (input.locale === "fr") {
-    return input.kind === "appointment_reminder"
-      ? `Rappel : votre rendez-vous pour ${input.serviceName} est prévu ${formattedTime}. Répondez à ce message si vous devez le reporter.`
-      : `Votre rendez-vous pour ${input.serviceName} est confirmé pour ${formattedTime}. Répondez à ce message si vous devez le reporter.`;
+    const body = input.kind === "appointment_reminder"
+      ? `${prefix}Rappel : votre rendez-vous pour ${input.serviceName} est prévu ${formattedTime}.`
+      : `${prefix}Votre rendez-vous pour ${input.serviceName} est confirmé pour ${formattedTime}.`;
+    return `${body} ${ALERT_SMS_COMPLIANCE_FOOTER}`;
   }
 
-  return input.kind === "appointment_reminder"
-    ? `Reminder: your ${input.serviceName} appointment is ${formattedTime}. Reply if you need to reschedule.`
-    : `Your ${input.serviceName} appointment is booked for ${formattedTime}. Reply if you need to reschedule.`;
+  const body = input.kind === "appointment_reminder"
+    ? `${prefix}Reminder: your ${input.serviceName} appointment is ${formattedTime}.`
+    : `${prefix}Your ${input.serviceName} appointment is confirmed for ${formattedTime}.`;
+  return `${body} ${ALERT_SMS_COMPLIANCE_FOOTER}`;
 }

--- a/convex/lib/smsConsent.ts
+++ b/convex/lib/smsConsent.ts
@@ -1,0 +1,45 @@
+import { v } from "convex/values";
+
+export const PLATFORM_ALERT_SMS_SCOPE = "platform_alert" as const;
+
+export const CUSTOMER_APPOINTMENT_SMS_DISCLOSURE_VERSION =
+  "appointment-alerts-2026-05-22";
+
+export const CUSTOMER_APPOINTMENT_SMS_DISCLOSURE_TEXT =
+  "Can I text this number with your appointment confirmation and reminder? Message and data rates may apply. Reply STOP to opt out or HELP for help.";
+
+export const OPERATOR_SMS_DISCLOSURE_VERSION = "operator-alerts-2026-05-22";
+
+export const OPERATOR_SMS_DISCLOSURE_TEXT =
+  "I agree to receive SMS alerts from LobbyStack about missed calls, new messages, appointment activity, and workspace notifications at my verified phone number. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out or HELP for help. SMS alerts are optional.";
+
+export const ALERT_SMS_COMPLIANCE_FOOTER =
+  "Msg & data rates may apply. Reply STOP to opt out or HELP for help.";
+
+export const smsConsentRecipientTypeValidator = v.union(
+  v.literal("contact"),
+  v.literal("operator"),
+  v.literal("platform_phone"),
+);
+
+export const smsConsentActionValidator = v.union(
+  v.literal("granted"),
+  v.literal("declined"),
+  v.literal("revoked"),
+  v.literal("opted_out"),
+  v.literal("resubscribed"),
+);
+
+export const smsConsentStatusValidator = v.union(
+  v.literal("subscribed"),
+  v.literal("declined"),
+  v.literal("revoked"),
+  v.literal("opted_out"),
+);
+
+export const smsConsentStateScopeValidator = v.literal(PLATFORM_ALERT_SMS_SCOPE);
+
+export const smsConsentStateStatusValidator = v.union(
+  v.literal("subscribed"),
+  v.literal("opted_out"),
+);

--- a/convex/lib/smsConsentState.ts
+++ b/convex/lib/smsConsentState.ts
@@ -1,0 +1,86 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { PLATFORM_ALERT_SMS_SCOPE } from "./smsConsent";
+
+type DbCtx = QueryCtx | MutationCtx;
+
+export async function getPlatformAlertSmsConsentState(
+  ctx: DbCtx,
+  phone: string,
+): Promise<Doc<"sms_consent_states"> | null> {
+  return await ctx.db
+    .query("sms_consent_states")
+    .withIndex("by_scope_and_phone", (q) =>
+      q.eq("scope", PLATFORM_ALERT_SMS_SCOPE).eq("phone", phone),
+    )
+    .unique();
+}
+
+export async function isPlatformAlertSmsOptedOut(
+  ctx: DbCtx,
+  phone: string,
+): Promise<boolean> {
+  const state = await getPlatformAlertSmsConsentState(ctx, phone);
+  return state?.status === "opted_out";
+}
+
+export async function recordPlatformAlertSmsConsentState(
+  ctx: MutationCtx,
+  input: {
+    phone: string;
+    status: "subscribed" | "opted_out";
+    source: string;
+    createdAt: string;
+  },
+): Promise<void> {
+  const existing = await getPlatformAlertSmsConsentState(ctx, input.phone);
+  const patch = {
+    status: input.status,
+    source: input.source,
+    updatedAt: input.createdAt,
+  };
+
+  if (existing) {
+    await ctx.db.patch(existing._id, patch);
+    return;
+  }
+
+  await ctx.db.insert("sms_consent_states", {
+    scope: PLATFORM_ALERT_SMS_SCOPE,
+    phone: input.phone,
+    ...patch,
+  });
+}
+
+export async function recordSmsConsentEvent(
+  ctx: MutationCtx,
+  input: {
+    recipientType: "contact" | "operator" | "platform_phone";
+    phone: string;
+    action: "granted" | "declined" | "revoked" | "opted_out" | "resubscribed";
+    source: string;
+    createdAt: string;
+    businessId?: Id<"businesses">;
+    contactId?: Id<"contacts">;
+    userId?: Id<"users">;
+    appointmentId?: Id<"appointments">;
+    disclosureVersion?: string;
+    disclosureText?: string;
+  },
+): Promise<Id<"sms_consent_events">> {
+  return await ctx.db.insert("sms_consent_events", {
+    recipientType: input.recipientType,
+    phone: input.phone,
+    action: input.action,
+    source: input.source,
+    createdAt: input.createdAt,
+    ...(input.businessId !== undefined ? { businessId: input.businessId } : {}),
+    ...(input.contactId !== undefined ? { contactId: input.contactId } : {}),
+    ...(input.userId !== undefined ? { userId: input.userId } : {}),
+    ...(input.appointmentId !== undefined ? { appointmentId: input.appointmentId } : {}),
+    ...(input.disclosureVersion !== undefined
+      ? { disclosureVersion: input.disclosureVersion }
+      : {}),
+    ...(input.disclosureText !== undefined ? { disclosureText: input.disclosureText } : {}),
+  });
+}

--- a/convex/notifications/reminders.ts
+++ b/convex/notifications/reminders.ts
@@ -21,6 +21,7 @@ import {
   inferRuntimeLocaleFromBusinessContext,
   normalizeRuntimeLocale,
 } from "../lib/runtimeLocale";
+import { isPlatformAlertSmsOptedOut } from "../lib/smsConsentState";
 
 type AppointmentNotificationKind = "appointment_reminder" | "booking_confirmation";
 
@@ -33,13 +34,14 @@ type NotificationDeliveryContext = {
   twilioMessagingServiceSid?: string;
   kind: AppointmentNotificationKind;
   serviceId: Id<"services">;
+  businessName: string;
   serviceName: string;
   startsAt: string;
   timezone: string;
   locale: "en" | "fr";
   senderRole: "platform_alert" | "business_ai";
 } | {
-  deliveryBlockedReason: "sms_opted_out";
+  deliveryBlockedReason: "sms_opted_out" | "sms_consent_missing";
   businessId: Id<"businesses">;
   notificationId: Id<"notifications">;
   appointmentId: Id<"appointments">;
@@ -53,7 +55,7 @@ type DeliverNotificationResult =
     }
   | {
       delivered: false;
-      reason: "sms_opted_out";
+      reason: "sms_opted_out" | "sms_consent_missing";
     };
 
 function isAppointmentNotificationKind(kind: string): kind is AppointmentNotificationKind {
@@ -180,9 +182,19 @@ export const getNotificationDeliveryContext = internalQuery({
     if (!isAppointmentNotificationKind(notification.kind)) {
       throw new Error("Unsupported notification kind.");
     }
-    if (contact.smsConsentStatus === "opted_out") {
+    const platformOptedOut = await isPlatformAlertSmsOptedOut(ctx, contact.phone);
+    if (contact.smsConsentStatus === "opted_out" || platformOptedOut) {
       return {
         deliveryBlockedReason: "sms_opted_out",
+        businessId: notification.businessId,
+        notificationId: notification._id,
+        appointmentId,
+        kind: notification.kind,
+      };
+    }
+    if (contact.smsConsentStatus !== "subscribed") {
+      return {
+        deliveryBlockedReason: "sms_consent_missing",
         businessId: notification.businessId,
         notificationId: notification._id,
         appointmentId,
@@ -223,6 +235,7 @@ export const getNotificationDeliveryContext = internalQuery({
         : {}),
       kind: notification.kind,
       serviceId: service._id,
+      businessName: business.name,
       serviceName: service.name,
       startsAt: appointment.startsAt,
       timezone: appointment.timezone,
@@ -373,6 +386,14 @@ export const createAppointmentNotifications = internalMutation({
     if (appointment.status !== "confirmed") {
       return null;
     }
+    const contact = await ctx.db.get(appointment.contactId);
+    if (
+      !contact ||
+      contact.smsConsentStatus !== "subscribed" ||
+      (await isPlatformAlertSmsOptedOut(ctx, contact.phone))
+    ) {
+      return null;
+    }
     const business = await ctx.db.get(appointment.businessId);
     const senderRole =
       business?.deploymentMode === "cloud" || business?.deploymentMode === "development"
@@ -422,6 +443,17 @@ export const ensureBookingConfirmationNotification = internalMutation({
     const appointment = await ctx.db.get(args.appointmentId);
     if (!appointment) {
       throw new Error("Appointment not found.");
+    }
+    const contact = await ctx.db.get(appointment.contactId);
+    if (
+      !contact ||
+      contact.smsConsentStatus !== "subscribed" ||
+      (await isPlatformAlertSmsOptedOut(ctx, contact.phone))
+    ) {
+      return {
+        notificationId: null,
+        created: false,
+      };
     }
     const business = await ctx.db.get(appointment.businessId);
     const senderRole =
@@ -503,7 +535,10 @@ export const deliverNotification = internalAction({
       await ctx.runMutation(internal.notifications.reminders.markNotificationDeliverySkipped, {
         notificationId: args.notificationId,
         providerUpdatedAt: new Date().toISOString(),
-        providerStatus: "skipped_opted_out",
+        providerStatus:
+          deliveryContext.deliveryBlockedReason === "sms_opted_out"
+            ? "skipped_opted_out"
+            : "skipped_consent_missing",
       });
       return {
         delivered: false,
@@ -528,6 +563,7 @@ export const deliverNotification = internalAction({
       );
       const body = buildLocalizedAppointmentNotificationBody({
         kind: deliveryContext.kind,
+        businessName: deliveryContext.businessName,
         serviceName: localizedServiceName,
         startsAt: deliveryContext.startsAt,
         timezone: deliveryContext.timezone,

--- a/convex/operatorNotifications.ts
+++ b/convex/operatorNotifications.ts
@@ -22,6 +22,11 @@ import {
   type OperatorNotificationEventPreferences,
 } from "./lib/operatorNotificationPreferences";
 import {
+  ALERT_SMS_COMPLIANCE_FOOTER,
+  OPERATOR_SMS_DISCLOSURE_VERSION,
+} from "./lib/smsConsent";
+import { isPlatformAlertSmsOptedOut } from "./lib/smsConsentState";
+import {
   getMessageContentExpiresAt,
   scheduleOperatorNotificationDeliveryContentExpiration,
 } from "./privacy/retention";
@@ -29,6 +34,7 @@ import {
 type EffectivePreferences = {
   emailEnabled: boolean;
   smsEnabled: boolean;
+  smsConsentGranted: boolean;
   eventPreferences: OperatorNotificationEventPreferences;
   dailySummaryEnabled: boolean;
   dailySummarySendTime: string;
@@ -76,6 +82,12 @@ function getEffectivePreferences(
   return {
     emailEnabled: preferences?.emailEnabled ?? true,
     smsEnabled: preferences?.smsEnabled ?? false,
+    smsConsentGranted: Boolean(
+      preferences?.smsConsentGrantedAt &&
+        preferences.smsConsentDisclosureVersion === OPERATOR_SMS_DISCLOSURE_VERSION &&
+        (!preferences.smsConsentRevokedAt ||
+          preferences.smsConsentRevokedAt < preferences.smsConsentGrantedAt),
+    ),
     eventPreferences:
       preferences?.eventPreferences ?? buildDefaultOperatorNotificationEventPreferences(),
     dailySummaryEnabled: preferences?.dailySummaryEnabled ?? true,
@@ -111,11 +123,13 @@ function buildOperatorSmsBody(input: {
   subject: string;
   body: string;
 }): string {
-  const body = `${input.subject}\n${input.body}`.trim();
+  const content = `${input.subject}\n${input.body}`.trim();
+  const body = `${content}\n${ALERT_SMS_COMPLIANCE_FOOTER}`.trim();
   if (body.length <= 600) {
     return body;
   }
-  return `${body.slice(0, 597)}...`;
+  const maxContentLength = Math.max(0, 600 - ALERT_SMS_COMPLIANCE_FOOTER.length - 4);
+  return `${content.slice(0, maxContentLength)}...\n${ALERT_SMS_COMPLIANCE_FOOTER}`;
 }
 
 function estimateSmsSegments(body: string): number {
@@ -219,6 +233,15 @@ function hasAlertSmsSender(input: {
   return Boolean(input.fromPhoneNumber || input.twilioMessagingServiceSid);
 }
 
+export const isPlatformAlertPhoneOptedOut = internalQuery({
+  args: {
+    phone: v.string(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    return await isPlatformAlertSmsOptedOut(ctx, args.phone);
+  },
+});
+
 export const listRecipientsForEvent = internalQuery({
   args: {
     businessId: v.id("businesses"),
@@ -267,6 +290,8 @@ export const listRecipientsForEvent = internalQuery({
       const smsEnabled =
         alertSmsSenderConfigured &&
         Boolean(user.phone && user.phoneVerificationTime) &&
+        effective.smsConsentGranted &&
+        !(user.phone ? await isPlatformAlertSmsOptedOut(ctx, user.phone) : false) &&
         isEventPreferenceEnabled(effective, args.eventKind, "sms");
 
       if (!emailEnabled && !smsEnabled) {
@@ -322,6 +347,22 @@ export const getDirectRecipient = internalQuery({
     }
     if (args.channel === "sms" && (!user.phone || !user.phoneVerificationTime)) {
       return null;
+    }
+    if (args.channel === "sms") {
+      const phone = user.phone;
+      if (!phone) {
+        return null;
+      }
+      const preference = await ctx.db
+        .query("operator_notification_preferences")
+        .withIndex("by_business_id_and_user_id", (q) =>
+          q.eq("businessId", args.businessId).eq("userId", args.userId),
+        )
+        .unique();
+      const effective = getEffectivePreferences(preference);
+      if (!effective.smsConsentGranted || await isPlatformAlertSmsOptedOut(ctx, phone)) {
+        return null;
+      }
     }
 
     return {
@@ -575,6 +616,13 @@ async function deliverSms(
   }
   if (!smsPolicy.fromPhoneNumber && !smsPolicy.twilioMessagingServiceSid) {
     throw new Error("No alert SMS sender is configured.");
+  }
+  const optedOut: boolean = await ctx.runQuery(
+    internal.operatorNotifications.isPlatformAlertPhoneOptedOut,
+    { phone: input.to },
+  );
+  if (optedOut) {
+    throw new Error("Recipient has opted out of SMS alerts.");
   }
 
   const body = buildOperatorSmsBody({ subject: input.subject, body: input.body });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -22,6 +22,12 @@ import {
   operatorNotificationEventKindValidator,
   operatorNotificationEventPreferencesValidator,
 } from "./lib/operatorNotificationPreferences";
+import {
+  smsConsentActionValidator,
+  smsConsentRecipientTypeValidator,
+  smsConsentStateScopeValidator,
+  smsConsentStateStatusValidator,
+} from "./lib/smsConsent";
 
 const serviceSummaryValidator = v.object({
   id: v.string(),
@@ -508,6 +514,32 @@ export default defineSchema({
     .index("by_business_id_and_phone", ["businessId", "phone"])
     .index("by_business_id_and_email", ["businessId", "email"]),
 
+  sms_consent_events: defineTable({
+    businessId: v.optional(v.id("businesses")),
+    contactId: v.optional(v.id("contacts")),
+    userId: v.optional(v.id("users")),
+    appointmentId: v.optional(v.id("appointments")),
+    recipientType: smsConsentRecipientTypeValidator,
+    phone: v.string(),
+    action: smsConsentActionValidator,
+    source: v.string(),
+    disclosureVersion: v.optional(v.string()),
+    disclosureText: v.optional(v.string()),
+    createdAt: v.string(),
+  })
+    .index("by_phone_and_created_at", ["phone", "createdAt"])
+    .index("by_business_id_and_created_at", ["businessId", "createdAt"])
+    .index("by_contact_id_and_created_at", ["contactId", "createdAt"])
+    .index("by_user_id_and_created_at", ["userId", "createdAt"]),
+
+  sms_consent_states: defineTable({
+    scope: smsConsentStateScopeValidator,
+    phone: v.string(),
+    status: smsConsentStateStatusValidator,
+    source: v.string(),
+    updatedAt: v.string(),
+  }).index("by_scope_and_phone", ["scope", "phone"]),
+
   conversations: defineTable({
     businessId: v.id("businesses"),
     contactId: v.optional(v.id("contacts")),
@@ -892,6 +924,10 @@ export default defineSchema({
     eventPreferences: operatorNotificationEventPreferencesValidator,
     dailySummaryEnabled: v.boolean(),
     dailySummarySendTime: v.string(),
+    smsConsentGrantedAt: v.optional(v.string()),
+    smsConsentRevokedAt: v.optional(v.string()),
+    smsConsentSource: v.optional(v.string()),
+    smsConsentDisclosureVersion: v.optional(v.string()),
     updatedAt: v.string(),
   })
     .index("by_business_id_and_user_id", ["businessId", "userId"])

--- a/convex/tests/dashboardOutcomeSummary.test.ts
+++ b/convex/tests/dashboardOutcomeSummary.test.ts
@@ -310,6 +310,7 @@ describe("Dashboard outcome summaries", () => {
       timezone: "America/Toronto",
       contactName: "Taylor Customer",
       contactPhone: "+14165550199",
+      smsConsentGranted: true,
     });
 
     const calls = await authed.query(api.voice.runtime.listRecentCalls, {

--- a/convex/tests/operatorNotifications.test.ts
+++ b/convex/tests/operatorNotifications.test.ts
@@ -165,6 +165,40 @@ describe("operator notification preferences", () => {
     ).rejects.toThrow(/verified phone number/i);
   });
 
+  it("rejects enabling SMS alerts without operator consent", async () => {
+    const t = createConvexHarness();
+    const seeded = await seedMember(t, {
+      subject: "operator-sms-consent-required",
+      email: "operator@example.com",
+      phone: "+15145550123",
+      phoneVerificationTime: Date.now(),
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("platform_sms_senders", {
+        role: "platform_alert",
+        label: "Test alert sender",
+        e164: "+15145550100",
+        status: "active",
+        smsEnabled: true,
+      });
+    });
+    const current = await seeded.authed.query(
+      api.users.preferences.getNotificationPreferences,
+      { businessId: seeded.businessId },
+    );
+
+    await expect(
+      seeded.authed.mutation(api.users.preferences.updateNotificationPreferences, {
+        businessId: seeded.businessId,
+        emailEnabled: true,
+        smsEnabled: true,
+        eventPreferences: current.eventPreferences,
+        dailySummaryEnabled: true,
+        dailySummarySendTime: "08:00",
+      }),
+    ).rejects.toThrow(/consent/i);
+  });
+
   it("marks SMS unavailable and rejects test SMS when no alert sender is configured", async () => {
     const originalTwilioAlertSmsFrom = process.env.TWILIO_ALERT_SMS_FROM;
     process.env.TWILIO_ALERT_SMS_FROM = "";
@@ -226,6 +260,20 @@ describe("operator notification preferences", () => {
           status: "active",
           smsEnabled: true,
         });
+      });
+
+      const current = await seeded.authed.query(
+        api.users.preferences.getNotificationPreferences,
+        { businessId: seeded.businessId },
+      );
+      await seeded.authed.mutation(api.users.preferences.updateNotificationPreferences, {
+        businessId: seeded.businessId,
+        emailEnabled: true,
+        smsEnabled: true,
+        eventPreferences: current.eventPreferences,
+        dailySummaryEnabled: true,
+        dailySummarySendTime: "08:00",
+        smsConsentAccepted: true,
       });
 
       for (let index = 0; index < 5; index += 1) {
@@ -315,6 +363,7 @@ describe("operator notification preferences", () => {
       eventPreferences: current.eventPreferences,
       dailySummaryEnabled: true,
       dailySummarySendTime: "08:00",
+      smsConsentAccepted: true,
     });
     await t.action(internal.operatorNotifications.dispatchEvent, {
       businessId: seeded.businessId,
@@ -432,6 +481,7 @@ describe("operator notification preferences", () => {
       },
       dailySummaryEnabled: true,
       dailySummarySendTime: "08:00",
+      smsConsentAccepted: true,
     });
 
     await t.action(internal.operatorNotifications.dispatchEvent, {

--- a/convex/tests/twilioSmsDelivery.test.ts
+++ b/convex/tests/twilioSmsDelivery.test.ts
@@ -499,7 +499,7 @@ describe("Twilio SMS delivery flow", () => {
     expect(sendTwilioMessageMock).toHaveBeenCalledWith({
       to: "+14165550195",
       from: smsNumber,
-      body: "LobbyStack: For help, contact support@lobbystack.com. Reply STOP to opt out.",
+      body: "LobbyStack: For help, contact hello@lobbystack.com or visit https://lobbystack.com. Reply STOP to opt out.",
       statusCallback: "https://example.convex.site/twilio/sms/status",
     });
 
@@ -522,7 +522,7 @@ describe("Twilio SMS delivery flow", () => {
       expect(contact?.smsConsentStatus).toBeUndefined();
       expect(messages.map((message) => message.direction)).toEqual(["inbound", "outbound"]);
       expect(outbound).toMatchObject({
-        body: "LobbyStack: For help, contact support@lobbystack.com. Reply STOP to opt out.",
+        body: "LobbyStack: For help, contact hello@lobbystack.com or visit https://lobbystack.com. Reply STOP to opt out.",
         aiGenerated: false,
         providerMessageSid: "SM-outbound-help-reply",
       });
@@ -578,7 +578,7 @@ describe("Twilio SMS delivery flow", () => {
         from: "+14165550196",
         body: "HELP",
         expected:
-          "LobbyStack: For help, contact support@lobbystack.com. Reply STOP to opt out.",
+          "LobbyStack: For help, contact hello@lobbystack.com or visit https://lobbystack.com. Reply STOP to opt out.",
       },
       {
         sid: "SM-inbound-start-no-ai",
@@ -659,7 +659,7 @@ describe("Twilio SMS delivery flow", () => {
     expect(sendTwilioMessageMock).toHaveBeenLastCalledWith({
       to: "+14165550197",
       from: smsNumber,
-      body: "LobbyStack: For help, contact support@lobbystack.com. Reply STOP to opt out.",
+      body: "LobbyStack: For help, contact hello@lobbystack.com or visit https://lobbystack.com. Reply STOP to opt out.",
       statusCallback: "https://example.convex.site/twilio/sms/status",
     });
 
@@ -1757,6 +1757,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550155",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const staffId = await ctx.db.insert("staff", {
         businessId,
@@ -1988,7 +1990,7 @@ describe("Twilio SMS delivery flow", () => {
     const notificationId = await t.run(async (ctx) => {
       const businessId = await ctx.db.insert("businesses", {
         slug: "twilio-notification-gsm-boundary",
-        name: "Twilio Notification GSM Boundary",
+        name: "T",
         timezone: "America/Toronto",
         businessType: "service_company",
         defaultLocale: "en",
@@ -2020,6 +2022,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550158",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const staffId = await ctx.db.insert("staff", {
         businessId,
@@ -2085,19 +2089,20 @@ describe("Twilio SMS delivery flow", () => {
     const serviceName = "Style AAAAAAAAAAAAAAAAA \ud83e\uddf4";
     const expectedBody = buildLocalizedAppointmentNotificationBody({
       kind: "appointment_reminder",
+      businessName: "T",
       serviceName,
       startsAt: "2026-06-15T15:00:00.000Z",
       timezone: "America/Toronto",
       locale: "en",
     });
 
-    expect(Array.from(expectedBody)).toHaveLength(134);
-    expect(expectedBody.length).toBe(135);
+    expect(Array.from(expectedBody)).toHaveLength(172);
+    expect(expectedBody.length).toBe(173);
 
     const notificationId = await t.run(async (ctx) => {
       const businessId = await ctx.db.insert("businesses", {
         slug: "twilio-notification-unicode-boundary",
-        name: "Twilio Notification Unicode Boundary",
+        name: "T",
         timezone: "America/Toronto",
         businessType: "service_company",
         defaultLocale: "en",
@@ -2129,6 +2134,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550159",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const staffId = await ctx.db.insert("staff", {
         businessId,
@@ -2197,6 +2204,8 @@ describe("Twilio SMS delivery flow", () => {
         name: "Taylor Customer",
         phone: "+14165550156",
         preferredLocale: "fr",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const staffId = await ctx.db.insert("staff", {
         businessId,
@@ -2250,7 +2259,7 @@ describe("Twilio SMS delivery flow", () => {
     });
     expect(sendTwilioMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.stringContaining("Répondez à ce message si vous devez le reporter."),
+        body: expect.stringContaining("Reply STOP to opt out or HELP for help."),
       }),
     );
     expect(sendTwilioMessageMock).toHaveBeenCalledWith(
@@ -2289,6 +2298,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550157",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const staffId = await ctx.db.insert("staff", {
         businessId,
@@ -2342,7 +2353,7 @@ describe("Twilio SMS delivery flow", () => {
     });
     expect(sendTwilioMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.stringContaining("Répondez à ce message si vous devez le reporter."),
+        body: expect.stringContaining("Reply STOP to opt out or HELP for help."),
       }),
     );
     expect(sendTwilioMessageMock).toHaveBeenCalledWith(
@@ -2371,6 +2382,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550154",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const staffId = await ctx.db.insert("staff", {
         businessId,
@@ -2456,6 +2469,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550153",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const conversationId = await ctx.db.insert("conversations", {
         businessId,
@@ -2554,6 +2569,8 @@ describe("Twilio SMS delivery flow", () => {
         businessId,
         name: "Taylor Customer",
         phone: "+14165550152",
+        smsConsentStatus: "subscribed",
+        smsConsentSource: "voice_booking",
       });
       const conversationId = await ctx.db.insert("conversations", {
         businessId,

--- a/convex/users/preferences.ts
+++ b/convex/users/preferences.ts
@@ -18,6 +18,11 @@ import {
   type OperatorNotificationChannel,
   type OperatorNotificationEventPreferences,
 } from "../lib/operatorNotificationPreferences";
+import {
+  OPERATOR_SMS_DISCLOSURE_TEXT,
+  OPERATOR_SMS_DISCLOSURE_VERSION,
+} from "../lib/smsConsent";
+import { recordSmsConsentEvent } from "../lib/smsConsentState";
 
 import { observedAction as action } from "../telemetry/observedFunctions";
 const localeValidator = v.union(v.literal("en"), v.literal("fr"));
@@ -35,6 +40,9 @@ type NotificationPreferencesPayload = {
   phoneVerified: boolean;
   canUseSms: boolean;
   smsUnavailableReason: SmsUnavailableReason;
+  smsConsentGranted: boolean;
+  smsConsentDisclosureVersion: string;
+  smsConsentDisclosureText: string;
 };
 
 type NotificationActionContext = {
@@ -82,13 +90,21 @@ function resolveNotificationPreferencesPayload(input: {
 }): NotificationPreferencesPayload {
   const phoneVerified = Boolean(input.user.phone && input.user.phoneVerificationTime);
   const canUseSms = input.smsUnavailableReason === null;
+  const grantedAt = input.preferences?.smsConsentGrantedAt;
+  const revokedAt = input.preferences?.smsConsentRevokedAt;
+  const smsConsentGranted = Boolean(
+    grantedAt &&
+      input.preferences?.smsConsentDisclosureVersion === OPERATOR_SMS_DISCLOSURE_VERSION &&
+      (!revokedAt || revokedAt < grantedAt),
+  );
+  const canSendSms = canUseSms && smsConsentGranted;
   const eventPreferences =
     input.preferences?.eventPreferences ?? buildDefaultOperatorNotificationEventPreferences();
 
   return {
     emailEnabled: input.preferences?.emailEnabled ?? true,
-    smsEnabled: canUseSms ? (input.preferences?.smsEnabled ?? false) : false,
-    eventPreferences: canUseSms
+    smsEnabled: canSendSms ? (input.preferences?.smsEnabled ?? false) : false,
+    eventPreferences: canSendSms
       ? eventPreferences
       : {
           voiceMessage: { ...eventPreferences.voiceMessage, sms: false },
@@ -106,6 +122,9 @@ function resolveNotificationPreferencesPayload(input: {
     phoneVerified,
     canUseSms,
     smsUnavailableReason: input.smsUnavailableReason,
+    smsConsentGranted,
+    smsConsentDisclosureVersion: OPERATOR_SMS_DISCLOSURE_VERSION,
+    smsConsentDisclosureText: OPERATOR_SMS_DISCLOSURE_TEXT,
   };
 }
 
@@ -113,12 +132,15 @@ function assertSmsPreferencesAllowed(input: {
   smsUnavailableReason: SmsUnavailableReason;
   smsEnabled: boolean;
   eventPreferences: OperatorNotificationEventPreferences;
+  smsConsentGranted: boolean;
+  smsConsentAccepted?: boolean;
 }) {
-  if (
-    input.smsUnavailableReason !== null &&
-    (input.smsEnabled || hasEnabledSmsEventPreference(input.eventPreferences))
-  ) {
+  const requestedSms = input.smsEnabled || hasEnabledSmsEventPreference(input.eventPreferences);
+  if (input.smsUnavailableReason !== null && requestedSms) {
     throw new Error(getSmsPreferenceErrorMessage(input.smsUnavailableReason));
+  }
+  if (requestedSms && !input.smsConsentGranted && input.smsConsentAccepted !== true) {
+    throw new Error("SMS notification consent is required before enabling SMS alerts.");
   }
 }
 
@@ -224,6 +246,7 @@ export const updateNotificationPreferences = mutation({
     eventPreferences: operatorNotificationEventPreferencesValidator,
     dailySummaryEnabled: v.boolean(),
     dailySummarySendTime: v.string(),
+    smsConsentAccepted: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<NotificationPreferencesPayload> => {
     const user = await ensureCurrentUser(ctx);
@@ -240,25 +263,56 @@ export const updateNotificationPreferences = mutation({
       args.dailySummarySendTime,
     );
 
-    assertSmsPreferencesAllowed({
-      smsUnavailableReason,
-      smsEnabled: args.smsEnabled,
-      eventPreferences: args.eventPreferences,
-    });
-
     const existing = await ctx.db
       .query("operator_notification_preferences")
       .withIndex("by_business_id_and_user_id", (q) =>
         q.eq("businessId", args.businessId).eq("userId", user._id),
       )
       .unique();
+    const existingGrantedAt = existing?.smsConsentGrantedAt;
+    const existingRevokedAt = existing?.smsConsentRevokedAt;
+    const existingSmsConsentGranted = Boolean(
+      existingGrantedAt &&
+        existing?.smsConsentDisclosureVersion === OPERATOR_SMS_DISCLOSURE_VERSION &&
+        (!existingRevokedAt || existingRevokedAt < existingGrantedAt),
+    );
+
+    assertSmsPreferencesAllowed({
+      smsUnavailableReason,
+      smsEnabled: args.smsEnabled,
+      eventPreferences: args.eventPreferences,
+      smsConsentGranted: existingSmsConsentGranted,
+      ...(args.smsConsentAccepted !== undefined
+        ? { smsConsentAccepted: args.smsConsentAccepted }
+        : {}),
+    });
+    const now = new Date().toISOString();
+    const requestedSms = args.smsEnabled || hasEnabledSmsEventPreference(args.eventPreferences);
+    const consentGrantPatch =
+      requestedSms && args.smsConsentAccepted === true
+        ? {
+            smsConsentGrantedAt: now,
+            smsConsentSource: "operator_notification_settings",
+            smsConsentDisclosureVersion: OPERATOR_SMS_DISCLOSURE_VERSION,
+          }
+        : {};
+    const consentRevokePatch =
+      existing?.smsEnabled === true && args.smsEnabled === false
+        ? {
+            smsConsentRevokedAt: now,
+            smsConsentSource: "operator_notification_settings",
+            smsConsentDisclosureVersion: OPERATOR_SMS_DISCLOSURE_VERSION,
+          }
+        : {};
     const patch = {
       emailEnabled: args.emailEnabled,
       smsEnabled: args.smsEnabled,
       eventPreferences: args.eventPreferences,
       dailySummaryEnabled: args.dailySummaryEnabled,
       dailySummarySendTime,
-      updatedAt: new Date().toISOString(),
+      ...consentGrantPatch,
+      ...consentRevokePatch,
+      updatedAt: now,
     };
 
     if (existing) {
@@ -271,14 +325,44 @@ export const updateNotificationPreferences = mutation({
       });
     }
 
-    return {
-      ...patch,
-      email: user.email ?? null,
-      phone: user.phone ?? null,
-      phoneVerified: Boolean(user.phone && user.phoneVerificationTime),
-      canUseSms: smsUnavailableReason === null,
+    if (user.phone && requestedSms && args.smsConsentAccepted === true) {
+      await recordSmsConsentEvent(ctx, {
+        businessId: args.businessId,
+        userId: user._id,
+        recipientType: "operator",
+        phone: user.phone,
+        action: "granted",
+        source: "operator_notification_settings",
+        disclosureVersion: OPERATOR_SMS_DISCLOSURE_VERSION,
+        disclosureText: OPERATOR_SMS_DISCLOSURE_TEXT,
+        createdAt: now,
+      });
+    }
+    if (user.phone && existing?.smsEnabled === true && args.smsEnabled === false) {
+      await recordSmsConsentEvent(ctx, {
+        businessId: args.businessId,
+        userId: user._id,
+        recipientType: "operator",
+        phone: user.phone,
+        action: "revoked",
+        source: "operator_notification_settings",
+        disclosureVersion: OPERATOR_SMS_DISCLOSURE_VERSION,
+        disclosureText: OPERATOR_SMS_DISCLOSURE_TEXT,
+        createdAt: now,
+      });
+    }
+
+    return resolveNotificationPreferencesPayload({
+      user,
+      preferences: existing
+        ? ({ ...existing, ...patch } as Doc<"operator_notification_preferences">)
+        : ({
+            businessId: args.businessId,
+            userId: user._id,
+            ...patch,
+          } as Doc<"operator_notification_preferences">),
       smsUnavailableReason,
-    };
+    });
   },
 });
 

--- a/convex/voice/runtime.ts
+++ b/convex/voice/runtime.ts
@@ -461,6 +461,7 @@ type BookAppointmentForVoiceArgs = {
   conversationId?: Id<"conversations">;
   contactName?: string;
   contactPhone: string;
+  smsConsentGranted: boolean;
 };
 type BookAppointmentForVoiceResult = {
   appointmentId: Id<"appointments">;
@@ -2196,6 +2197,7 @@ export const bookAppointmentForVoice = internalAction({
     conversationId: v.optional(v.id("conversations")),
     contactName: v.optional(v.string()),
     contactPhone: v.string(),
+    smsConsentGranted: v.boolean(),
   },
   handler: async (
     ctx: ActionCtx,
@@ -2228,6 +2230,7 @@ export const bookAppointmentForVoice = internalAction({
         ...(args.contactName !== undefined ? { contactName: args.contactName } : {}),
         contactPhone: args.contactPhone,
         sourceChannel: args.channel ?? "voice",
+        smsConsentGranted: args.smsConsentGranted,
       },
     );
 

--- a/mintlify/integrations/sms.mdx
+++ b/mintlify/integrations/sms.mdx
@@ -1,58 +1,73 @@
 ---
-title: "SMS, AI replies, and compliance"
-description: "Understand the difference between SMS alerts, AI SMS, manual replies, attachments, opt-out handling, and 10DLC setup."
+title: "SMS alerts and consent"
+description: "How LobbyStack collects consent for outbound appointment and workspace alert SMS."
 ---
 
-LobbyStack has two SMS-related concepts:
+LobbyStack uses one toll-free SMS number for outbound, non-marketing account notifications.
 
-- **Alert SMS**: system-sent SMS notifications, such as appointment confirmations or reminders, subject to the hosted alert SMS usage pool.
-- **AI SMS**: two-way AI-assisted SMS conversations with callers, available as a Pro add-on after setup and compliance approval.
+This number sends:
 
-<Note>
-  Hosted AI SMS is available on Pro with the AI SMS add-on and approved SMS compliance setup.
-</Note>
+- Appointment confirmations and reminders to customers.
+- Workspace alerts to verified operators.
 
-## Manual SMS conversations
+This number does not send marketing, promotions, age-gated content, AI SMS replies, or manual SMS conversations.
 
-The **Messages** page shows SMS conversations linked to contacts. Operators can reply manually to SMS conversations and can attach supported files.
+## Consent model
 
-Messages support:
+LobbyStack collects SMS consent before sending alerts.
 
-- Inbound and outbound SMS history.
-- Manual operator replies.
-- Attachments, including images and documents.
-- Delivery status.
-- Pausing or resuming AI automation for a conversation.
+Appointment customers and operators use the same toll-free number, but they consent in different places.
 
-## AI SMS add-on
+### Appointment customers
 
-AI SMS lets the receptionist respond to inbound text conversations using the same business context used for calls. The add-on is available on Pro and includes a compliance setup step before hosted business-number sending is ready.
+When a customer books by phone, the AI receptionist asks for verbal SMS consent before sending an appointment confirmation or reminder.
 
-Current catalog pricing in the app:
+The disclosure is:
 
-| Item | Price |
-| --- | --- |
-| AI SMS monthly add-on | $5/month |
-| AI SMS setup fee | $19 one time |
-| AI SMS usage | $0.03 per segment |
+> Can I text this number with your appointment confirmation and reminder? Message and data rates may apply. Reply STOP to opt out or HELP for help.
 
-## SMS compliance
+If the caller says yes, LobbyStack records the opt-in and sends appointment SMS for that phone number.
 
-Hosted AI SMS uses A2P 10DLC compliance setup. In **Settings** > **Billing**, the SMS compliance section collects business identity, contact, address, campaign, sample message, and opt-in information.
+If the caller says no, the appointment is still booked and no appointment SMS is sent.
 
-After compliance approval, LobbyStack can use your hosted business sender for AI SMS conversations.
+### Operators
 
-## Opt-out handling
+Operators are verified workspace users.
 
-LobbyStack tracks SMS consent. STOP-style keywords mark a contact as opted out, and START-style keywords can mark them subscribed again. You can review SMS consent on the contact detail page.
+Before operator workspace alerts are sent by SMS, the operator must enable SMS alerts in **Settings** > **Notifications** and accept the SMS disclosure in the dashboard.
 
-## Related pages
+The operator disclosure is:
 
-<CardGroup cols={2}>
-  <Card title="Messages" icon="message" href="/dashboard/messages">
-    Review SMS conversations, send manual replies, and pause or resume AI handling.
-  </Card>
-  <Card title="Plans and usage" icon="credit-card" href="/billing/usage">
-    See usage pools and metered segment behavior.
-  </Card>
-</CardGroup>
+> I agree to receive SMS alerts from LobbyStack about missed calls, new messages, appointment activity, and workspace notifications at my verified phone number. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out or HELP for help. SMS alerts are optional.
+
+Operators can disable SMS alerts later in notification settings.
+
+## Example messages
+
+Appointment confirmation:
+
+> Example Business: Your haircut appointment is confirmed for May 24 at 2:00 PM. Msg & data rates may apply. Reply STOP to opt out or HELP for help.
+
+Operator alert:
+
+> LobbyStack: New voice message for Example Business. Open your dashboard to review. Msg & data rates may apply. Reply STOP to opt out or HELP for help.
+
+## Opt-out and help
+
+Recipients can reply `STOP` to opt out of future SMS from the toll-free alert number.
+
+Recipients can reply `START` or `SUBSCRIBE` to resubscribe where supported.
+
+Recipients can reply `HELP` for support information.
+
+For help, contact [hello@lobbystack.com](mailto:hello@lobbystack.com) or visit [https://lobbystack.com](https://lobbystack.com).
+
+Message and data rates may apply.
+
+## SMS is optional
+
+SMS alerts are optional.
+
+Customers can book appointments without receiving SMS confirmations or reminders.
+
+Operators can use the dashboard without enabling SMS alerts.


### PR DESCRIPTION
## Summary
- require explicit appointment-customer SMS consent before voice-booked confirmations/reminders
- require dashboard operator consent before enabling/sending SMS alerts
- add shared platform alert opt-out state handling and outbound-only SMS consent docs

## Verification
- pnpm typecheck:convex
- pnpm --filter @lobbystack/web typecheck
- pnpm --filter @lobbystack/voice-gateway typecheck
- pnpm --filter @lobbystack/web test -- SettingsNotificationsPage.test.tsx
- pnpm --filter @lobbystack/voice-gateway test -- src/realtime/toolExecutor.test.ts src/webCall/routes.test.ts
- pnpm exec vitest run --config convex/vitest.config.ts convex/tests/operatorNotifications.test.ts convex/tests/twilioSmsDelivery.test.ts
- pnpm docs:validate
- pnpm docs:broken-links
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm convex dev --once

## Notes
- Twilio form should not be submitted until docs.lobbystack.com/integrations/sms serves this updated outbound-only consent page.