### PR TITLE
Fix signup Turnstile challenge

### DIFF
--- a/apps/web/src/components/signup-form.tsx
+++ b/apps/web/src/components/signup-form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, type FormEvent, type Ref } from "react";
+import { useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { LoaderCircle, TriangleAlert } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { Turnstile, type TurnstileHandle } from "@/components/turnstile";
+import { Turnstile } from "@/components/turnstile";
 import { isValidEmailAddress } from "@/lib/auth-validation";
 import {
   Field,
@@ -31,7 +31,6 @@ type SignupFormProps = {
   errorMessage: string | null;
   turnstileResetKey?: number;
   turnstileSiteKey?: string;
-  turnstileRef?: Ref<TurnstileHandle>;
   onEmailChange: (value: string) => void;
   onPasswordChange: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
@@ -48,7 +47,6 @@ export function SignupForm({
   errorMessage,
   turnstileResetKey = 0,
   turnstileSiteKey,
-  turnstileRef,
   onEmailChange,
   onPasswordChange,
   onSubmit,
@@ -56,8 +54,6 @@ export function SignupForm({
   onTurnstileTokenChange,
 }: SignupFormProps) {
   const { t } = useTranslation("auth");
-  const [shouldReserveTurnstileSpace, setShouldReserveTurnstileSpace] =
-    useState(false);
   const [hasBlurredEmail, setHasBlurredEmail] = useState(false);
   const [hasFocusedPassword, setHasFocusedPassword] = useState(false);
   const isEmailInvalid =
@@ -138,25 +134,6 @@ export function SignupForm({
             ) : null}
           </Field>
 
-          {turnstileSiteKey ? (
-            <div
-              className={
-                shouldReserveTurnstileSpace
-                  ? "-mt-1"
-                  : "pointer-events-none absolute left-0 top-0 h-0 w-full overflow-hidden"
-              }
-            >
-              <Turnstile
-                key={turnstileResetKey}
-                ref={turnstileRef}
-                onReserveSpaceChange={setShouldReserveTurnstileSpace}
-                onTokenChange={onTurnstileTokenChange ?? (() => {})}
-                siteKey={turnstileSiteKey}
-                {...(onTurnstileError ? { onError: onTurnstileError } : {})}
-              />
-            </div>
-          ) : null}
-
           {errorMessage ? (
             <div className="flex flex-col gap-2 -mt-1">
               <FieldError>{errorMessage}</FieldError>
@@ -175,6 +152,15 @@ export function SignupForm({
           </Button>
         </FieldGroup>
       </form>
+
+      {turnstileSiteKey ? (
+        <Turnstile
+          key={turnstileResetKey}
+          onTokenChange={onTurnstileTokenChange ?? (() => {})}
+          siteKey={turnstileSiteKey}
+          {...(onTurnstileError ? { onError: onTurnstileError } : {})}
+        />
+      ) : null}
 
       <p className="text-center text-sm text-muted-foreground">
         {t("signup.haveAccount")}{" "}

--- a/apps/web/src/components/turnstile.test.tsx
+++ b/apps/web/src/components/turnstile.test.tsx
@@ -1,4 +1,4 @@
-import { act, createRef } from "react";
+import { createRef } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -30,31 +30,30 @@ describe("Turnstile", () => {
     delete window.turnstile;
   });
 
-  it("does not reserve widget space before a challenge is needed", async () => {
+  it("keeps widget space reserved while the challenge is mounted", async () => {
     const turnstile = installTurnstileMock();
     const rendered = render(
       <Turnstile onTokenChange={() => {}} siteKey="site-key" />,
     );
     const wrapper = rendered.container.firstElementChild as HTMLElement;
 
-    expect(wrapper.className).toContain("h-0");
-    expect(wrapper.className).toContain("overflow-hidden");
+    expect(wrapper.className).toContain("min-h-[80px]");
 
     await waitFor(() => expect(turnstile.render).toHaveBeenCalledOnce());
 
     expect(turnstile.getRenderOptions()).toMatchObject({
-      appearance: "interaction-only",
-      execution: "execute",
+      appearance: "always",
+      execution: "render",
       "response-field": false,
-      tabindex: -1,
+      size: "flexible",
+      tabindex: 0,
       theme: "auto",
     });
-    expect(wrapper.className).toContain("h-0");
-    expect(wrapper.className).toContain("overflow-hidden");
-    expect(wrapper.hasAttribute("inert")).toBe(true);
+    expect(wrapper.className).toContain("min-h-[80px]");
+    expect(wrapper.hasAttribute("inert")).toBe(false);
   });
 
-  it("reserves widget space only when Turnstile enters interactive mode", async () => {
+  it("executes the rendered widget without hiding the challenge container", async () => {
     const turnstile = installTurnstileMock();
     const turnstileRef = createRef<TurnstileHandle>();
     const rendered = render(
@@ -70,25 +69,7 @@ describe("Turnstile", () => {
     await waitFor(() => {
       expect(turnstile.execute).toHaveBeenCalledWith(widgetContainer);
     });
-    expect(wrapper.className).toContain("h-0");
-    expect(wrapper.className).toContain("overflow-hidden");
-    expect(wrapper.hasAttribute("inert")).toBe(true);
-
-    act(() => {
-      turnstile.getRenderOptions()?.["before-interactive-callback"]?.();
-    });
-
-    await waitFor(() => {
-      expect(wrapper.className).toContain("min-h-[65px]");
-    });
+    expect(wrapper.className).toContain("min-h-[80px]");
     expect(wrapper.hasAttribute("inert")).toBe(false);
-
-    act(() => {
-      turnstile.getRenderOptions()?.["after-interactive-callback"]?.();
-    });
-
-    expect(wrapper.className).toContain("h-0");
-    expect(wrapper.className).toContain("overflow-hidden");
-    expect(wrapper.hasAttribute("inert")).toBe(true);
   });
 });

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -109,7 +109,6 @@ type TurnstileProps = {
   siteKey: string;
   onTokenChange: (token: string | null) => void;
   onError?: (errorCode?: string) => void;
-  onReserveSpaceChange?: (shouldReserveSpace: boolean) => void;
 };
 
 export type TurnstileHandle = {
@@ -117,7 +116,7 @@ export type TurnstileHandle = {
 };
 
 export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Turnstile(
-  { siteKey, onTokenChange, onError, onReserveSpaceChange },
+  { siteKey, onTokenChange, onError },
   ref,
 ) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -126,7 +125,6 @@ export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Tu
   const executeTimerRef = useRef<number | null>(null);
   const onTokenChangeRef = useRef(onTokenChange);
   const onErrorRef = useRef(onError);
-  const [isActive, setIsActive] = useState(false);
   const [errorCode, setErrorCode] = useState<string | null>(null);
 
   onTokenChangeRef.current = onTokenChange;
@@ -134,7 +132,6 @@ export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Tu
 
   function handleLoadError(error?: unknown): void {
     onTokenChangeRef.current(null);
-    setIsActive(false);
     setErrorCode(error instanceof Error ? error.message : "script-load-failed");
     onErrorRef.current?.();
   }
@@ -150,34 +147,24 @@ export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Tu
 
     widgetIdRef.current = window.turnstile.render(containerRef.current, {
       sitekey: siteKey,
-      appearance: "interaction-only",
-      execution: "execute",
+      appearance: "always",
+      execution: "render",
       "response-field": false,
       size: "flexible",
-      tabindex: -1,
+      tabindex: 0,
       theme: "auto",
       callback: (token) => {
-        setIsActive(false);
         onTokenChangeRef.current(token);
       },
       "expired-callback": () => {
-        setIsActive(false);
         onTokenChangeRef.current(null);
       },
       "timeout-callback": () => {
-        setIsActive(true);
         onTokenChangeRef.current(null);
-      },
-      "before-interactive-callback": () => {
-        setIsActive(true);
-      },
-      "after-interactive-callback": () => {
-        setIsActive(false);
       },
       "error-callback": (errorCode) => {
         console.warn("Turnstile challenge failed to render.", { errorCode });
         onTokenChangeRef.current(null);
-        setIsActive(false);
         setErrorCode(errorCode ?? "unknown");
         onErrorRef.current?.(errorCode);
         return true;
@@ -208,7 +195,6 @@ export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Tu
   }
 
   function executeChallenge(): boolean {
-    setIsActive(false);
     setErrorCode(null);
 
     if (!renderWidget()) {
@@ -246,7 +232,6 @@ export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Tu
   useEffect(() => {
     let isMounted = true;
 
-    setIsActive(false);
     setErrorCode(null);
     onTokenChangeRef.current(null);
 
@@ -287,32 +272,9 @@ export const Turnstile = forwardRef<TurnstileHandle, TurnstileProps>(function Tu
     };
   }, [siteKey]);
 
-  const shouldShowDevError = Boolean(errorCode && import.meta.env.DEV);
-  const shouldReserveSpace = isActive || shouldShowDevError;
-
-  useEffect(() => {
-    onReserveSpaceChange?.(shouldReserveSpace);
-  }, [onReserveSpaceChange, shouldReserveSpace]);
-
-  useEffect(() => {
-    return () => {
-      onReserveSpaceChange?.(false);
-    };
-  }, [onReserveSpaceChange]);
-
   return (
-    <div
-      inert={shouldReserveSpace ? undefined : true}
-      className={
-        shouldReserveSpace
-          ? "flex min-h-[65px] w-full flex-col items-start justify-center gap-2"
-          : "pointer-events-none h-0 w-full overflow-hidden"
-      }
-    >
-      <div className="h-[65px] w-full min-w-[300px]" ref={containerRef} />
-      {shouldShowDevError ? (
-        <p className="text-sm text-destructive">Turnstile error: {errorCode}</p>
-      ) : null}
+    <div className="flex min-h-[80px] w-full flex-col items-start justify-center gap-2">
+      <div className="min-h-[80px] w-full" ref={containerRef} />
     </div>
   );
 });

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -35,6 +35,10 @@ vi.mock("@/components/turnstile", async () => {
       props: TurnstileMockProps,
       ref,
     ) {
+      React.useEffect(() => {
+        props.onTokenChange(turnstileTokenMock());
+      }, [props.onTokenChange]);
+
       React.useImperativeHandle(ref, () => ({
         execute: () => {
           const result = turnstileExecuteMock();
@@ -381,9 +385,19 @@ describe("SignupPage", () => {
     expect(screen.queryByText("errors.signupFailed")).toBeNull();
   });
 
-  it("preflights Turnstile after the user fills plausible credentials", async () => {
+  it("renders Turnstile as soon as the signup page loads", async () => {
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("turnstile")).toBeTruthy();
+    expect(turnstileExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an explicit Turnstile site key when one is configured", async () => {
     vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key");
-    turnstileExecuteMock.mockReturnValue(true);
 
     render(
       <MemoryRouter>
@@ -391,23 +405,7 @@ describe("SignupPage", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByTestId("turnstile")).toBeNull();
-
-    const user = userEvent.setup();
-    await user.type(screen.getByLabelText("signup.email"), "owner@example.com");
-    await user.type(screen.getByLabelText("signup.password"), "abcde1!");
-
-    await new Promise((resolve) => window.setTimeout(resolve, 800));
-
-    expect(screen.queryByTestId("turnstile")).toBeNull();
-    expect(turnstileExecuteMock).not.toHaveBeenCalled();
-
-    await user.type(screen.getByLabelText("signup.password"), "f");
-
-    await waitFor(() => expect(screen.getByTestId("turnstile")).toBeTruthy());
-    await waitFor(() => expect(turnstileExecuteMock).toHaveBeenCalledOnce(), {
-      timeout: 1000,
-    });
+    expect(screen.getByTestId("turnstile")).toBeTruthy();
   });
 
   it("unblocks signup when Turnstile returns without a token during submit", async () => {

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useConvexAuth } from "convex/react";
 import { useTranslation } from "react-i18next";
@@ -10,7 +10,6 @@ import { api } from "../../../../../convex/_generated/api";
 import { ForgotPasswordForm } from "@/components/forgot-password-form";
 import { LoginForm } from "@/components/login-form";
 import { SignupForm } from "@/components/signup-form";
-import type { TurnstileHandle } from "@/components/turnstile";
 import { Button } from "@/components/ui/button";
 import { OnboardingShell } from "@/features/onboarding/components/OnboardingShell";
 import { captureAnalyticsEvent, resetAnalyticsIdentity } from "@/lib/analytics";
@@ -18,6 +17,8 @@ import { isValidEmailAddress, meetsSignupPasswordRequirements } from "@/lib/auth
 import { useObservedAction } from "@/lib/observed-convex";
 
 type AuthErrorFlow = "signIn" | "signUp" | "resetRequest" | "resetVerification";
+
+const DEV_TURNSTILE_SITE_KEY = "0x4AAAAAADKUjCqHD6BIFbWo";
 
 function capturePublicAuthEvent(name: "web.auth.login_succeeded" | "web.auth.signup_succeeded") {
   resetAnalyticsIdentity();
@@ -147,27 +148,20 @@ export function LoginPage() {
 export function SignupPage() {
   const { t } = useTranslation("auth");
   const { signIn } = useAuthActions();
-  const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY?.trim();
+  const configuredTurnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY?.trim();
+  const turnstileSiteKey =
+    configuredTurnstileSiteKey || (import.meta.env.DEV ? DEV_TURNSTILE_SITE_KEY : undefined);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [turnstileResetKey, setTurnstileResetKey] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const turnstileRef = useRef<TurnstileHandle | null>(null);
   const pendingTurnstileSubmitRef = useRef(false);
-  const turnstilePreflightKeyRef = useRef<string | null>(null);
-  const normalizedEmail = email.trim().toLowerCase();
   const isSignupReady = isValidEmailAddress(email) && meetsSignupPasswordRequirements(password);
-  const hasPlausibleSignupCredentials =
-    normalizedEmail.includes("@") && meetsSignupPasswordRequirements(password);
-  const shouldPrepareTurnstile = Boolean(
-    turnstileSiteKey && hasPlausibleSignupCredentials,
-  );
 
   const handleTurnstileError = useCallback(() => {
     pendingTurnstileSubmitRef.current = false;
-    turnstilePreflightKeyRef.current = null;
     setTurnstileToken(null);
     setIsSubmitting(false);
     setErrorMessage(t("errors.turnstileFailed"));
@@ -202,7 +196,6 @@ export function SignupPage() {
       keepSubmitting = true;
       capturePublicAuthEvent("web.auth.signup_succeeded");
     } catch (error) {
-      turnstilePreflightKeyRef.current = null;
       setTurnstileToken(null);
       setTurnstileResetKey((current) => current + 1);
       setErrorMessage(getAuthErrorMessage(error, "signUp", t));
@@ -217,7 +210,6 @@ export function SignupPage() {
     (token: string | null) => {
       setTurnstileToken(token);
       if (!token) {
-        turnstilePreflightKeyRef.current = null;
         if (pendingTurnstileSubmitRef.current) {
           pendingTurnstileSubmitRef.current = false;
           setIsSubmitting(false);
@@ -234,35 +226,11 @@ export function SignupPage() {
     [submitSignUp, t],
   );
 
-  useEffect(() => {
-    if (!shouldPrepareTurnstile || turnstileToken || isSubmitting) {
-      return;
-    }
-
-    const preflightKey = `${normalizedEmail}\n${password}`;
-    if (turnstilePreflightKeyRef.current === preflightKey) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      turnstilePreflightKeyRef.current = preflightKey;
-      const started = turnstileRef.current?.execute() ?? false;
-      if (!started) {
-        turnstilePreflightKeyRef.current = null;
-      }
-    }, 700);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [isSubmitting, normalizedEmail, password, shouldPrepareTurnstile, turnstileToken]);
-
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     if (!isValidEmailAddress(email) || !meetsSignupPasswordRequirements(password)) {
       pendingTurnstileSubmitRef.current = false;
-      turnstilePreflightKeyRef.current = null;
       setTurnstileToken(null);
       setErrorMessage(
         isValidEmailAddress(email) ? t("errors.invalidPassword") : t("signup.emailInvalid"),
@@ -270,16 +238,10 @@ export function SignupPage() {
       return;
     }
 
-    if (turnstileSiteKey && hasPlausibleSignupCredentials && !turnstileToken) {
-      setIsSubmitting(true);
+    if (turnstileSiteKey && !turnstileToken) {
       setErrorMessage(null);
       pendingTurnstileSubmitRef.current = true;
-      const started = turnstileRef.current?.execute() ?? false;
-      if (!started) {
-        pendingTurnstileSubmitRef.current = false;
-        setIsSubmitting(false);
-        setErrorMessage(t("errors.turnstileRequired"));
-      }
+      setErrorMessage(t("errors.turnstileRequired"));
       return;
     }
 
@@ -327,8 +289,7 @@ export function SignupPage() {
         onTurnstileTokenChange={handleTurnstileTokenChange}
         password={password}
         turnstileResetKey={turnstileResetKey}
-        turnstileRef={turnstileRef}
-        turnstileSiteKey={shouldPrepareTurnstile ? turnstileSiteKey : undefined}
+        turnstileSiteKey={turnstileSiteKey || undefined}
       />
     </OnboardingShell>
   );

--- a/convex/lib/turnstile.test.ts
+++ b/convex/lib/turnstile.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { verifyTurnstileForSignUp } from "./turnstile";
+
+describe("verifyTurnstileForSignUp", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("posts the token to Cloudflare as form-encoded siteverify data", async () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "secret-key");
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await verifyTurnstileForSignUp({
+      "cf-turnstile-response": "turnstile-token",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    expect(init.body).toBeInstanceOf(URLSearchParams);
+    expect((init.body as URLSearchParams).get("secret")).toBe("secret-key");
+    expect((init.body as URLSearchParams).get("response")).toBe("turnstile-token");
+  });
+
+  it("allows local development without a configured secret", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CONVEX_SITE_URL", "http://127.0.0.1:3211");
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "");
+    vi.stubGlobal("fetch", vi.fn());
+
+    await expect(
+      verifyTurnstileForSignUp({
+        "cf-turnstile-response": "turnstile-token",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("requires a configured secret outside local development", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DEPLOYMENT_MODE", "cloud");
+    vi.stubEnv("CONVEX_SITE_URL", "https://valiant-ibis-521.convex.site");
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "");
+
+    await expect(
+      verifyTurnstileForSignUp({
+        "cf-turnstile-response": "turnstile-token",
+      }),
+    ).rejects.toThrow("Turnstile is not configured.");
+  });
+
+  it("includes Cloudflare error codes in thrown verification errors", async () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "secret-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            success: false,
+            "error-codes": ["invalid-input-response"],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(
+      verifyTurnstileForSignUp({
+        "cf-turnstile-response": "turnstile-token",
+      }),
+    ).rejects.toThrow("Turnstile verification failed: invalid-input-response");
+  });
+});

--- a/convex/lib/turnstile.ts
+++ b/convex/lib/turnstile.ts
@@ -7,6 +7,15 @@ type TurnstileSiteverifyResponse = {
   "error-codes"?: Array<string>;
 };
 
+function getVerificationFailureMessage(outcome?: TurnstileSiteverifyResponse): string {
+  const errorCodes = outcome?.["error-codes"];
+  if (!errorCodes || errorCodes.length === 0) {
+    return "Turnstile verification failed.";
+  }
+
+  return `Turnstile verification failed: ${errorCodes.join(", ")}`;
+}
+
 function getStringParam(
   params: Partial<Record<string, Value | undefined>>,
   key: string,
@@ -15,12 +24,20 @@ function getStringParam(
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function isLocalConvexSiteUrl(): boolean {
+  const siteUrl = process.env.CONVEX_SITE_URL?.trim();
+  return Boolean(
+    siteUrl?.startsWith("http://127.0.0.1:") ||
+      siteUrl?.startsWith("http://localhost:"),
+  );
+}
+
 export async function verifyTurnstileForSignUp(
   params: Partial<Record<string, Value | undefined>>,
 ): Promise<void> {
   const secret = process.env.TURNSTILE_SECRET_KEY?.trim();
   if (!secret) {
-    if (process.env.DEPLOYMENT_MODE === "development" && process.env.NODE_ENV !== "production") {
+    if (isLocalConvexSiteUrl()) {
       return;
     }
 
@@ -34,15 +51,17 @@ export async function verifyTurnstileForSignUp(
     throw new Error("Turnstile verification required.");
   }
 
+  const body = new URLSearchParams({
+    secret,
+    response: token,
+  });
+
   const response = await fetch(TURNSTILE_SITEVERIFY_URL, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: JSON.stringify({
-      secret,
-      response: token,
-    }),
+    body,
   });
 
   if (!response.ok) {
@@ -51,6 +70,6 @@ export async function verifyTurnstileForSignUp(
 
   const outcome = (await response.json()) as TurnstileSiteverifyResponse;
   if (outcome.success !== true) {
-    throw new Error("Turnstile verification failed.");
+    throw new Error(getVerificationFailureMessage(outcome));
   }
 }


### PR DESCRIPTION
## Summary
- render the signup Turnstile challenge immediately with visible flexible sizing
- keep signup submission blocked until a Turnstile token is available
- send Turnstile siteverify requests as form-encoded data and keep missing-secret bypass local-only
- add frontend and Convex verifier regression tests

## Tests
- pnpm exec vitest run --config convex/vitest.config.ts convex/lib/turnstile.test.ts
- pnpm --filter @lobbystack/web exec vitest run src/components/turnstile.test.tsx src/features/auth/AuthPages.test.tsx