### PR TITLE
fix: preserve web voice SDP offers

### DIFF
--- a/apps/voice-gateway/src/webCall/routes.test.ts
+++ b/apps/voice-gateway/src/webCall/routes.test.ts
@@ -395,6 +395,60 @@ describe("web call routes", () => {
     );
   });
 
+  it("creates OpenAI web calls with multipart SDP and session config", async () => {
+    fetchWebVoiceContextMock.mockResolvedValueOnce({ snapshot: demoSnapshot });
+    startWebVoiceCallMock.mockResolvedValueOnce({
+      businessId: "business_123",
+      callId: "call_123",
+      conversationId: "conversation_123",
+    });
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response("answer-sdp", {
+        status: 200,
+        headers: { location: "/v1/realtime/calls/rtc_test" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const server = createServer();
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/web-call/sessions",
+      headers: {
+        origin: "https://lobbystack.com",
+        "content-type": "application/json",
+      },
+      payload: {
+        businessSlug: "lobbystack",
+        sdp: "v=0\r\n",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/realtime/calls",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-openai-key",
+        },
+      }),
+    );
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(requestInit?.body).toBeInstanceOf(FormData);
+    const formData = requestInit?.body as FormData;
+    expect(formData.get("sdp")).toBe("v=0\r\n");
+    expect(JSON.parse(String(formData.get("session")))).toEqual({
+      type: "realtime",
+      model: "gpt-realtime",
+      audio: {
+        output: {
+          voice: "marin",
+        },
+      },
+    });
+  });
+
   it("returns durable Convex rate limits before starting an OpenAI web call", async () => {
     fetchWebVoiceContextMock.mockRejectedValueOnce(
       new runtimeRequestErrorClass({

--- a/apps/voice-gateway/src/webCall/routes.ts
+++ b/apps/voice-gateway/src/webCall/routes.ts
@@ -194,8 +194,8 @@ function parseWebCallSessionRequest(body: unknown):
     return { ok: false, message: "Missing business slug." };
   }
 
-  const sdp = rawSdp?.trim() ?? "";
-  if (!sdp) {
+  const sdp = rawSdp ?? "";
+  if (!sdp.trim()) {
     return { ok: false, message: "Missing SDP offer." };
   }
 
@@ -927,18 +927,28 @@ async function exchangeWebRtcOffer(input: {
   model: string;
   sdp: string;
 }): Promise<{ answerSdp: string; providerCallId: string }> {
-  const response = await fetch(
-    `https://api.openai.com/v1/realtime/calls?model=${encodeURIComponent(input.model)}`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${input.apiKey}`,
-        "Content-Type": "application/sdp",
-        Accept: "application/sdp",
+  const formData = new FormData();
+  formData.set("sdp", input.sdp);
+  formData.set(
+    "session",
+    JSON.stringify({
+      type: "realtime",
+      model: input.model,
+      audio: {
+        output: {
+          voice: "marin",
+        },
       },
-      body: input.sdp,
-    },
+    }),
   );
+
+  const response = await fetch("https://api.openai.com/v1/realtime/calls", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`,
+    },
+    body: formData,
+  });
 
   if (!response.ok) {
     throw new OpenAiWebRtcSetupError({


### PR DESCRIPTION
## Summary
- preserve browser SDP offers exactly so OpenAI can parse terminating CRLFs
- send OpenAI Realtime calls using multipart form data with session config
- add regression coverage for multipart SDP forwarding

## Verification
- pnpm --filter @lobbystack/voice-gateway test
- pnpm --filter @lobbystack/voice-gateway typecheck
- pnpm --filter @lobbystack/voice-gateway build
- Live prod verification: https://lobbystack.com demo connected and persisted completed call mx7b3b4p1vzm8rjcn84eegkgbh87amvz