### PR TITLE
OPE-135 fix Google Calendar disconnect cleanup

### DIFF
--- a/convex/integrations/calendar.ts
+++ b/convex/integrations/calendar.ts
@@ -1135,12 +1135,19 @@ export const processGoogleCalendarDisconnectBatch = internalAction({
 
     for (const appointmentId of page.appointmentIds) {
       if (args.phase === "delete") {
-        await ctx.runAction(
-          internal.integrations.googleCalendar.deleteAppointmentEventForDisconnect,
-          {
-            appointmentId,
-          },
-        );
+        try {
+          await ctx.runAction(
+            internal.integrations.googleCalendar.deleteAppointmentEventForDisconnect,
+            {
+              appointmentId,
+            },
+          );
+        } catch (error) {
+          console.warn("Failed to delete Google Calendar event during disconnect.", {
+            appointmentId: String(appointmentId),
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
         continue;
       }
 

--- a/convex/tests/calendarReconciliation.test.ts
+++ b/convex/tests/calendarReconciliation.test.ts
@@ -54,6 +54,7 @@ const originalSessionEncryptionKey = process.env.SESSION_ENCRYPTION_KEY;
 
 let googleEventCounter = 0;
 let failGoogleEventWrites = false;
+let failGoogleEventDeletes = false;
 let forceInvalidGoogleSyncToken = false;
 let forceGoogleRefreshTokenRevoked = false;
 let googleEventsByCalendar: Record<string, Record<string, MockGoogleEvent>> = {};
@@ -61,6 +62,7 @@ let googleEventsByCalendar: Record<string, Record<string, MockGoogleEvent>> = {}
 function resetGoogleMockState(): void {
   googleEventCounter = 0;
   failGoogleEventWrites = false;
+  failGoogleEventDeletes = false;
   forceInvalidGoogleSyncToken = false;
   forceGoogleRefreshTokenRevoked = false;
   googleEventsByCalendar = {
@@ -198,6 +200,13 @@ function installGoogleFetchMock(): void {
         }
 
         if (method === "DELETE" && eventId) {
+          if (failGoogleEventDeletes) {
+            return new Response(JSON.stringify({ error: { message: "Google delete failed." } }), {
+              status: 500,
+              headers: { "content-type": "application/json" },
+            });
+          }
+
           delete googleEventsByCalendar[calendarId][eventId];
           return new Response(null, { status: 204 });
         }
@@ -707,6 +716,52 @@ describe("calendar reconciliation backend", () => {
     });
 
     expect(Object.keys(googleEventsByCalendar["primary-calendar"] ?? {})).toHaveLength(0);
+  });
+
+  it("disconnects locally when mirrored Google event cleanup fails", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, serviceId, staffId } = await t.run(async (ctx) => {
+      return await seedBookableBusiness(ctx, {
+        slug: "disconnect-calendar-delete-failure-business",
+        name: "Disconnect Calendar Delete Failure Business",
+      });
+    });
+    const connectionId = await connectGoogleCalendar(t, { businessId, staffId });
+    const appointmentId = await bookAppointment(t, { businessId, serviceId });
+
+    const syncResult = await t.action(
+      internal.integrations.calendar.syncAppointmentToExternalCalendars,
+      {
+        appointmentId,
+      },
+    );
+
+    expect(syncResult).toMatchObject({
+      ok: true,
+      status: "synced",
+    });
+    expect(Object.keys(googleEventsByCalendar["primary-calendar"] ?? {})).toHaveLength(1);
+
+    failGoogleEventDeletes = true;
+
+    const authed = t.withIdentity({
+      subject: `calendar-owner:${String(businessId)}:${String(staffId)}`,
+    });
+    await authed.action(api.integrations.calendar.disconnectGoogleCalendar, {
+      businessId,
+    });
+
+    await t.run(async (ctx) => {
+      const connection = await ctx.db.get(connectionId);
+      const appointment = await ctx.db.get(appointmentId);
+
+      expect(connection).toBeNull();
+      expect(appointment?.calendarSyncState).toBe("not_required");
+      expect(appointment?.calendarExternalEventId).toBeUndefined();
+      expect(appointment?.calendarLastSyncError).toBeUndefined();
+      expect(appointment?.calendarReconcileAfter).toBeUndefined();
+    });
+    expect(Object.keys(googleEventsByCalendar["primary-calendar"] ?? {})).toHaveLength(1);
   });
 
   it("records sync failures and schedules reconciliation", async () => {


### PR DESCRIPTION
## Summary
- Continue local Google Calendar disconnect when mirrored external event deletion fails
- Log failed Google event cleanup instead of aborting the disconnect batch
- Add regression coverage for failed external event cleanup during disconnect

## Verification
- pnpm typecheck:convex
- pnpm test:convex -- calendarReconciliation.test.ts