### PR TITLE
Fix business deployment mode bootstrap

### DIFF
--- a/convex/businesses/admin.ts
+++ b/convex/businesses/admin.ts
@@ -27,8 +27,21 @@ import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboard
 
 import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 
+const businessDeploymentModes = new Set([
+  "cloud",
+  "self_hosted_standard",
+  "development",
+]);
+
 function normalizeBootstrapBusinessName(name: string): string {
   return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function getBusinessDeploymentMode(): string {
+  const deploymentMode = process.env.DEPLOYMENT_MODE;
+  return deploymentMode && businessDeploymentModes.has(deploymentMode)
+    ? deploymentMode
+    : "development";
 }
 
 async function findExistingBootstrapBusiness(
@@ -114,7 +127,7 @@ export const bootstrapBusiness = mutation({
       // the user has supplied a website, knowledge, and greeting.
       onboardingStage: "website",
       businessType: args.businessType,
-      deploymentMode: "development",
+      deploymentMode: getBusinessDeploymentMode(),
       status: "active",
     });
 

--- a/convex/tests/onboardingAbuseControls.test.ts
+++ b/convex/tests/onboardingAbuseControls.test.ts
@@ -1,6 +1,6 @@
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest } from "convex-test";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api } from "../_generated/api";
 import { onboardingRateLimiter } from "../lib/components";
@@ -13,6 +13,8 @@ import { modules } from "../test.setup";
 const { workflowStartMock } = vi.hoisted(() => ({
   workflowStartMock: vi.fn(async () => null),
 }));
+
+const originalDeploymentMode = process.env.DEPLOYMENT_MODE;
 
 vi.mock("../lib/components", async () => {
   const actual = await vi.importActual<typeof import("../lib/components")>("../lib/components");
@@ -36,6 +38,10 @@ beforeEach(() => {
   workflowStartMock.mockClear();
 });
 
+afterEach(() => {
+  process.env.DEPLOYMENT_MODE = originalDeploymentMode;
+});
+
 async function seedBootstrapUser(subject: string) {
   const t = createConvexHarness();
   const userId = await t.run(async (ctx) => {
@@ -49,6 +55,26 @@ async function seedBootstrapUser(subject: string) {
 }
 
 describe("onboarding abuse controls", () => {
+  it("uses the configured deployment mode for bootstrapped businesses", async () => {
+    process.env.DEPLOYMENT_MODE = "cloud";
+
+    const subject = "bootstrap-cloud-deployment-mode";
+    const { t } = await seedBootstrapUser(subject);
+    const authed = t.withIdentity({ subject });
+
+    const result = await authed.mutation(api.businesses.admin.bootstrapBusiness, {
+      name: "Cloud Business",
+      slug: "cloud-business",
+      timezone: "America/Toronto",
+      businessType: "general",
+    });
+
+    await t.run(async (ctx) => {
+      const business = await ctx.db.get(result.businessId);
+      expect(business?.deploymentMode).toBe("cloud");
+    });
+  });
+
   it("reuses an existing same-name bootstrap business for duplicate submissions", async () => {
     const subject = "bootstrap-idempotent";
     const { t, userId } = await seedBootstrapUser(subject);


### PR DESCRIPTION
## Summary
- Use the configured Convex `DEPLOYMENT_MODE` when bootstrapping new businesses instead of hardcoding `development`.
- Add a Convex regression test that verifies cloud deployments create cloud businesses.

## Production Data
- Production Convex was patched after a dry run matched the expected 7 businesses.
- Verified all 7 existing production `businesses` rows now have `deploymentMode: "cloud"`.
- The temporary backfill function was deployed only for the patch and then removed in the final deployed code.

## Verification
- `pnpm exec vitest run --config convex/vitest.config.ts convex/tests/onboardingAbuseControls.test.ts`
- `pnpm typecheck:convex`
- `npx convex data businesses --prod --format json --limit 100`