### PR TITLE
OPE-25 document Railway template rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ pnpm self-hosted:verify
 
 For prerequisites, local smoke vs production go-live, helper scripts, and troubleshooting, see the [Docker Compose self-hosting guide](https://docs.lobbystack.com/self-hosting/docker-compose).
 
+### Self-Hosted Railway
+
+Deploy on Railway using a marketplace template based on the official [Convex template](https://railway.com/deploy/convex) plus LobbyStack Web and Voice Gateway services. Full wiring, variable reference, and marketplace publish steps are in [`docs/deployment/railway-template.md`](docs/deployment/railway-template.md).
+
+After the unlisted template validates successfully and is published, add:
+
+```md
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/<TEMPLATE_CODE>?utm_medium=integration&utm_source=button&utm_campaign=lobbystack)
+```
+
 ## Contributing
 
 Contributions are welcome. Start with [CONTRIBUTING.md](./CONTRIBUTING.md), keep Convex as the primary backend, and keep the voice gateway focused on the live call path.

--- a/docs/deployment/railway-marketplace-overview.md
+++ b/docs/deployment/railway-marketplace-overview.md
@@ -1,0 +1,64 @@
+# Marketplace overview (paste into Railway publish form)
+
+Use this copy after the unlisted LobbyStack template validates successfully. Replace `<TEMPLATE_CODE>` after creation.
+
+---
+
+# Deploy and Host LobbyStack with Railway
+
+LobbyStack is an open-source AI receptionist for phone calls, SMS, and appointment scheduling. This template deploys a self-hosted stack: official Convex + Postgres, the operator web dashboard, and the voice gateway for Twilio and OpenAI Realtime.
+
+## About Hosting LobbyStack
+
+This template extends the official [Convex template](https://railway.com/deploy/convex) with LobbyStack application services. Railway provisions Postgres, the Convex backend and dashboard, builds the LobbyStack web app, and runs the voice gateway. After deploy, you push Convex functions from your machine and configure provider credentials (Twilio, OpenAI, etc.).
+
+The Convex layer uses the same admin-key flow as the official Convex template: copy the key from **Convex Backend** deploy logs, set `CONVEX_SELF_HOSTED_ADMIN_KEY`, and restart the backend.
+
+## Common Use Cases
+
+- Self-hosted AI phone receptionist for clinics, salons, and local service businesses
+- HIPAA- or GDPR-sensitive deployments where you control infrastructure
+- Teams that want open-source voice AI with calendar and SMS integrations
+- Developers evaluating LobbyStack before production hardening
+
+## Dependencies for LobbyStack Hosting
+
+### Deployment Dependencies
+
+- [LobbyStack repository](https://github.com/lobbystack/lobbystack)
+- [Official Convex on Railway](https://railway.com/deploy/convex)
+- [LobbyStack Railway deployment guide](https://github.com/lobbystack/lobbystack/blob/main/docs/deployment/railway-template.md)
+- [Self-hosting documentation](https://docs.lobbystack.com/self-hosting/overview)
+
+### Implementation Details
+
+Services included:
+
+1. **Postgres** — Convex persistence (from Convex template)
+2. **Convex Backend** — ports 3210 (API) and 3211 (HTTP actions via TCP proxy)
+3. **Convex Dashboard** — admin UI on port 8080
+4. **Web** — LobbyStack operator dashboard (`Dockerfile.web`, port 8080)
+5. **Voice Gateway** — live call runtime (`Dockerfile.voice-gateway`, port 3001)
+
+Post-deploy (required):
+
+1. Set `CONVEX_SELF_HOSTED_ADMIN_KEY` from Convex Backend logs
+2. Run `pnpm self-hosted:convex:env` and `pnpm self-hosted:convex:deploy` from a local clone
+3. Redeploy **Web** after public URLs are final
+4. Configure Twilio and OpenAI credentials
+
+## Why Deploy LobbyStack on Railway?
+
+Railway hosts the full stack—database, backend, web, and voice—on one platform with private networking between services, managed TLS, and vertical scaling. You avoid operating Caddy or separate Fly.io voice hosting for a standard self-hosted LobbyStack deployment.
+
+---
+
+## Deploy button (after publish)
+
+```md
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/<TEMPLATE_CODE>?utm_medium=integration&utm_source=button&utm_campaign=lobbystack)
+```
+
+## Template authoring
+
+Create and validate the template privately from [Railway workspace templates](https://railway.com/workspace/templates) using the service settings listed in the Railway deployment guide. Publish only after a fresh Railway deploy passes the post-deploy checklist.

--- a/docs/deployment/railway-template.md
+++ b/docs/deployment/railway-template.md
@@ -1,0 +1,179 @@
+# Railway marketplace template for self-hosted LobbyStack
+
+Author a full self-hosted LobbyStack template in the [Railway template composer](https://railway.com/workspace/templates). The template should extend Railway's official **[Convex template](https://railway.com/deploy/convex)** pattern with LobbyStack **Web** and **Voice Gateway** services.
+
+Railway templates do not need `railway.toml` files. Configure each service directly in the template composer, or generate an unpublished template from a cleaned Railway reference project and review it in the composer before publishing.
+
+Start with an **unlisted** template. Deploy it once in your own workspace, fix any wiring gaps, then publish it to the marketplace. Do not attach a live demo project for the first version.
+
+> Railway must have an active workspace plan before you can create or attach services for validation. If the workspace trial is expired, finish the local docs and resume the Railway validation after billing is active.
+
+## Architecture
+
+| Service | Source | Role |
+|---------|--------|------|
+| Postgres | [Convex template](https://railway.com/deploy/convex) | Convex persistence |
+| Convex Backend | Convex template | Self-hosted Convex API (3210) and HTTP actions (3211) |
+| Convex Dashboard | Convex template | Admin UI (8080) |
+| Web | `lobbystack/lobbystack` + [`Dockerfile.web`](../../Dockerfile.web) | Operator dashboard (nginx, port 8080) |
+| Voice Gateway | `lobbystack/lobbystack` + [`Dockerfile.voice-gateway`](../../Dockerfile.voice-gateway) | Twilio / OpenAI Realtime runtime (port 3001) |
+
+Railway provides HTTPS per service. Caddy from the Docker Compose stack is not required.
+
+## Author the template
+
+1. Confirm the source branch is `main` and includes `Dockerfile.web`, `Dockerfile.voice-gateway`, and the self-hosted helper scripts.
+2. Open [Railway workspace templates](https://railway.com/workspace/templates).
+3. Click **New Template**.
+4. Add the Convex services using the official [Convex template](https://railway.com/deploy/convex) as the configuration reference:
+   - **Postgres**
+   - **Convex Backend**
+   - **Convex Dashboard**
+5. Add two GitHub services from `lobbystack/lobbystack` on `main`:
+   - **Web**
+   - **Voice Gateway**
+6. Configure service build and deploy settings directly in the composer:
+
+| Service | Dockerfile | Start command | Healthcheck |
+|---------|------------|---------------|-------------|
+| Web | `Dockerfile.web` | `nginx -g 'daemon off;'` | `/healthz` |
+| Voice Gateway | `Dockerfile.voice-gateway` | `./node_modules/.bin/tsx src/index.ts` | `/health` |
+
+7. Generate public networking:
+   - **Web** → port **8080**
+   - **Voice Gateway** → port **3001**
+   - **Convex Backend** → HTTP port **3210**
+   - **Convex Backend** → **TCP proxy** port **3211** (HTTP actions / `CONVEX_SITE_URL`)
+   - **Convex Dashboard** → port **8080**
+
+## Variable wiring
+
+Use exact service names for `${{...}}` references (case-sensitive): `Convex Backend`, `Convex Dashboard`, `Postgres`, `Web`, `Voice Gateway`.
+
+### Convex Backend (from official template + LobbyStack)
+
+| Variable | Value |
+|----------|-------|
+| `CONVEX_CLOUD_ORIGIN` | `${{PUBLIC_CONVEX_CLOUD_ORIGIN}}` |
+| `CONVEX_SITE_ORIGIN` | `${{PUBLIC_CONVEX_SITE_ORIGIN}}` |
+| `CONVEX_SELF_HOSTED_ADMIN_KEY` | Copy from first-run deploy logs, then restart backend |
+| `INSTANCE_SECRET` | `${{secret(64, "abcdef0123456789")}}` (template default) |
+| `POSTGRES_URL` | `${{Postgres.CONVEX_DATABASE_URL}}` |
+| `APP_BASE_URL` | `https://${{Web.RAILWAY_PUBLIC_DOMAIN}}` |
+| `SITE_URL` | `https://${{Web.RAILWAY_PUBLIC_DOMAIN}}` |
+| `VOICE_GATEWAY_BASE_URL` | `https://${{Voice Gateway.RAILWAY_PUBLIC_DOMAIN}}` |
+| `CONVEX_URL` | `${{PUBLIC_CONVEX_CLOUD_ORIGIN}}` |
+| `CONVEX_SITE_URL` | `${{PUBLIC_CONVEX_SITE_ORIGIN}}` |
+| `INTERNAL_SERVICE_TOKEN` | `${{secret(32)}}` |
+| `SESSION_ENCRYPTION_KEY` | `${{secret(32)}}` |
+| `NUMBER_CLAIM_TOKEN_SECRET` | `${{secret(32)}}` |
+| `DEPLOYMENT_MODE` | `self_hosted_standard` |
+
+Enable **TCP proxy** on **Convex Backend** for port **3211** so `PUBLIC_CONVEX_SITE_ORIGIN` resolves to `http://${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}`.
+
+### Web (build-time + runtime)
+
+| Variable | Value |
+|----------|-------|
+| `CONVEX_URL` | `${{Convex Backend.PUBLIC_CONVEX_CLOUD_ORIGIN}}` |
+| `CONVEX_SITE_URL` | `${{Convex Backend.PUBLIC_CONVEX_SITE_ORIGIN}}` |
+| `VITE_APP_NAME` | `LobbyStack` |
+| `VITE_DEPLOYMENT_MODE` | `self_hosted_standard` |
+
+Redeploy **Web** after Convex public URLs are final.
+
+### Voice Gateway
+
+| Variable | Value |
+|----------|-------|
+| `CONVEX_SITE_URL` | `http://${{Convex Backend.RAILWAY_PRIVATE_DOMAIN}}:3211` |
+| `VOICE_GATEWAY_BASE_URL` | `https://${{Voice Gateway.RAILWAY_PUBLIC_DOMAIN}}` |
+| `WEB_CALL_ALLOWED_ORIGINS` | `https://${{Web.RAILWAY_PUBLIC_DOMAIN}}` |
+| `INTERNAL_SERVICE_TOKEN` | Same value as on **Convex Backend** |
+| `DEPLOYMENT_MODE` | `self_hosted_standard` |
+| `VOICE_GATEWAY_TRUST_PROXY` | `true` |
+| `PORT` | `3001` |
+| `OPENAI_API_KEY` | User-supplied (required for voice) |
+| Twilio vars | User-supplied when using telephony |
+
+## Post-deploy checklist
+
+### 1. Convex admin key ([official Convex template flow](https://railway.com/deploy/convex))
+
+1. Open **Convex Backend** deploy logs on first run.
+2. Copy the line after `Admin key:` (format `railway|...`).
+3. Set `CONVEX_SELF_HOSTED_ADMIN_KEY` on **Convex Backend**.
+4. Restart **Convex Backend**.
+5. Open **Convex Dashboard** public URL and sign in with the admin key.
+
+Do **not** use the `convex-postgres` SSH flow (`./generate_admin_key.sh`) for the `convex` template unless you migrate templates.
+
+### 2. Deploy LobbyStack Convex functions
+
+From a local clone:
+
+```bash
+cp .env.self-hosted.example .env.self-hosted
+# Set:
+# CONVEX_SELF_HOSTED_URL=https://<convex-backend-3210-domain>
+# CONVEX_SELF_HOSTED_ADMIN_KEY=<admin-key-from-logs>
+pnpm self-hosted:convex:env
+pnpm self-hosted:convex:deploy
+```
+
+Sync provider secrets (Twilio, OpenAI, Turnstile, etc.) via `pnpm self-hosted:convex:env` — see [environment variables](https://docs.lobbystack.com/self-hosting/environment-variables).
+
+### 3. Redeploy Web
+
+After public URLs and Convex env are stable:
+
+```bash
+railway redeploy --service Web --yes
+```
+
+### 4. Verify
+
+```bash
+pnpm self-hosted:verify
+```
+
+Manual checks:
+
+- `https://<web-domain>/healthz` → 200
+- `https://<convex-backend-domain>/version` → 200
+- `https://<voice-domain>/health` → 200
+
+## Validate the unpublished template
+
+1. Create the template and leave it unpublished/unlisted.
+2. Deploy the template into a fresh Railway project in your own workspace.
+3. Complete the post-deploy checklist above.
+4. Run `pnpm self-hosted:verify` with Railway-specific verify URLs.
+5. Fix the template composer settings until the deploy passes without manual service rewiring.
+
+## Publish the marketplace template
+
+1. Review all five services, volumes, TCP proxy on 3211, and variable descriptions in the composer.
+2. Publish using the overview in [`railway-marketplace-overview.md`](./railway-marketplace-overview.md).
+3. Leave **Live Demo** empty for v1.
+4. Copy the template code and add the **Deploy on Railway** button to the README:
+
+   ```md
+   [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/<TEMPLATE_CODE>?utm_medium=integration&utm_source=button&utm_campaign=lobbystack)
+   ```
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `PUBLIC_CONVEX_SITE_ORIGIN` is `http://:` | Enable TCP proxy on **Convex Backend** port 3211 and redeploy |
+| Web loads but Convex client errors | Redeploy **Web** after setting final `CONVEX_URL` / `CONVEX_SITE_URL` build args |
+| Voice gateway unhealthy | Confirm `PORT=3001`, private `CONVEX_SITE_URL`, and `INTERNAL_SERVICE_TOKEN` match Convex Backend |
+| Service limit in a throwaway project | Author the template directly in the template composer instead of provisioning a reference project |
+| `pnpm self-hosted:convex:deploy` fails | Confirm admin key is set and backend restarted |
+
+## Related docs
+
+- [Docker Compose self-hosting](https://docs.lobbystack.com/self-hosting/docker-compose)
+- [Environment variables](https://docs.lobbystack.com/self-hosting/environment-variables)
+- [Official Convex on Railway](https://railway.com/deploy/convex)

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -102,6 +102,7 @@
         "pages": [
           "self-hosting/overview",
           "self-hosting/docker-compose",
+          "self-hosting/railway",
           "self-hosting/environment-variables",
           "self-hosting/providers"
         ]

--- a/mintlify/self-hosting/railway.mdx
+++ b/mintlify/self-hosting/railway.mdx
@@ -1,0 +1,49 @@
+---
+title: "Railway deployment"
+description: "Deploy self-hosted LobbyStack on Railway using the official Convex template plus Web and Voice Gateway services."
+---
+
+## Overview
+
+The Railway template deploys:
+
+- **Postgres**, **Convex Backend**, and **Convex Dashboard** from the official [Convex template](https://railway.com/deploy/convex)
+- **Web** — LobbyStack operator dashboard
+- **Voice Gateway** — Twilio and OpenAI Realtime runtime
+
+See the full runbook in the repository: [Railway template guide](https://github.com/lobbystack/lobbystack/blob/main/docs/deployment/railway-template.md).
+
+## Quick start
+
+1. Deploy the LobbyStack Railway template.
+2. Enable **TCP proxy** on **Convex Backend** port **3211**.
+3. Copy the **Admin key** from Convex Backend deploy logs → set `CONVEX_SELF_HOSTED_ADMIN_KEY` → restart backend.
+4. From a local clone, run `pnpm self-hosted:convex:env` and `pnpm self-hosted:convex:deploy`.
+5. Redeploy **Web** and configure Twilio / OpenAI credentials.
+
+For template maintainers: create the first template as unlisted, validate it in a fresh Railway project, and publish only after the health checks and Convex deploy flow pass. A live demo project is optional and not required for the first marketplace version.
+
+## Service ports
+
+| Service | Port |
+|---------|------|
+| Convex Backend (API) | 3210 |
+| Convex Backend (HTTP actions) | 3211 (TCP proxy) |
+| Convex Dashboard | 8080 |
+| Web | 8080 |
+| Voice Gateway | 3001 |
+
+## Template service settings
+
+Configure the LobbyStack app services directly in the Railway template composer:
+
+| Service | Dockerfile | Start command | Healthcheck |
+|---------|------------|---------------|-------------|
+| Web | `Dockerfile.web` | `nginx -g 'daemon off;'` | `/healthz` |
+| Voice Gateway | `Dockerfile.voice-gateway` | `./node_modules/.bin/tsx src/index.ts` | `/health` |
+
+## Related
+
+- [Docker Compose deployment](/self-hosting/docker-compose)
+- [Environment variables](/self-hosting/environment-variables)
+- [Provider setup](/self-hosting/providers)


### PR DESCRIPTION
## Summary
- add the Railway self-hosting template runbook and marketplace overview copy
- add the Mintlify Railway self-hosting page and nav entry
- document the unlisted-first validation flow, no live demo for v1, and active Railway plan prerequisite

## Railway status
- Railway auth/context reads worked for project lobbystack-self-hosted-reference
- creating/attaching Web failed because the Railway workspace trial is expired
- template creation/validation remains blocked until the workspace has an active plan

## Verification
- pnpm docs:validate