### PR TITLE
OPE-137 allow Cal embed in landing CSP

### DIFF
--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -110,14 +110,16 @@ export default defineConfig({
       scriptDirective: {
         resources: [
           "'self'",
+          "https://app.cal.com",
           "https://ts.lobbystack.com",
           "https://us-assets.i.posthog.com",
         ],
       },
       directives: [
         "default-src 'self'",
-        "connect-src 'self' https://voice.lobbystack.com https://voice-dev.lobbystack.com https://lobbystack-voice-prod.fly.dev https://ai-receptionist-voice-dev-raphael.fly.dev http://localhost:3001 http://127.0.0.1:3001 https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
-        "img-src 'self' data: https://images.unsplash.com https://i.pravatar.cc https://media.theresanaiforthat.com https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
+        "connect-src 'self' https://app.cal.com https://voice.lobbystack.com https://voice-dev.lobbystack.com https://lobbystack-voice-prod.fly.dev https://ai-receptionist-voice-dev-raphael.fly.dev http://localhost:3001 http://127.0.0.1:3001 https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
+        "frame-src 'self' https://app.cal.com",
+        "img-src 'self' data: https://app.cal.com https://images.unsplash.com https://i.pravatar.cc https://media.theresanaiforthat.com https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
       ],
     },
   },


### PR DESCRIPTION
## Summary
- Allows `https://app.cal.com` in the landing site's CSP for scripts, frames, images, and connections.
- Fixes production-only behavior where the Cal embed script was blocked, so `Book a Demo` did nothing and the floating calendar button never rendered.

## Verification
- `pnpm --filter @lobbystack/landing build`
- `pnpm --filter @lobbystack/landing typecheck` (0 errors; existing Astro hint only)
- Confirmed generated `dist/index.html` CSP includes `app.cal.com` in `script-src`, `connect-src`, `frame-src`, and `img-src`.

Linear: OPE-137