### PR TITLE
OPE-137 widen Cal modal

### DIFF
--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -116,7 +116,8 @@ cal-modal-box.cal-element-embed-light {
 }
 
 cal-modal-box.cal-element-embed-light > iframe.cal-embed {
-  width: min(100%, 748px) !important;
+  width: calc(100vw - 48px) !important;
+  max-width: 1000px !important;
   height: min(957px, calc(100dvh - 48px)) !important;
   max-height: calc(100dvh - 48px) !important;
   border: 0;


### PR DESCRIPTION
## Summary
- Fix the Cal modal iframe width so desktop displays a proper wide calendar instead of the 300px intrinsic iframe width
- Preserve the mobile full-screen behavior

## Verification
- pnpm --filter @lobbystack/landing build
- pnpm --filter @lobbystack/landing typecheck
- Browser: localhost:4321 at 1440x900 shows Cal iframe at 1000px wide