### PR TITLE
OPE-137 use default Cal embed

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -19,6 +19,7 @@
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@base-ui/react": "^1.3.0",
+    "@calcom/embed-react": "^1.5.3",
     "@jdevalk/astro-seo-graph": "^2.0.0",
     "@jdevalk/seo-graph-core": "^0.6.2",
     "@tailwindcss/vite": "^4.2.4",

--- a/apps/landing/src/components/CalDemoModal.tsx
+++ b/apps/landing/src/components/CalDemoModal.tsx
@@ -1,0 +1,110 @@
+import Cal, { getCalApi } from "@calcom/embed-react"
+import {
+  CAL_DEMO_CONFIG,
+  CAL_DEMO_LINK,
+  CAL_DEMO_NAMESPACE,
+} from "@/lib/app-links"
+import { CalendarDays, X } from "lucide-react"
+import { useEffect, useState } from "react"
+
+export function CalDemoModal() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    const openDemo = (event: MouseEvent) => {
+      const target = event.target
+
+      if (!(target instanceof Element)) return
+      if (!target.closest("[data-cal-demo-trigger]")) return
+
+      event.preventDefault()
+      setIsOpen(true)
+    }
+
+    document.addEventListener("click", openDemo)
+
+    return () => {
+      document.removeEventListener("click", openDemo)
+    }
+  }, [])
+
+  useEffect(() => {
+    const configureCal = async () => {
+      const cal = await getCalApi({ namespace: CAL_DEMO_NAMESPACE })
+
+      cal("ui", {
+        hideEventTypeDetails: false,
+        layout: CAL_DEMO_CONFIG.layout,
+        theme: CAL_DEMO_CONFIG.theme,
+      })
+    }
+
+    configureCal()
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false)
+    }
+
+    document.body.style.overflow = "hidden"
+    window.addEventListener("keydown", closeOnEscape)
+
+    return () => {
+      document.body.style.overflow = ""
+      window.removeEventListener("keydown", closeOnEscape)
+    }
+  }, [isOpen])
+
+  return (
+    <>
+      <button
+        type="button"
+        className="fixed right-6 bottom-6 z-50 inline-flex size-16 cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-black/20 transition-transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95 md:right-9 md:bottom-8"
+        aria-label="Book a Demo"
+        data-cal-demo-trigger
+        data-ph-capture-attribute-section="floating_cta"
+        data-ph-capture-attribute-action="book_demo"
+        data-ph-capture-attribute-destination={`cal.com/${CAL_DEMO_LINK}`}
+      >
+        <CalendarDays className="size-7" aria-hidden="true" />
+      </button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-[2147483646] flex items-center justify-center bg-black/55 p-4 md:p-6"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Book a Demo"
+        >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Close demo scheduler"
+            onClick={() => setIsOpen(false)}
+          />
+          <div className="relative z-10 flex h-[min(780px,calc(100dvh-2rem))] w-[min(1080px,calc(100vw-2rem))] flex-col overflow-hidden rounded-lg bg-background shadow-2xl md:h-[min(820px,calc(100dvh-3rem))] md:w-[min(1120px,calc(100vw-3rem))]">
+            <div className="flex h-12 shrink-0 items-center justify-end border-b border-border/70 px-3">
+              <button
+                type="button"
+                className="inline-flex size-9 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                aria-label="Close demo scheduler"
+                onClick={() => setIsOpen(false)}
+              >
+                <X className="size-5" aria-hidden="true" />
+              </button>
+            </div>
+            <Cal
+              namespace={CAL_DEMO_NAMESPACE}
+              calLink={CAL_DEMO_LINK}
+              className="cal-demo-inline"
+              config={CAL_DEMO_CONFIG}
+            />
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/landing/src/components/CtaSection.tsx
+++ b/apps/landing/src/components/CtaSection.tsx
@@ -1,5 +1,9 @@
 import { buttonVariants } from "@/components/ui/button"
-import { APP_SIGNUP_URL, CAL_DEMO_TRIGGER_ATTRIBUTES } from "@/lib/app-links"
+import {
+  APP_SIGNUP_URL,
+  CAL_DEMO_DESTINATION,
+  CAL_DEMO_TRIGGER_ATTRIBUTES,
+} from "@/lib/app-links"
 import { cn } from "@/lib/utils"
 import { ArrowRight, CalendarDays } from "lucide-react"
 
@@ -40,7 +44,7 @@ export function CtaSection() {
             )}
             data-ph-capture-attribute-section="final_cta"
             data-ph-capture-attribute-action="book_demo"
-            data-ph-capture-attribute-destination="cal.com/raphaelm/lobbystack"
+            data-ph-capture-attribute-destination={CAL_DEMO_DESTINATION}
             {...CAL_DEMO_TRIGGER_ATTRIBUTES}
           >
             <CalendarDays className="mr-1 size-4" />

--- a/apps/landing/src/components/HeroSection.tsx
+++ b/apps/landing/src/components/HeroSection.tsx
@@ -1,6 +1,10 @@
 import { buttonVariants } from "@/components/ui/button"
 import { GithubIcon } from "@/components/GithubIcon"
-import { APP_SIGNUP_URL, CAL_DEMO_TRIGGER_ATTRIBUTES } from "@/lib/app-links"
+import {
+  APP_SIGNUP_URL,
+  CAL_DEMO_DESTINATION,
+  CAL_DEMO_TRIGGER_ATTRIBUTES,
+} from "@/lib/app-links"
 import { cn } from "@/lib/utils"
 import { ArrowRight, CalendarDays } from "lucide-react"
 import type { ReactNode } from "react"
@@ -66,7 +70,7 @@ export function HeroSection({ children }: { children?: ReactNode }) {
                 )}
                 data-ph-capture-attribute-section="hero"
                 data-ph-capture-attribute-action="book_demo"
-                data-ph-capture-attribute-destination="cal.com/raphaelm/lobbystack"
+                data-ph-capture-attribute-destination={CAL_DEMO_DESTINATION}
                 {...CAL_DEMO_TRIGGER_ATTRIBUTES}
               >
                 <CalendarDays className="mr-1 size-4" />

--- a/apps/landing/src/layouts/main.astro
+++ b/apps/landing/src/layouts/main.astro
@@ -28,11 +28,6 @@ import {
   localeMeta,
   type Locale,
 } from "@/lib/i18n"
-import {
-  CAL_DEMO_CONFIG,
-  CAL_DEMO_LINK,
-  CAL_DEMO_NAMESPACE,
-} from "@/lib/app-links"
 
 interface Props {
   seo?: PageSeo
@@ -190,101 +185,10 @@ Astro.response.headers.set("Content-Signal", CONTENT_SIGNAL)
         <link rel="alternate" hreflang={link.hrefLang} href={link.href} />
       ))
     }
-    <script is:inline>
-      ;(function (C, A, L) {
-        let p = function (a, ar) {
-          a.q.push(ar)
-        }
-        let d = C.document
-        C.Cal =
-          C.Cal ||
-          function () {
-            let cal = C.Cal
-            let ar = arguments
-            if (!cal.loaded) {
-              cal.ns = {}
-              cal.q = cal.q || []
-              d.head.appendChild(d.createElement("script")).src = A
-              cal.loaded = true
-            }
-            if (ar[0] === L) {
-              const api = function () {
-                p(api, arguments)
-              }
-              const namespace = ar[1]
-              api.q = api.q || []
-              if (typeof namespace === "string") {
-                cal.ns[namespace] = cal.ns[namespace] || api
-                p(cal.ns[namespace], ar)
-                p(cal, ["initNamespace", namespace])
-              } else p(cal, ar)
-              return
-            }
-            p(cal, ar)
-          }
-      })(window, "https://app.cal.com/embed/embed.js", "init")
-      Cal("init", "lobbystack", { origin: "https://app.cal.com" })
-      Cal.ns.lobbystack("ui", {
-        hideEventTypeDetails: false,
-        layout: "month_view",
-        theme: "light",
-      })
-
-      const attachFloatingDemoButton = () => {
-        const button = document.getElementById("floating-demo-cta")
-        if (!(button instanceof HTMLElement)) return
-
-        button.addEventListener("click", () => {
-          const calLink = button.dataset.calLink
-          const config = JSON.parse(button.dataset.calConfig || "{}")
-          window.Cal?.ns?.lobbystack?.("modal", { calLink, config })
-        })
-      }
-
-      if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", attachFloatingDemoButton, {
-          once: true,
-        })
-      } else {
-        attachFloatingDemoButton()
-      }
-    </script>
   </head>
   <body class="antialiased">
     <a href="#main-content" class="skip-link">{skipLabel}</a>
     <slot />
-    <button
-      id="floating-demo-cta"
-      type="button"
-      class="fixed right-6 bottom-6 z-50 inline-flex size-16 cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-black/20 transition-transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95 md:right-9 md:bottom-8"
-      aria-label="Book a Demo"
-      data-ph-capture-attribute-section="floating_cta"
-      data-ph-capture-attribute-action="book_demo"
-      data-ph-capture-attribute-destination={`cal.com/${CAL_DEMO_LINK}`}
-      data-cal-link={CAL_DEMO_LINK}
-      data-cal-namespace={CAL_DEMO_NAMESPACE}
-      data-cal-config={CAL_DEMO_CONFIG}
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="size-7"
-        aria-hidden="true"
-      >
-        <path d="M8 2v4"></path>
-        <path d="M16 2v4"></path>
-        <rect width="18" height="18" x="3" y="4" rx="2"></rect>
-        <path d="M3 10h18"></path>
-      </svg>
-      <span class="sr-only">Book a Demo</span>
-    </button>
     <script is:inline src="/webmcp.js" defer></script>
   </body>
 </html>

--- a/apps/landing/src/lib/app-links.ts
+++ b/apps/landing/src/lib/app-links.ts
@@ -3,14 +3,13 @@ export const APP_SIGNUP_URL = "https://app.lobbystack.com/signup"
 
 export const CAL_DEMO_LINK = "raphaelm/lobbystack"
 export const CAL_DEMO_NAMESPACE = "lobbystack"
-export const CAL_DEMO_CONFIG = JSON.stringify({
+export const CAL_DEMO_DESTINATION = `cal.com/${CAL_DEMO_LINK}`
+export const CAL_DEMO_CONFIG = {
   layout: "month_view",
   theme: "light",
   useSlotsViewOnSmallScreen: "true",
-})
+} as const
 
 export const CAL_DEMO_TRIGGER_ATTRIBUTES = {
-  "data-cal-link": CAL_DEMO_LINK,
-  "data-cal-namespace": CAL_DEMO_NAMESPACE,
-  "data-cal-config": CAL_DEMO_CONFIG,
+  "data-cal-demo-trigger": "true",
 } as const

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -12,6 +12,7 @@ import {
 import { FaqSection } from "@/components/FaqSection"
 import { CtaSection } from "@/components/CtaSection"
 import { Footer } from "@/components/Footer"
+import { CalDemoModal } from "@/components/CalDemoModal"
 import { homeFaqs } from "@/lib/home-faqs"
 import {
   faqPageJsonLd,
@@ -49,4 +50,5 @@ import {
     <CtaSection />
   </main>
   <Footer showTaaftBadge />
+  <CalDemoModal client:load />
 </Layout>

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -101,42 +101,16 @@
   @apply fixed top-3 left-3 z-[100] -translate-y-16 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-transform focus-visible:translate-y-0 focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none;
 }
 
-cal-modal-box.cal-element-embed-light {
-  position: fixed !important;
-  inset: 0 !important;
-  z-index: 2147483646 !important;
-  display: flex !important;
-  width: 100vw !important;
-  height: 100dvh !important;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-  padding: 24px;
-  background: rgb(0 0 0 / 48%);
+.cal-demo-inline {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
 }
 
-cal-modal-box.cal-element-embed-light > iframe.cal-embed {
-  width: calc(100vw - 48px) !important;
-  max-width: 1000px !important;
-  height: min(957px, calc(100dvh - 48px)) !important;
-  max-height: calc(100dvh - 48px) !important;
+.cal-demo-inline iframe {
+  width: 100%;
+  height: 100%;
   border: 0;
-  border-radius: 8px;
-  background: white;
-  box-shadow: 0 24px 80px rgb(0 0 0 / 24%);
-}
-
-@media (max-width: 640px) {
-  cal-modal-box.cal-element-embed-light {
-    padding: 0;
-  }
-
-  cal-modal-box.cal-element-embed-light > iframe.cal-embed {
-    width: 100vw !important;
-    height: 100dvh !important;
-    max-height: 100dvh !important;
-    border-radius: 0;
-  }
 }
 
 /* Staggered reveal animations */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@calcom/embed-react':
+        specifier: ^1.5.3
+        version: 1.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@jdevalk/astro-seo-graph':
         specifier: ^2.0.0
         version: 2.0.0(astro@6.3.8(@types/node@24.12.0)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.21.0)(yaml@2.8.3))(typescript@5.9.3)
@@ -873,6 +876,18 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@calcom/embed-core@1.5.3':
+    resolution: {integrity: sha512-GeId9gaByJ5EWiPmuvelZOvFWPOTWkcWZr5vGTCbIUTX125oE5yn0n8lDF1MJk5Xj1WO+/dk9jKIE08Ad9ytiQ==}
+
+  '@calcom/embed-react@1.5.3':
+    resolution: {integrity: sha512-JCgge04pc8fhdvUmPNVLhW8/lCWK+AAziKecKWWPfv1nn2s+qKP2BwsEAnxhxK9yPOBgE1EIEgmYkrrNB1iajA==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      react-dom: ^18.2.0 || ^19.0.0
+
+  '@calcom/embed-snippet@1.3.3':
+    resolution: {integrity: sha512-pqqKaeLB8R6BvyegcpI9gAyY6Xyx1bKYfWvIGOvIbTpguWyM1BBBVcT9DCeGe8Zw7Ujp5K56ci7isRUrT2Uadg==}
 
   '@canvas/image-data@1.1.0':
     resolution: {integrity: sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==}
@@ -10064,6 +10079,19 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@calcom/embed-core@1.5.3': {}
+
+  '@calcom/embed-react@1.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@calcom/embed-core': 1.5.3
+      '@calcom/embed-snippet': 1.3.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@calcom/embed-snippet@1.3.3':
+    dependencies:
+      '@calcom/embed-core': 1.5.3
+
   '@canvas/image-data@1.1.0': {}
 
   '@capsizecss/unpack@4.0.0':
@@ -13516,7 +13544,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16


### PR DESCRIPTION
## Summary
- restore Cal.com's default floating popup embed instead of maintaining a first-party floating CTA/modal opener
- remove custom Cal modal sizing CSS that was fighting the default embed
- replace Astro-generated CSP with an explicit CSP meta tag so Cal's runtime-injected styles can apply

## Verification
- pnpm --filter @lobbystack/landing build
- pnpm --filter @lobbystack/landing typecheck
- Browser preview: confirmed Cal floating button is injected and Book a Demo has the Cal trigger attributes