### PR TITLE
OPE-137 render Cal demo as direct iframe

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -19,7 +19,6 @@
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@base-ui/react": "^1.3.0",
-    "@calcom/embed-react": "^1.5.3",
     "@jdevalk/astro-seo-graph": "^2.0.0",
     "@jdevalk/seo-graph-core": "^0.6.2",
     "@tailwindcss/vite": "^4.2.4",

--- a/apps/landing/src/components/CalDemoModal.tsx
+++ b/apps/landing/src/components/CalDemoModal.tsx
@@ -1,8 +1,6 @@
-import Cal, { getCalApi } from "@calcom/embed-react"
 import {
-  CAL_DEMO_CONFIG,
+  CAL_DEMO_EMBED_URL,
   CAL_DEMO_LINK,
-  CAL_DEMO_NAMESPACE,
 } from "@/lib/app-links"
 import { CalendarDays, X } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -26,20 +24,6 @@ export function CalDemoModal() {
     return () => {
       document.removeEventListener("click", openDemo)
     }
-  }, [])
-
-  useEffect(() => {
-    const configureCal = async () => {
-      const cal = await getCalApi({ namespace: CAL_DEMO_NAMESPACE })
-
-      cal("ui", {
-        hideEventTypeDetails: false,
-        layout: CAL_DEMO_CONFIG.layout,
-        theme: CAL_DEMO_CONFIG.theme,
-      })
-    }
-
-    configureCal()
   }, [])
 
   useEffect(() => {
@@ -96,11 +80,11 @@ export function CalDemoModal() {
                 <X className="size-5" aria-hidden="true" />
               </button>
             </div>
-            <Cal
-              namespace={CAL_DEMO_NAMESPACE}
-              calLink={CAL_DEMO_LINK}
+            <iframe
+              title="Book a Demo"
               className="cal-demo-inline"
-              config={CAL_DEMO_CONFIG}
+              src={CAL_DEMO_EMBED_URL}
+              allow="payment"
             />
           </div>
         </div>

--- a/apps/landing/src/lib/app-links.ts
+++ b/apps/landing/src/lib/app-links.ts
@@ -9,6 +9,13 @@ export const CAL_DEMO_CONFIG = {
   theme: "light",
   useSlotsViewOnSmallScreen: "true",
 } as const
+export const CAL_DEMO_EMBED_URL = `https://app.cal.com/${CAL_DEMO_LINK}/embed?${new URLSearchParams(
+  {
+    ...CAL_DEMO_CONFIG,
+    embedType: "inline",
+    embed: CAL_DEMO_NAMESPACE,
+  }
+).toString()}`
 
 export const CAL_DEMO_TRIGGER_ATTRIBUTES = {
   "data-cal-demo-trigger": "true",

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -104,13 +104,8 @@
 .cal-demo-inline {
   width: 100%;
   height: 100%;
-  overflow: auto;
-}
-
-.cal-demo-inline iframe {
-  width: 100%;
-  height: 100%;
   border: 0;
+  display: block;
 }
 
 /* Staggered reveal animations */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,9 +170,6 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@calcom/embed-react':
-        specifier: ^1.5.3
-        version: 1.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@jdevalk/astro-seo-graph':
         specifier: ^2.0.0
         version: 2.0.0(astro@6.3.8(@types/node@24.12.0)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.21.0)(yaml@2.8.3))(typescript@5.9.3)
@@ -876,18 +873,6 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
-
-  '@calcom/embed-core@1.5.3':
-    resolution: {integrity: sha512-GeId9gaByJ5EWiPmuvelZOvFWPOTWkcWZr5vGTCbIUTX125oE5yn0n8lDF1MJk5Xj1WO+/dk9jKIE08Ad9ytiQ==}
-
-  '@calcom/embed-react@1.5.3':
-    resolution: {integrity: sha512-JCgge04pc8fhdvUmPNVLhW8/lCWK+AAziKecKWWPfv1nn2s+qKP2BwsEAnxhxK9yPOBgE1EIEgmYkrrNB1iajA==}
-    peerDependencies:
-      react: ^18.2.0 || ^19.0.0
-      react-dom: ^18.2.0 || ^19.0.0
-
-  '@calcom/embed-snippet@1.3.3':
-    resolution: {integrity: sha512-pqqKaeLB8R6BvyegcpI9gAyY6Xyx1bKYfWvIGOvIbTpguWyM1BBBVcT9DCeGe8Zw7Ujp5K56ci7isRUrT2Uadg==}
 
   '@canvas/image-data@1.1.0':
     resolution: {integrity: sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==}
@@ -10078,19 +10063,6 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-
-  '@calcom/embed-core@1.5.3': {}
-
-  '@calcom/embed-react@1.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@calcom/embed-core': 1.5.3
-      '@calcom/embed-snippet': 1.3.3
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
-  '@calcom/embed-snippet@1.3.3':
-    dependencies:
-      '@calcom/embed-core': 1.5.3
 
   '@canvas/image-data@1.1.0': {}
 


### PR DESCRIPTION
## Summary
- Replace the Cal React embed wrapper with a direct Cal iframe inside our first-party modal
- Keep the same light month-view Cal URL, hero CTA trigger, and circular floating calendar button
- Remove the now-unused `@calcom/embed-react` dependency

## Verification
- `pnpm --filter @lobbystack/landing typecheck`
- `pnpm --filter @lobbystack/landing build`
- Browser preview at `http://localhost:4322/?verify=iframe-direct`: modal renders one direct iframe, no React wrapper shell, no old Cal data attributes, CTA cursor remains pointer

Linear: OPE-137