### PR TITLE
Normalize auth emails and migrate legacy password accounts

### DIFF
--- a/apps/web/public/locales/en/auth.json
+++ b/apps/web/public/locales/en/auth.json
@@ -74,11 +74,7 @@
     "signInCompleted": "Sign-in completed. Finalizing your session...",
     "continuingSignUp": "Continuing sign-up in a new browser flow...",
     "accountCreatedFinishing": "Account created. Finishing your session...",
-    "accountCreatedFinalizing": "Account created. Finalizing your session...",
-    "resetCodeSent": "If an account exists for that email, we sent a reset code.",
-    "continuingPasswordReset": "Continuing password reset in a new browser flow...",
-    "passwordResetFinishing": "Password reset complete. Finishing your session...",
-    "passwordResetCompleted": "Password reset complete. Finalizing your session..."
+    "accountCreatedFinalizing": "Account created. Finalizing your session..."
   },
   "errors": {
     "incorrectCredentials": "Incorrect email or password. Please try again.",

--- a/apps/web/public/locales/fr/auth.json
+++ b/apps/web/public/locales/fr/auth.json
@@ -74,11 +74,7 @@
     "signInCompleted": "Connexion terminée. Finalisation de votre session...",
     "continuingSignUp": "Poursuite de l'inscription dans un nouveau flux du navigateur...",
     "accountCreatedFinishing": "Compte créé. Finalisation de votre session...",
-    "accountCreatedFinalizing": "Compte créé. Finalisation de votre session...",
-    "resetCodeSent": "Si un compte existe pour ce courriel, nous avons envoyé un code de réinitialisation.",
-    "continuingPasswordReset": "Poursuite de la réinitialisation dans un nouveau flux du navigateur...",
-    "passwordResetFinishing": "Mot de passe réinitialisé. Finalisation de votre session...",
-    "passwordResetCompleted": "Mot de passe réinitialisé. Finalisation de votre session..."
+    "accountCreatedFinalizing": "Compte créé. Finalisation de votre session..."
   },
   "errors": {
     "incorrectCredentials": "Courriel ou mot de passe incorrect. Veuillez réessayer.",

--- a/apps/web/src/components/forgot-password-form.tsx
+++ b/apps/web/src/components/forgot-password-form.tsx
@@ -3,12 +3,12 @@
 import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { LoaderCircle } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Field,
-  FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
@@ -23,7 +23,6 @@ type ForgotPasswordFormProps = {
   newPassword: string;
   isSubmitting: boolean;
   errorMessage: string | null;
-  statusMessage: string | null;
   onEmailChange: (value: string) => void;
   onCodeChange: (value: string) => void;
   onNewPasswordChange: (value: string) => void;
@@ -39,7 +38,6 @@ export function ForgotPasswordForm({
   newPassword,
   isSubmitting,
   errorMessage,
-  statusMessage,
   onEmailChange,
   onCodeChange,
   onNewPasswordChange,
@@ -102,22 +100,28 @@ export function ForgotPasswordForm({
             </Field>
           )}
 
-          {statusMessage || errorMessage ? (
+          {errorMessage ? (
             <div className="flex flex-col gap-2 -mt-1">
-              {statusMessage ? <FieldDescription>{statusMessage}</FieldDescription> : null}
-              {errorMessage ? <FieldError>{errorMessage}</FieldError> : null}
+              <FieldError>{errorMessage}</FieldError>
             </div>
           ) : null}
 
           <div className="mt-2 flex flex-col gap-3">
             <Button className="h-11 w-full" disabled={isSubmitting} type="submit">
-              {isSubmitting
-                ? isVerifyStep
-                  ? t("forgotPassword.verifySubmitting")
-                  : t("forgotPassword.submitting")
-                : isVerifyStep
-                  ? t("forgotPassword.verifySubmit")
-                  : t("forgotPassword.submit")}
+              {isSubmitting ? (
+                <>
+                  <LoaderCircle className="size-4 animate-spin" />
+                  <span className="sr-only">
+                    {isVerifyStep
+                      ? t("forgotPassword.verifySubmitting")
+                      : t("forgotPassword.submitting")}
+                  </span>
+                </>
+              ) : isVerifyStep ? (
+                t("forgotPassword.verifySubmit")
+              ) : (
+                t("forgotPassword.submit")
+              )}
             </Button>
 
             {isVerifyStep ? (

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -108,7 +108,7 @@ describe("LoginPage", () => {
     expect(screen.getByText("shell.privacy")).toBeTruthy();
   });
 
-  it("submits a normalized email for login", async () => {
+  it("submits the raw email for login", async () => {
     signInMock.mockResolvedValue({});
 
     render(
@@ -125,7 +125,7 @@ describe("LoginPage", () => {
     expect(signInMock).toHaveBeenCalledTimes(1);
     const [, formData] = signInMock.mock.calls[0] as [string, FormData];
 
-    expect(formData.get("email")).toBe("owner@example.com");
+    expect(formData.get("email")).toBe("OWNER@Example.COM");
   });
 });
 
@@ -155,7 +155,7 @@ describe("ForgotPasswordPage", () => {
 
     expect(provider).toBe("password");
     expect(formData.get("flow")).toBe("reset");
-    expect(formData.get("email")).toBe("owner@example.com");
+    expect(formData.get("email")).toBe("OWNER@Example.COM");
     expect(screen.getByText("forgotPassword.verifyTitle")).toBeTruthy();
     expect(screen.queryByText("forgotPassword.submitting")).toBeNull();
   });
@@ -176,7 +176,7 @@ describe("ForgotPasswordPage", () => {
     expect(screen.getByText("errors.passwordResetMissingSiteUrl")).toBeTruthy();
   });
 
-  it("submits reset verification with email, code, and new password", async () => {
+  it("submits reset verification with raw email, code, and new password", async () => {
     signInMock
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ signingIn: true });
@@ -188,7 +188,7 @@ describe("ForgotPasswordPage", () => {
     );
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.type(screen.getByLabelText("forgotPassword.email"), " OWNER@Example.COM ");
     await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
     await user.type(screen.getByLabelText("forgotPassword.code"), "12345678");
     await user.type(screen.getByLabelText("forgotPassword.newPassword"), "a-secure-password");
@@ -199,7 +199,7 @@ describe("ForgotPasswordPage", () => {
 
     expect(provider).toBe("password");
     expect(formData.get("flow")).toBe("reset-verification");
-    expect(formData.get("email")).toBe("owner@example.com");
+    expect(formData.get("email")).toBe("OWNER@Example.COM");
     expect(formData.get("code")).toBe("12345678");
     expect(formData.get("newPassword")).toBe("a-secure-password");
     expect(screen.queryByText("status.passwordResetFinishing")).toBeNull();
@@ -409,7 +409,7 @@ describe("SignupPage", () => {
     expect(screen.queryByText("errors.signupFailed")).toBeNull();
   });
 
-  it("submits a normalized email for signup", async () => {
+  it("submits the raw email for signup", async () => {
     vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key");
     signInMock.mockResolvedValueOnce({});
 
@@ -427,7 +427,7 @@ describe("SignupPage", () => {
     expect(signInMock).toHaveBeenCalledTimes(1);
     const [, formData] = signInMock.mock.calls[0] as [string, FormData];
 
-    expect(formData.get("email")).toBe("owner@example.com");
+    expect(formData.get("email")).toBe("OWNER@Example.COM");
   });
 
   it("renders Turnstile as soon as the signup page loads", async () => {

--- a/apps/web/src/features/auth/AuthPages.test.tsx
+++ b/apps/web/src/features/auth/AuthPages.test.tsx
@@ -107,6 +107,26 @@ describe("LoginPage", () => {
     expect(screen.getByText("shell.terms")).toBeTruthy();
     expect(screen.getByText("shell.privacy")).toBeTruthy();
   });
+
+  it("submits a normalized email for login", async () => {
+    signInMock.mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("login.email"), " OWNER@Example.COM ");
+    await user.type(screen.getByLabelText("login.password"), "CurrentPass123!");
+    await user.click(screen.getByRole("button", { name: "login.submit" }));
+
+    expect(signInMock).toHaveBeenCalledTimes(1);
+    const [, formData] = signInMock.mock.calls[0] as [string, FormData];
+
+    expect(formData.get("email")).toBe("owner@example.com");
+  });
 });
 
 describe("ForgotPasswordPage", () => {
@@ -127,7 +147,7 @@ describe("ForgotPasswordPage", () => {
     );
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.type(screen.getByLabelText("forgotPassword.email"), " OWNER@Example.COM ");
     await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
 
     expect(signInMock).toHaveBeenCalledTimes(1);
@@ -137,6 +157,7 @@ describe("ForgotPasswordPage", () => {
     expect(formData.get("flow")).toBe("reset");
     expect(formData.get("email")).toBe("owner@example.com");
     expect(screen.getByText("forgotPassword.verifyTitle")).toBeTruthy();
+    expect(screen.queryByText("forgotPassword.submitting")).toBeNull();
   });
 
   it("renders a specific error when SITE_URL is missing on the Convex deployment", async () => {
@@ -149,7 +170,7 @@ describe("ForgotPasswordPage", () => {
     );
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText("forgotPassword.email"), "owner@example.com");
+    await user.type(screen.getByLabelText("forgotPassword.email"), " OWNER@Example.COM ");
     await user.click(screen.getByRole("button", { name: "forgotPassword.submit" }));
 
     expect(screen.getByText("errors.passwordResetMissingSiteUrl")).toBeTruthy();
@@ -181,7 +202,10 @@ describe("ForgotPasswordPage", () => {
     expect(formData.get("email")).toBe("owner@example.com");
     expect(formData.get("code")).toBe("12345678");
     expect(formData.get("newPassword")).toBe("a-secure-password");
-    expect(screen.getByText("status.passwordResetFinishing")).toBeTruthy();
+    expect(screen.queryByText("status.passwordResetFinishing")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "forgotPassword.verifySubmitting" }),
+    ).toBeTruthy();
   });
 
   it("renders reset-specific errors from Convex Auth failures", async () => {
@@ -383,6 +407,27 @@ describe("SignupPage", () => {
 
     expect(await screen.findByText("errors.accountExists")).toBeTruthy();
     expect(screen.queryByText("errors.signupFailed")).toBeNull();
+  });
+
+  it("submits a normalized email for signup", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITE_KEY", "site-key");
+    signInMock.mockResolvedValueOnce({});
+
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("signup.email"), " OWNER@Example.COM ");
+    await user.type(screen.getByLabelText("signup.password"), "abcde1!f");
+    await user.click(screen.getByRole("button", { name: "signup.submit" }));
+
+    expect(signInMock).toHaveBeenCalledTimes(1);
+    const [, formData] = signInMock.mock.calls[0] as [string, FormData];
+
+    expect(formData.get("email")).toBe("owner@example.com");
   });
 
   it("renders Turnstile as soon as the signup page loads", async () => {

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -1,6 +1,7 @@
 import type { FormEvent } from "react";
 import { useCallback, useRef, useState } from "react";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { normalizeAuthEmail } from "@lobbystack/shared";
 import { useConvexAuth } from "convex/react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -100,7 +101,7 @@ export function LoginPage() {
     try {
       const formData = new FormData();
       formData.set("flow", "signIn");
-      formData.set("email", email);
+      formData.set("email", normalizeAuthEmail(email));
       formData.set("password", password);
       const result = await signIn("password", formData);
 
@@ -175,7 +176,7 @@ export function SignupPage() {
     try {
       const formData = new FormData();
       formData.set("flow", "signUp");
-      formData.set("email", email);
+      formData.set("email", normalizeAuthEmail(email));
       formData.set("password", password);
       if (verifiedTurnstileToken) {
         formData.set("cf-turnstile-response", verifiedTurnstileToken);
@@ -303,24 +304,22 @@ export function ForgotPasswordPage() {
   const [code, setCode] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    let keepSubmitting = false;
     setIsSubmitting(true);
-    setStatusMessage(null);
     setErrorMessage(null);
 
     try {
       const formData = new FormData();
-      formData.set("email", email);
+      formData.set("email", normalizeAuthEmail(email));
 
       if (step === "request") {
         formData.set("flow", "reset");
         await signIn("password", formData);
         setStep("verify");
-        setStatusMessage(t("status.resetCodeSent"));
         return;
       }
 
@@ -330,20 +329,19 @@ export function ForgotPasswordPage() {
       const result = await signIn("password", formData);
 
       if (result.redirect) {
-        setStatusMessage(t("status.continuingPasswordReset"));
+        keepSubmitting = true;
         return;
       }
 
       if (result.signingIn) {
-        setStatusMessage(t("status.passwordResetFinishing"));
+        keepSubmitting = true;
         return;
       }
 
-      setStatusMessage(t("status.passwordResetCompleted"));
+      keepSubmitting = true;
     } catch (error) {
       if (step === "request" && isResetRequestLookupError(error)) {
         setStep("verify");
-        setStatusMessage(t("status.resetCodeSent"));
         return;
       }
 
@@ -351,7 +349,9 @@ export function ForgotPasswordPage() {
         getAuthErrorMessage(error, step === "request" ? "resetRequest" : "resetVerification", t),
       );
     } finally {
-      setIsSubmitting(false);
+      if (!keepSubmitting) {
+        setIsSubmitting(false);
+      }
     }
   }
 
@@ -359,7 +359,6 @@ export function ForgotPasswordPage() {
     setStep("request");
     setCode("");
     setNewPassword("");
-    setStatusMessage(null);
     setErrorMessage(null);
   }
 
@@ -382,7 +381,6 @@ export function ForgotPasswordPage() {
         onEmailChange={setEmail}
         onNewPasswordChange={setNewPassword}
         onSubmit={handleSubmit}
-        statusMessage={statusMessage}
         step={step}
       />
     </OnboardingShell>

--- a/apps/web/src/features/auth/AuthPages.tsx
+++ b/apps/web/src/features/auth/AuthPages.tsx
@@ -1,7 +1,6 @@
 import type { FormEvent } from "react";
 import { useCallback, useRef, useState } from "react";
 import { useAuthActions } from "@convex-dev/auth/react";
-import { normalizeAuthEmail } from "@lobbystack/shared";
 import { useConvexAuth } from "convex/react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -101,7 +100,7 @@ export function LoginPage() {
     try {
       const formData = new FormData();
       formData.set("flow", "signIn");
-      formData.set("email", normalizeAuthEmail(email));
+      formData.set("email", email);
       formData.set("password", password);
       const result = await signIn("password", formData);
 
@@ -176,7 +175,7 @@ export function SignupPage() {
     try {
       const formData = new FormData();
       formData.set("flow", "signUp");
-      formData.set("email", normalizeAuthEmail(email));
+      formData.set("email", email);
       formData.set("password", password);
       if (verifiedTurnstileToken) {
         formData.set("cf-turnstile-response", verifiedTurnstileToken);
@@ -314,7 +313,7 @@ export function ForgotPasswordPage() {
 
     try {
       const formData = new FormData();
-      formData.set("email", normalizeAuthEmail(email));
+      formData.set("email", email);
 
       if (step === "request") {
         formData.set("flow", "reset");

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -87,6 +87,7 @@ import type * as lib_twilioUrls from "../lib/twilioUrls.js";
 import type * as lib_voiceCallStatus from "../lib/voiceCallStatus.js";
 import type * as lib_websiteIngestion from "../lib/websiteIngestion.js";
 import type * as lib_websiteIngestionStorage from "../lib/websiteIngestionStorage.js";
+import type * as migrations_authEmailNormalization from "../migrations/authEmailNormalization.js";
 import type * as notifications_reminders from "../notifications/reminders.js";
 import type * as onboarding_abuse from "../onboarding/abuse.js";
 import type * as onboarding_attribution from "../onboarding/attribution.js";
@@ -198,6 +199,7 @@ declare const fullApi: ApiFromModules<{
   "lib/voiceCallStatus": typeof lib_voiceCallStatus;
   "lib/websiteIngestion": typeof lib_websiteIngestion;
   "lib/websiteIngestionStorage": typeof lib_websiteIngestionStorage;
+  "migrations/authEmailNormalization": typeof migrations_authEmailNormalization;
   "notifications/reminders": typeof notifications_reminders;
   "onboarding/abuse": typeof onboarding_abuse;
   "onboarding/attribution": typeof onboarding_attribution;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -43,6 +43,7 @@ import type * as integrations_twilioVoice from "../integrations/twilioVoice.js";
 import type * as lib_accountCredentials from "../lib/accountCredentials.js";
 import type * as lib_appointmentChangePolicy from "../lib/appointmentChangePolicy.js";
 import type * as lib_auth from "../lib/auth.js";
+import type * as lib_authEmailClaims from "../lib/authEmailClaims.js";
 import type * as lib_availability from "../lib/availability.js";
 import type * as lib_billing from "../lib/billing.js";
 import type * as lib_billingAccess from "../lib/billingAccess.js";
@@ -155,6 +156,7 @@ declare const fullApi: ApiFromModules<{
   "lib/accountCredentials": typeof lib_accountCredentials;
   "lib/appointmentChangePolicy": typeof lib_appointmentChangePolicy;
   "lib/auth": typeof lib_auth;
+  "lib/authEmailClaims": typeof lib_authEmailClaims;
   "lib/availability": typeof lib_availability;
   "lib/billing": typeof lib_billing;
   "lib/billingAccess": typeof lib_billingAccess;

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -1,13 +1,11 @@
-import {
-  v } from "convex/values";
-import { observedInternalAction as internalAction, observedInternalMutation as internalMutation, observedMutation as mutation } from "../telemetry/observedFunctions";
+import { v } from "convex/values";
 import {
   getAuthSessionId,
   getAuthUserId,
   invalidateSessions,
   modifyAccountCredentials,
   retrieveAccount,
-  } from "@convex-dev/auth/server";
+} from "@convex-dev/auth/server";
 import { internal } from "../_generated/api";
 import {
   internalQuery,
@@ -21,6 +19,7 @@ import {
   getPasswordAccountForUser,
   resolveUserForPasswordCredentials,
 } from "../lib/accountCredentials";
+import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import {
   getCurrentUser,
   requireMembership,
@@ -54,7 +53,12 @@ import {
 } from "../lib/twilioUrls";
 import { scheduleSnapshotRefresh } from "./admin";
 
-import { observedAction as action } from "../telemetry/observedFunctions";
+import {
+  observedAction as action,
+  observedInternalAction as internalAction,
+  observedInternalMutation as internalMutation,
+  observedMutation as mutation,
+} from "../telemetry/observedFunctions";
 const phoneNumberSaveArgs = {
   businessId: v.id("businesses"),
   phoneNumberId: v.optional(v.id("phone_numbers")),
@@ -95,6 +99,16 @@ type PhoneNumberWebhookSyncInput = {
 };
 
 type CredentialsWriterCtx = Pick<MutationCtx, "db">;
+
+const NORMALIZED_EMAIL_AVAILABILITY_BATCH_SIZE = 100;
+
+type NormalizedPasswordEmailCollisionPage = {
+  hasCollision: boolean;
+  accountsContinueCursor: string;
+  accountsIsDone: boolean;
+  usersContinueCursor: string;
+  usersIsDone: boolean;
+};
 
 function shouldSyncSmsWebhook(input: PhoneNumberWebhookSyncInput): boolean {
   return Boolean(input.twilioPhoneSid && input.smsEnabled && input.status === "active");
@@ -213,6 +227,48 @@ async function assertPasswordEmailAvailable(
   if (duplicateUser && duplicateUser._id !== input.userId) {
     throw new Error("An account with that email already exists.");
   }
+}
+
+async function hasNormalizedPasswordEmailCollision(
+  ctx: Pick<ActionCtx, "runQuery">,
+  input: {
+    newEmail: string;
+    userId: Id<"users">;
+    currentAccountId?: Id<"authAccounts">;
+  },
+): Promise<boolean> {
+  const normalizedEmail = normalizeAuthEmail(input.newEmail);
+  let accountsCursor: string | null = null;
+  let usersCursor: string | null = null;
+  let accountsIsDone = false;
+  let usersIsDone = false;
+
+  while (!accountsIsDone || !usersIsDone) {
+    const page: NormalizedPasswordEmailCollisionPage = await ctx.runQuery(
+      internal.businesses.catalog.findNormalizedPasswordEmailCollisionPage,
+      {
+        normalizedEmail,
+        userId: input.userId,
+        ...(input.currentAccountId ? { currentAccountId: input.currentAccountId } : {}),
+        accountsCursor,
+        usersCursor,
+        scanAccounts: !accountsIsDone,
+        scanUsers: !usersIsDone,
+        numItems: NORMALIZED_EMAIL_AVAILABILITY_BATCH_SIZE,
+      },
+    );
+
+    if (page.hasCollision) {
+      return true;
+    }
+
+    accountsCursor = page.accountsContinueCursor;
+    accountsIsDone = page.accountsIsDone;
+    usersCursor = page.usersContinueCursor;
+    usersIsDone = page.usersIsDone;
+  }
+
+  return false;
 }
 
 async function hashVerificationCode(code: string): Promise<string> {
@@ -464,6 +520,108 @@ export const getCurrentUserForPasswordChange = internalQuery({
   },
 });
 
+export const findNormalizedPasswordEmailCollisionPage = internalQuery({
+  args: {
+    normalizedEmail: v.string(),
+    userId: v.id("users"),
+    currentAccountId: v.optional(v.id("authAccounts")),
+    accountsCursor: v.union(v.string(), v.null()),
+    usersCursor: v.union(v.string(), v.null()),
+    scanAccounts: v.boolean(),
+    scanUsers: v.boolean(),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<NormalizedPasswordEmailCollisionPage> => {
+    const numItems = args.numItems ?? NORMALIZED_EMAIL_AVAILABILITY_BATCH_SIZE;
+    const [accountsPage, usersPage] = await Promise.all([
+      args.scanAccounts
+        ? ctx.db
+            .query("authAccounts")
+            .withIndex("providerAndAccountId", (q) => q.eq("provider", "password"))
+            .paginate({
+              cursor: args.accountsCursor,
+              numItems,
+            })
+        : Promise.resolve(null),
+      args.scanUsers
+        ? ctx.db.query("users").paginate({
+            cursor: args.usersCursor,
+            numItems,
+          })
+        : Promise.resolve(null),
+    ]);
+
+    const hasAccountCollision = Boolean(
+      accountsPage?.page.some(
+        (account) =>
+          typeof account.providerAccountId === "string" &&
+          normalizeAuthEmail(account.providerAccountId) === args.normalizedEmail &&
+          account._id !== args.currentAccountId,
+      ),
+    );
+    const hasUserCollision = Boolean(
+      usersPage?.page.some(
+        (user) =>
+          typeof user.email === "string" &&
+          normalizeAuthEmail(user.email) === args.normalizedEmail &&
+          user._id !== args.userId,
+      ),
+    );
+
+    return {
+      hasCollision: hasAccountCollision || hasUserCollision,
+      accountsContinueCursor:
+        accountsPage?.continueCursor ?? args.accountsCursor ?? "",
+      accountsIsDone: accountsPage?.isDone ?? true,
+      usersContinueCursor: usersPage?.continueCursor ?? args.usersCursor ?? "",
+      usersIsDone: usersPage?.isDone ?? true,
+    };
+  },
+});
+
+export const getPendingEmailChangeAvailabilityTarget = internalQuery({
+  args: {
+    codeHash: v.string(),
+    email: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    accountId: Id<"authAccounts">;
+    userId: Id<"users">;
+  } | null> => {
+    const pendingEmailChange = await ctx.db
+      .query("pending_email_changes")
+      .withIndex("by_code_hash", (q) => q.eq("codeHash", args.codeHash))
+      .unique();
+
+    if (!pendingEmailChange || pendingEmailChange.expirationTime < Date.now()) {
+      return null;
+    }
+
+    const nextEmail = normalizeAuthEmail(pendingEmailChange.email);
+    if (!nextEmail || nextEmail !== args.email) {
+      return null;
+    }
+
+    const account = await ctx.db.get(pendingEmailChange.accountId);
+    if (!account || account.provider !== "password") {
+      return null;
+    }
+
+    const user = await ctx.db.get(account.userId);
+    if (!user) {
+      return null;
+    }
+
+    return {
+      accountId: account._id,
+      userId: user._id,
+    };
+  },
+});
+
 export const assertPendingEmailChangeTarget = internalQuery({
   args: {
     newEmail: v.string(),
@@ -678,6 +836,25 @@ export const changeEmail = action({
       },
     });
 
+    if (
+      await hasNormalizedPasswordEmailCollision(ctx, {
+        newEmail: nextEmail,
+        userId: user.userId,
+        currentAccountId: user.passwordAccountId,
+      })
+    ) {
+      const clearPendingEmailChangesResult: null = await ctx.runMutation(
+        (internal as any).businesses.catalog.clearPendingEmailChanges,
+        {
+          accountId: user.passwordAccountId,
+        },
+      );
+      void clearPendingEmailChangesResult;
+      return {
+        email: nextEmail,
+      };
+    }
+
     const canSendConfirmation: boolean = await ctx.runQuery(
       internal.businesses.catalog.assertPendingEmailChangeTarget,
       {
@@ -745,8 +922,27 @@ export const confirmEmailChange = action({
       throw new Error("Invalid or expired email confirmation link.");
     }
 
+    const codeHash = await hashVerificationCode(code);
+    const target = await ctx.runQuery(
+      internal.businesses.catalog.getPendingEmailChangeAvailabilityTarget,
+      {
+        codeHash,
+        email,
+      },
+    );
+    if (
+      target &&
+      (await hasNormalizedPasswordEmailCollision(ctx, {
+        newEmail: email,
+        userId: target.userId,
+        currentAccountId: target.accountId,
+      }))
+    ) {
+      throw new Error("An account with that email already exists.");
+    }
+
     const result = await ctx.runMutation(internal.businesses.catalog.confirmPendingEmailChange, {
-      codeHash: await hashVerificationCode(code),
+      codeHash,
       email,
     });
     const authCtx = ctx as unknown as Parameters<typeof invalidateSessions>[0];

--- a/convex/businesses/catalog.ts
+++ b/convex/businesses/catalog.ts
@@ -21,6 +21,11 @@ import {
 } from "../lib/accountCredentials";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import {
+  assertAuthEmailClaimAvailable,
+  replaceAuthEmailClaimsForAccount,
+  type AuthEmailClaimAvailability,
+} from "../lib/authEmailClaims";
+import {
   getCurrentUser,
   requireMembership,
   requireTenantAdminAccess,
@@ -99,16 +104,6 @@ type PhoneNumberWebhookSyncInput = {
 };
 
 type CredentialsWriterCtx = Pick<MutationCtx, "db">;
-
-const NORMALIZED_EMAIL_AVAILABILITY_BATCH_SIZE = 100;
-
-type NormalizedPasswordEmailCollisionPage = {
-  hasCollision: boolean;
-  accountsContinueCursor: string;
-  accountsIsDone: boolean;
-  usersContinueCursor: string;
-  usersIsDone: boolean;
-};
 
 function shouldSyncSmsWebhook(input: PhoneNumberWebhookSyncInput): boolean {
   return Boolean(input.twilioPhoneSid && input.smsEnabled && input.status === "active");
@@ -237,38 +232,17 @@ async function hasNormalizedPasswordEmailCollision(
     currentAccountId?: Id<"authAccounts">;
   },
 ): Promise<boolean> {
-  const normalizedEmail = normalizeAuthEmail(input.newEmail);
-  let accountsCursor: string | null = null;
-  let usersCursor: string | null = null;
-  let accountsIsDone = false;
-  let usersIsDone = false;
+  const availability: AuthEmailClaimAvailability = await ctx.runQuery(
+    internal.lib.authEmailClaims.getAvailability,
+    {
+      provider: "password",
+      normalizedEmail: normalizeAuthEmail(input.newEmail),
+      ...(input.currentAccountId ? { currentAccountId: input.currentAccountId } : {}),
+      currentUserId: input.userId,
+    },
+  );
 
-  while (!accountsIsDone || !usersIsDone) {
-    const page: NormalizedPasswordEmailCollisionPage = await ctx.runQuery(
-      internal.businesses.catalog.findNormalizedPasswordEmailCollisionPage,
-      {
-        normalizedEmail,
-        userId: input.userId,
-        ...(input.currentAccountId ? { currentAccountId: input.currentAccountId } : {}),
-        accountsCursor,
-        usersCursor,
-        scanAccounts: !accountsIsDone,
-        scanUsers: !usersIsDone,
-        numItems: NORMALIZED_EMAIL_AVAILABILITY_BATCH_SIZE,
-      },
-    );
-
-    if (page.hasCollision) {
-      return true;
-    }
-
-    accountsCursor = page.accountsContinueCursor;
-    accountsIsDone = page.accountsIsDone;
-    usersCursor = page.usersContinueCursor;
-    usersIsDone = page.usersIsDone;
-  }
-
-  return false;
+  return availability.authAccountClaimed || availability.userEmailClaimed;
 }
 
 async function hashVerificationCode(code: string): Promise<string> {
@@ -520,65 +494,6 @@ export const getCurrentUserForPasswordChange = internalQuery({
   },
 });
 
-export const findNormalizedPasswordEmailCollisionPage = internalQuery({
-  args: {
-    normalizedEmail: v.string(),
-    userId: v.id("users"),
-    currentAccountId: v.optional(v.id("authAccounts")),
-    accountsCursor: v.union(v.string(), v.null()),
-    usersCursor: v.union(v.string(), v.null()),
-    scanAccounts: v.boolean(),
-    scanUsers: v.boolean(),
-    numItems: v.optional(v.number()),
-  },
-  handler: async (ctx, args): Promise<NormalizedPasswordEmailCollisionPage> => {
-    const numItems = args.numItems ?? NORMALIZED_EMAIL_AVAILABILITY_BATCH_SIZE;
-    const [accountsPage, usersPage] = await Promise.all([
-      args.scanAccounts
-        ? ctx.db
-            .query("authAccounts")
-            .withIndex("providerAndAccountId", (q) => q.eq("provider", "password"))
-            .paginate({
-              cursor: args.accountsCursor,
-              numItems,
-            })
-        : Promise.resolve(null),
-      args.scanUsers
-        ? ctx.db.query("users").paginate({
-            cursor: args.usersCursor,
-            numItems,
-          })
-        : Promise.resolve(null),
-    ]);
-
-    const hasAccountCollision = Boolean(
-      accountsPage?.page.some(
-        (account) =>
-          typeof account.providerAccountId === "string" &&
-          normalizeAuthEmail(account.providerAccountId) === args.normalizedEmail &&
-          account._id !== args.currentAccountId,
-      ),
-    );
-    const hasUserCollision = Boolean(
-      usersPage?.page.some(
-        (user) =>
-          typeof user.email === "string" &&
-          normalizeAuthEmail(user.email) === args.normalizedEmail &&
-          user._id !== args.userId,
-      ),
-    );
-
-    return {
-      hasCollision: hasAccountCollision || hasUserCollision,
-      accountsContinueCursor:
-        accountsPage?.continueCursor ?? args.accountsCursor ?? "",
-      accountsIsDone: accountsPage?.isDone ?? true,
-      usersContinueCursor: usersPage?.continueCursor ?? args.usersCursor ?? "",
-      usersIsDone: usersPage?.isDone ?? true,
-    };
-  },
-});
-
 export const getPendingEmailChangeAvailabilityTarget = internalQuery({
   args: {
     codeHash: v.string(),
@@ -638,6 +553,12 @@ export const assertPendingEmailChangeTarget = internalQuery({
         newEmail: args.newEmail,
         userId: args.userId,
         currentAccountId: passwordAccount._id,
+      });
+      await assertAuthEmailClaimAvailable(ctx, {
+        provider: "password",
+        normalizedEmail: normalizeAuthEmail(args.newEmail),
+        currentAccountId: passwordAccount._id,
+        currentUserId: args.userId,
       });
       return true;
     } catch (error) {
@@ -711,6 +632,12 @@ export const confirmPendingEmailChange = internalMutation({
       userId: user._id,
       currentAccountId: account._id,
     });
+    await assertAuthEmailClaimAvailable(ctx, {
+      provider: "password",
+      normalizedEmail: nextEmail,
+      currentAccountId: account._id,
+      currentUserId: user._id,
+    });
 
     await clearVerificationCodesForAccount(ctx, account._id);
     await ctx.db.patch(account._id, {
@@ -720,6 +647,12 @@ export const confirmPendingEmailChange = internalMutation({
     await ctx.db.patch(user._id, {
       email: nextEmail,
       emailVerificationTime: Date.now(),
+    });
+    await replaceAuthEmailClaimsForAccount(ctx, {
+      provider: "password",
+      normalizedEmail: nextEmail,
+      accountId: account._id,
+      userId: user._id,
     });
     await ctx.db.delete(pendingEmailChange._id);
 

--- a/convex/lib/authEmailClaims.ts
+++ b/convex/lib/authEmailClaims.ts
@@ -2,11 +2,11 @@ import { v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
 import {
-  internalMutation,
   internalQuery,
   type MutationCtx,
   type QueryCtx,
 } from "../_generated/server";
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 
 type EmailClaimReaderCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;

--- a/convex/lib/authEmailClaims.ts
+++ b/convex/lib/authEmailClaims.ts
@@ -1,0 +1,174 @@
+import { v } from "convex/values";
+
+import type { Id } from "../_generated/dataModel";
+import {
+  internalMutation,
+  internalQuery,
+  type MutationCtx,
+  type QueryCtx,
+} from "../_generated/server";
+
+type EmailClaimReaderCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type EmailClaimWriterCtx = Pick<MutationCtx, "db">;
+
+export type AuthEmailClaimAvailability = {
+  authAccountClaimed: boolean;
+  userEmailClaimed: boolean;
+};
+
+async function getAuthEmailClaim(
+  ctx: EmailClaimReaderCtx,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+  },
+) {
+  return await ctx.db
+    .query("auth_email_claims")
+    .withIndex("by_provider_and_normalized_email", (q) =>
+      q.eq("provider", input.provider).eq("normalizedEmail", input.normalizedEmail),
+    )
+    .unique();
+}
+
+async function getUserEmailClaim(
+  ctx: EmailClaimReaderCtx,
+  normalizedEmail: string,
+) {
+  return await ctx.db
+    .query("user_email_claims")
+    .withIndex("by_normalized_email", (q) =>
+      q.eq("normalizedEmail", normalizedEmail),
+    )
+    .unique();
+}
+
+export async function getAuthEmailClaimAvailability(
+  ctx: EmailClaimReaderCtx,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+    currentAccountId?: Id<"authAccounts">;
+    currentUserId?: Id<"users">;
+  },
+): Promise<AuthEmailClaimAvailability> {
+  const [authClaim, userClaim] = await Promise.all([
+    getAuthEmailClaim(ctx, input),
+    getUserEmailClaim(ctx, input.normalizedEmail),
+  ]);
+
+  return {
+    authAccountClaimed: Boolean(
+      authClaim &&
+        (!input.currentAccountId || authClaim.accountId !== input.currentAccountId),
+    ),
+    userEmailClaimed: Boolean(
+      userClaim && (!input.currentUserId || userClaim.userId !== input.currentUserId),
+    ),
+  };
+}
+
+export async function assertAuthEmailClaimAvailable(
+  ctx: EmailClaimReaderCtx,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+    currentAccountId?: Id<"authAccounts">;
+    currentUserId?: Id<"users">;
+  },
+): Promise<void> {
+  const availability = await getAuthEmailClaimAvailability(ctx, input);
+  if (availability.authAccountClaimed || availability.userEmailClaimed) {
+    throw new Error("An account with that email already exists.");
+  }
+}
+
+export async function replaceAuthEmailClaimsForAccount(
+  ctx: EmailClaimWriterCtx,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+    accountId: Id<"authAccounts">;
+    userId: Id<"users">;
+  },
+): Promise<void> {
+  await assertAuthEmailClaimAvailable(ctx, {
+    provider: input.provider,
+    normalizedEmail: input.normalizedEmail,
+    currentAccountId: input.accountId,
+    currentUserId: input.userId,
+  });
+
+  const existingAccountClaims = await ctx.db
+    .query("auth_email_claims")
+    .withIndex("by_account_id", (q) => q.eq("accountId", input.accountId))
+    .collect();
+  for (const claim of existingAccountClaims) {
+    if (
+      claim.provider !== input.provider ||
+      claim.normalizedEmail !== input.normalizedEmail
+    ) {
+      await ctx.db.delete(claim._id);
+    }
+  }
+
+  const existingUserClaims = await ctx.db
+    .query("user_email_claims")
+    .withIndex("by_user_id", (q) => q.eq("userId", input.userId))
+    .collect();
+  for (const claim of existingUserClaims) {
+    if (claim.normalizedEmail !== input.normalizedEmail) {
+      await ctx.db.delete(claim._id);
+    }
+  }
+
+  const authClaim = await getAuthEmailClaim(ctx, input);
+  if (authClaim) {
+    await ctx.db.patch(authClaim._id, {
+      accountId: input.accountId,
+      userId: input.userId,
+    });
+  } else {
+    await ctx.db.insert("auth_email_claims", {
+      provider: input.provider,
+      normalizedEmail: input.normalizedEmail,
+      accountId: input.accountId,
+      userId: input.userId,
+    });
+  }
+
+  const userClaim = await getUserEmailClaim(ctx, input.normalizedEmail);
+  if (userClaim) {
+    await ctx.db.patch(userClaim._id, { userId: input.userId });
+  } else {
+    await ctx.db.insert("user_email_claims", {
+      normalizedEmail: input.normalizedEmail,
+      userId: input.userId,
+    });
+  }
+}
+
+export const getAvailability = internalQuery({
+  args: {
+    provider: v.string(),
+    normalizedEmail: v.string(),
+    currentAccountId: v.optional(v.id("authAccounts")),
+    currentUserId: v.optional(v.id("users")),
+  },
+  handler: async (ctx, args): Promise<AuthEmailClaimAvailability> => {
+    return await getAuthEmailClaimAvailability(ctx, args);
+  },
+});
+
+export const replaceForAccount = internalMutation({
+  args: {
+    provider: v.string(),
+    normalizedEmail: v.string(),
+    accountId: v.id("authAccounts"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    await replaceAuthEmailClaimsForAccount(ctx, args);
+    return null;
+  },
+});

--- a/convex/lib/authEmailClaims.ts
+++ b/convex/lib/authEmailClaims.ts
@@ -7,9 +7,12 @@ import {
   type MutationCtx,
   type QueryCtx,
 } from "../_generated/server";
+import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 
 type EmailClaimReaderCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
 type EmailClaimWriterCtx = Pick<MutationCtx, "db">;
+
+export const AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY = "password_claims_backfilled";
 
 export type AuthEmailClaimAvailability = {
   authAccountClaimed: boolean;
@@ -43,6 +46,69 @@ async function getUserEmailClaim(
     .unique();
 }
 
+async function isAuthEmailClaimBackfillComplete(
+  ctx: EmailClaimReaderCtx,
+): Promise<boolean> {
+  const state = await ctx.db
+    .query("auth_email_claim_backfill_state")
+    .withIndex("by_key", (q) =>
+      q.eq("key", AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY),
+    )
+    .unique();
+
+  return state !== null;
+}
+
+async function getLegacyAuthEmailClaimAvailability(
+  ctx: EmailClaimReaderCtx,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+    currentAccountId?: Id<"authAccounts">;
+    currentUserId?: Id<"users">;
+    checkAuthAccounts: boolean;
+    checkUsers: boolean;
+  },
+): Promise<AuthEmailClaimAvailability> {
+  let authAccountClaimed = false;
+  let userEmailClaimed = false;
+
+  // Backfill safety net: steady-state checks use the indexed claim tables above,
+  // but legacy documents may not have claim rows yet during rollout.
+  if (input.checkAuthAccounts) {
+    for await (const account of ctx.db
+      .query("authAccounts")
+      .withIndex("providerAndAccountId", (q) => q.eq("provider", input.provider))) {
+      if (
+        typeof account.providerAccountId === "string" &&
+        normalizeAuthEmail(account.providerAccountId) === input.normalizedEmail &&
+        (!input.currentAccountId || account._id !== input.currentAccountId)
+      ) {
+        authAccountClaimed = true;
+        break;
+      }
+    }
+  }
+
+  if (input.checkUsers) {
+    for await (const user of ctx.db.query("users")) {
+      if (
+        typeof user.email === "string" &&
+        normalizeAuthEmail(user.email) === input.normalizedEmail &&
+        (!input.currentUserId || user._id !== input.currentUserId)
+      ) {
+        userEmailClaimed = true;
+        break;
+      }
+    }
+  }
+
+  return {
+    authAccountClaimed,
+    userEmailClaimed,
+  };
+}
+
 export async function getAuthEmailClaimAvailability(
   ctx: EmailClaimReaderCtx,
   input: {
@@ -57,14 +123,36 @@ export async function getAuthEmailClaimAvailability(
     getUserEmailClaim(ctx, input.normalizedEmail),
   ]);
 
+  const authAccountClaimed = Boolean(
+    authClaim &&
+      (!input.currentAccountId || authClaim.accountId !== input.currentAccountId),
+  );
+  const userEmailClaimed = Boolean(
+    userClaim && (!input.currentUserId || userClaim.userId !== input.currentUserId),
+  );
+
+  if (authAccountClaimed && userEmailClaimed) {
+    return {
+      authAccountClaimed,
+      userEmailClaimed,
+    };
+  }
+
+  if (await isAuthEmailClaimBackfillComplete(ctx)) {
+    return {
+      authAccountClaimed,
+      userEmailClaimed,
+    };
+  }
+
+  const legacyAvailability = await getLegacyAuthEmailClaimAvailability(ctx, {
+    ...input,
+    checkAuthAccounts: !authAccountClaimed,
+    checkUsers: !userEmailClaimed,
+  });
   return {
-    authAccountClaimed: Boolean(
-      authClaim &&
-        (!input.currentAccountId || authClaim.accountId !== input.currentAccountId),
-    ),
-    userEmailClaimed: Boolean(
-      userClaim && (!input.currentUserId || userClaim.userId !== input.currentUserId),
-    ),
+    authAccountClaimed: authAccountClaimed || legacyAvailability.authAccountClaimed,
+    userEmailClaimed: userEmailClaimed || legacyAvailability.userEmailClaimed,
   };
 }
 

--- a/convex/lib/authEmailClaims.ts
+++ b/convex/lib/authEmailClaims.ts
@@ -236,6 +236,34 @@ export async function replaceAuthEmailClaimsForAccount(
   }
 }
 
+export async function ensureUserEmailClaimForUser(
+  ctx: EmailClaimWriterCtx,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+    userId: Id<"users">;
+    currentAccountId?: Id<"authAccounts">;
+  },
+): Promise<boolean> {
+  await assertAuthEmailClaimAvailable(ctx, {
+    provider: input.provider,
+    normalizedEmail: input.normalizedEmail,
+    ...(input.currentAccountId ? { currentAccountId: input.currentAccountId } : {}),
+    currentUserId: input.userId,
+  });
+
+  const userClaim = await getUserEmailClaim(ctx, input.normalizedEmail);
+  if (userClaim) {
+    return false;
+  }
+
+  await ctx.db.insert("user_email_claims", {
+    normalizedEmail: input.normalizedEmail,
+    userId: input.userId,
+  });
+  return true;
+}
+
 export const getAvailability = internalQuery({
   args: {
     provider: v.string(),

--- a/convex/lib/passwordWithTurnstile.ts
+++ b/convex/lib/passwordWithTurnstile.ts
@@ -9,9 +9,11 @@ import {
   signInViaProvider,
 } from "@convex-dev/auth/server";
 import type { DocumentByName, GenericDataModel, WithoutSystemFields } from "convex/server";
-import type { Value } from "convex/values";
+import { v, type Value } from "convex/values";
 import { Scrypt } from "lucia";
 
+import { internal } from "../_generated/api";
+import { internalQuery } from "../_generated/server";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import { verifyTurnstileForSignUp } from "./turnstile";
 
@@ -19,6 +21,14 @@ type PasswordProfile<DataModel extends GenericDataModel> =
   WithoutSystemFields<DocumentByName<DataModel, "users">> & {
     email: string;
   };
+
+const NORMALIZED_EMAIL_LOOKUP_BATCH_SIZE = 100;
+
+type NormalizedPasswordAccountLookupPage = {
+  hasMatch: boolean;
+  continueCursor: string;
+  isDone: boolean;
+};
 
 function getStringParam(
   params: Partial<Record<string, Value | undefined>>,
@@ -94,6 +104,67 @@ async function retrievePasswordAccount<DataModel extends GenericDataModel>(
   return null;
 }
 
+async function hasPasswordAccountForNormalizedEmail<DataModel extends GenericDataModel>(
+  ctx: GenericActionCtxWithAuthConfig<DataModel>,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+  },
+): Promise<boolean> {
+  let cursor: string | null = null;
+
+  do {
+    const page: NormalizedPasswordAccountLookupPage = await ctx.runQuery(
+      internal.lib.passwordWithTurnstile.findPasswordAccountByNormalizedEmailPage,
+      {
+        provider: input.provider,
+        normalizedEmail: input.normalizedEmail,
+        cursor,
+        numItems: NORMALIZED_EMAIL_LOOKUP_BATCH_SIZE,
+      },
+    );
+
+    if (page.hasMatch) {
+      return true;
+    }
+
+    cursor = page.continueCursor;
+    if (page.isDone) {
+      return false;
+    }
+  } while (cursor !== null);
+
+  return false;
+}
+
+export const findPasswordAccountByNormalizedEmailPage = internalQuery({
+  args: {
+    provider: v.string(),
+    normalizedEmail: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<NormalizedPasswordAccountLookupPage> => {
+    const page = await ctx.db
+      .query("authAccounts")
+      .withIndex("providerAndAccountId", (q) => q.eq("provider", args.provider))
+      .paginate({
+        cursor: args.cursor,
+        numItems: args.numItems ?? NORMALIZED_EMAIL_LOOKUP_BATCH_SIZE,
+      });
+
+    return {
+      hasMatch: page.page.some(
+        (account) =>
+          typeof account.providerAccountId === "string" &&
+          normalizeAuthEmail(account.providerAccountId) === args.normalizedEmail,
+      ),
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+    };
+  },
+});
+
 export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
   config: PasswordConfig<DataModel> = {},
 ) {
@@ -147,6 +218,15 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
           if (!isMissingAccountError(error)) {
             throw error;
           }
+        }
+
+        if (
+          await hasPasswordAccountForNormalizedEmail(ctx, {
+            provider,
+            normalizedEmail: email,
+          })
+        ) {
+          throw new Error("Account already exists");
         }
 
         const created = await createAccount(ctx, {

--- a/convex/lib/passwordWithTurnstile.ts
+++ b/convex/lib/passwordWithTurnstile.ts
@@ -234,7 +234,7 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
         }
 
         const result = await signInViaProvider(ctx, config.reset, {
-          params: normalizedParams,
+          params: { ...normalizedParams, email: retrieved.email },
         });
         if (result === null) {
           throw new Error("Invalid code");

--- a/convex/lib/passwordWithTurnstile.ts
+++ b/convex/lib/passwordWithTurnstile.ts
@@ -65,7 +65,7 @@ async function retrievePasswordAccount<DataModel extends GenericDataModel>(
 ): Promise<(Awaited<ReturnType<typeof retrieveAccount<DataModel>>> & { email: string }) | null> {
   const candidates =
     input.originalEmail && input.originalEmail !== input.email
-      ? [input.email, input.originalEmail]
+      ? [input.originalEmail, input.email]
       : [input.email];
   let lastMissingAccountError: unknown = null;
 
@@ -288,7 +288,7 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
       if (config.verify && !account.emailVerified) {
         return await signInViaProvider(ctx, config.verify, {
           accountId: account._id,
-          params,
+          params: normalizedParams,
         });
       }
 

--- a/convex/lib/passwordWithTurnstile.ts
+++ b/convex/lib/passwordWithTurnstile.ts
@@ -9,26 +9,19 @@ import {
   signInViaProvider,
 } from "@convex-dev/auth/server";
 import type { DocumentByName, GenericDataModel, WithoutSystemFields } from "convex/server";
-import { v, type Value } from "convex/values";
+import type { Value } from "convex/values";
 import { Scrypt } from "lucia";
 
 import { internal } from "../_generated/api";
-import { internalQuery } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import { verifyTurnstileForSignUp } from "./turnstile";
+import type { AuthEmailClaimAvailability } from "./authEmailClaims";
 
 type PasswordProfile<DataModel extends GenericDataModel> =
   WithoutSystemFields<DocumentByName<DataModel, "users">> & {
     email: string;
   };
-
-const NORMALIZED_EMAIL_LOOKUP_BATCH_SIZE = 100;
-
-type NormalizedPasswordAccountLookupPage = {
-  hasMatch: boolean;
-  continueCursor: string;
-  isDone: boolean;
-};
 
 function getStringParam(
   params: Partial<Record<string, Value | undefined>>,
@@ -111,59 +104,28 @@ async function hasPasswordAccountForNormalizedEmail<DataModel extends GenericDat
     normalizedEmail: string;
   },
 ): Promise<boolean> {
-  let cursor: string | null = null;
+  const availability: AuthEmailClaimAvailability = await ctx.runQuery(
+    internal.lib.authEmailClaims.getAvailability,
+    {
+      provider: input.provider,
+      normalizedEmail: input.normalizedEmail,
+    },
+  );
 
-  do {
-    const page: NormalizedPasswordAccountLookupPage = await ctx.runQuery(
-      internal.lib.passwordWithTurnstile.findPasswordAccountByNormalizedEmailPage,
-      {
-        provider: input.provider,
-        normalizedEmail: input.normalizedEmail,
-        cursor,
-        numItems: NORMALIZED_EMAIL_LOOKUP_BATCH_SIZE,
-      },
-    );
-
-    if (page.hasMatch) {
-      return true;
-    }
-
-    cursor = page.continueCursor;
-    if (page.isDone) {
-      return false;
-    }
-  } while (cursor !== null);
-
-  return false;
+  return availability.authAccountClaimed || availability.userEmailClaimed;
 }
 
-export const findPasswordAccountByNormalizedEmailPage = internalQuery({
-  args: {
-    provider: v.string(),
-    normalizedEmail: v.string(),
-    cursor: v.union(v.string(), v.null()),
-    numItems: v.optional(v.number()),
+async function replacePasswordAccountEmailClaim<DataModel extends GenericDataModel>(
+  ctx: GenericActionCtxWithAuthConfig<DataModel>,
+  input: {
+    provider: string;
+    normalizedEmail: string;
+    accountId: Id<"authAccounts">;
+    userId: Id<"users">;
   },
-  handler: async (ctx, args): Promise<NormalizedPasswordAccountLookupPage> => {
-    const page = await ctx.db
-      .query("authAccounts")
-      .withIndex("providerAndAccountId", (q) => q.eq("provider", args.provider))
-      .paginate({
-        cursor: args.cursor,
-        numItems: args.numItems ?? NORMALIZED_EMAIL_LOOKUP_BATCH_SIZE,
-      });
-
-    return {
-      hasMatch: page.page.some(
-        (account) =>
-          typeof account.providerAccountId === "string" &&
-          normalizeAuthEmail(account.providerAccountId) === args.normalizedEmail,
-      ),
-      continueCursor: page.continueCursor,
-      isDone: page.isDone,
-    };
-  },
-});
+): Promise<void> {
+  await ctx.runMutation(internal.lib.authEmailClaims.replaceForAccount, input);
+}
 
 export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
   config: PasswordConfig<DataModel> = {},
@@ -235,6 +197,12 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
           profile,
           shouldLinkViaEmail: config.verify !== undefined,
           shouldLinkViaPhone: false,
+        });
+        await replacePasswordAccountEmailClaim(ctx, {
+          provider,
+          normalizedEmail: email,
+          accountId: created.account._id as Id<"authAccounts">,
+          userId: created.user._id as Id<"users">,
         });
         ({ account, user } = created);
       } else if (flow === "signIn") {

--- a/convex/lib/passwordWithTurnstile.ts
+++ b/convex/lib/passwordWithTurnstile.ts
@@ -1,5 +1,6 @@
 import { ConvexCredentials } from "@convex-dev/auth/providers/ConvexCredentials";
 import type { PasswordConfig } from "@convex-dev/auth/providers/Password";
+import type { GenericActionCtxWithAuthConfig } from "@convex-dev/auth/server";
 import {
   createAccount,
   invalidateSessions,
@@ -11,6 +12,7 @@ import type { DocumentByName, GenericDataModel, WithoutSystemFields } from "conv
 import type { Value } from "convex/values";
 import { Scrypt } from "lucia";
 
+import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import { verifyTurnstileForSignUp } from "./turnstile";
 
 type PasswordProfile<DataModel extends GenericDataModel> =
@@ -29,7 +31,7 @@ function getStringParam(
 function defaultProfile<DataModel extends GenericDataModel>(
   params: Partial<Record<string, Value | undefined>>,
 ): PasswordProfile<DataModel> {
-  const email = getStringParam(params, "email")?.trim();
+  const email = normalizeOptionalAuthEmail(getStringParam(params, "email"));
   if (!email) {
     throw new Error("Missing `email` param");
   }
@@ -46,6 +48,50 @@ function validateDefaultPasswordRequirements(password: string | undefined) {
 function isMissingAccountError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : "";
   return message.includes("InvalidAccountId");
+}
+
+function normalizeOptionalAuthEmail(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : normalizeAuthEmail(value);
+}
+
+async function retrievePasswordAccount<DataModel extends GenericDataModel>(
+  ctx: GenericActionCtxWithAuthConfig<DataModel>,
+  input: {
+    provider: string;
+    email: string;
+    originalEmail?: string | undefined;
+    secret?: string | undefined;
+  },
+): Promise<(Awaited<ReturnType<typeof retrieveAccount<DataModel>>> & { email: string }) | null> {
+  const candidates =
+    input.originalEmail && input.originalEmail !== input.email
+      ? [input.email, input.originalEmail]
+      : [input.email];
+  let lastMissingAccountError: unknown = null;
+
+  for (const candidate of candidates) {
+    try {
+      const retrieved = await retrieveAccount(ctx, {
+        provider: input.provider,
+        account: {
+          id: candidate,
+          ...(input.secret !== undefined ? { secret: input.secret } : {}),
+        },
+      });
+      return { ...retrieved, email: candidate };
+    } catch (error) {
+      if (!isMissingAccountError(error)) {
+        throw error;
+      }
+      lastMissingAccountError = error;
+    }
+  }
+
+  if (lastMissingAccountError) {
+    throw lastMissingAccountError;
+  }
+
+  return null;
 }
 
 export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
@@ -74,8 +120,11 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
         }
       }
 
-      const profile = config.profile?.(params, ctx) ?? defaultProfile<DataModel>(params);
-      const { email } = profile;
+      const rawProfile = config.profile?.(params, ctx) ?? defaultProfile<DataModel>(params);
+      const email = normalizeAuthEmail(rawProfile.email);
+      const profile = { ...rawProfile, email } as PasswordProfile<DataModel>;
+      const originalEmail = getStringParam(params, "email")?.trim();
+      const normalizedParams = { ...params, email };
       const secret = getStringParam(params, "password");
       let account;
       let user;
@@ -88,9 +137,10 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
         await verifyTurnstileForSignUp(params);
 
         try {
-          await retrieveAccount(ctx, {
+          await retrievePasswordAccount(ctx, {
             provider,
-            account: { id: email },
+            email,
+            originalEmail,
           });
           throw new Error("Account already exists");
         } catch (error) {
@@ -114,9 +164,11 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         let retrieved;
         try {
-          retrieved = await retrieveAccount(ctx, {
+          retrieved = await retrievePasswordAccount(ctx, {
             provider,
-            account: { id: email, secret },
+            email,
+            originalEmail,
+            secret,
           });
         } catch (error) {
           if (isMissingAccountError(error)) {
@@ -135,9 +187,10 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         let retrieved;
         try {
-          retrieved = await retrieveAccount(ctx, {
+          retrieved = await retrievePasswordAccount(ctx, {
             provider,
-            account: { id: email },
+            email,
+            originalEmail,
           });
         } catch (error) {
           if (isMissingAccountError(error)) {
@@ -151,7 +204,7 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         return await signInViaProvider(ctx, config.reset, {
           accountId: retrieved.account._id,
-          params,
+          params: normalizedParams,
         });
       } else if (flow === "reset-verification") {
         if (!config.reset) {
@@ -165,9 +218,10 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         let retrieved;
         try {
-          retrieved = await retrieveAccount(ctx, {
+          retrieved = await retrievePasswordAccount(ctx, {
             provider,
-            account: { id: email },
+            email,
+            originalEmail,
           });
         } catch (error) {
           if (isMissingAccountError(error)) {
@@ -179,7 +233,9 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
           throw new Error("Invalid code");
         }
 
-        const result = await signInViaProvider(ctx, config.reset, { params });
+        const result = await signInViaProvider(ctx, config.reset, {
+          params: normalizedParams,
+        });
         if (result === null) {
           throw new Error("Invalid code");
         }
@@ -191,7 +247,7 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         await modifyAccountCredentials(ctx, {
           provider,
-          account: { id: email, secret: newPassword },
+          account: { id: retrieved.email, secret: newPassword },
         });
         await invalidateSessions(ctx, { userId, except: [sessionId] });
         return { userId, sessionId };
@@ -202,9 +258,10 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         let retrieved;
         try {
-          retrieved = await retrieveAccount(ctx, {
+          retrieved = await retrievePasswordAccount(ctx, {
             provider,
-            account: { id: email },
+            email,
+            originalEmail,
           });
         } catch (error) {
           if (isMissingAccountError(error)) {
@@ -218,7 +275,7 @@ export function PasswordWithTurnstile<DataModel extends GenericDataModel>(
 
         return await signInViaProvider(ctx, config.verify, {
           accountId: retrieved.account._id,
-          params,
+          params: normalizedParams,
         });
       } else {
         throw new Error(

--- a/convex/migrations/authEmailNormalization.ts
+++ b/convex/migrations/authEmailNormalization.ts
@@ -7,6 +7,7 @@ import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import {
   AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY,
   assertAuthEmailClaimAvailable,
+  ensureUserEmailClaimForUser,
   replaceAuthEmailClaimsForAccount,
 } from "../lib/authEmailClaims";
 
@@ -61,6 +62,25 @@ async function markAuthEmailClaimsBackfillComplete(ctx: MutationCtx): Promise<vo
     key: AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY,
     completedAt,
   });
+}
+
+async function getCurrentPasswordAccountIdForUserEmail(
+  ctx: MutationCtx,
+  user: Doc<"users"> & { email: string },
+  normalizedEmail: string,
+) {
+  const passwordAccount = await ctx.db
+    .query("authAccounts")
+    .withIndex("userIdAndProvider", (q) =>
+      q.eq("userId", user._id).eq("provider", "password"),
+    )
+    .unique();
+
+  return passwordAccount &&
+    typeof passwordAccount.providerAccountId === "string" &&
+    normalizeAuthEmail(passwordAccount.providerAccountId) === normalizedEmail
+    ? passwordAccount._id
+    : undefined;
 }
 
 export const auditLegacyPasswordEmailsPage = internalMutation({
@@ -226,21 +246,29 @@ export const normalizeLegacyPasswordEmails = internalMutation({
 export const backfillAuthEmailClaimsPage = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
+    usersCursor: v.optional(v.union(v.string(), v.null())),
     dryRun: v.boolean(),
     numItems: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const page = await ctx.db.query("authAccounts").paginate({
-      cursor: args.cursor,
-      numItems: getBatchSize(args.numItems),
-    });
+    const numItems = getBatchSize(args.numItems);
+    const [accountsPage, usersPage] = await Promise.all([
+      ctx.db.query("authAccounts").paginate({
+        cursor: args.cursor,
+        numItems,
+      }),
+      ctx.db.query("users").paginate({
+        cursor: args.usersCursor ?? null,
+        numItems,
+      }),
+    ]);
 
     let scannedAccounts = 0;
     let passwordAccounts = 0;
     let claimableAccounts = 0;
     let backfilledClaims = 0;
 
-    for (const account of page.page) {
+    for (const account of accountsPage.page) {
       scannedAccounts += 1;
       if (!isPasswordAccountWithEmail(account)) {
         continue;
@@ -276,18 +304,76 @@ export const backfillAuthEmailClaimsPage = internalMutation({
       }
     }
 
-    if (!args.dryRun && page.isDone) {
+    let scannedUsers = 0;
+    let userEmails = 0;
+    let claimableUserEmails = 0;
+    let backfilledUserClaims = 0;
+
+    for (const user of usersPage.page) {
+      scannedUsers += 1;
+      if (typeof user.email !== "string") {
+        continue;
+      }
+
+      userEmails += 1;
+      const normalizedEmail = normalizeAuthEmail(user.email);
+      if (!normalizedEmail) {
+        continue;
+      }
+
+      const currentAccountId = await getCurrentPasswordAccountIdForUserEmail(
+        ctx,
+        user as Doc<"users"> & { email: string },
+        normalizedEmail,
+      );
+
+      claimableUserEmails += 1;
+      await assertAuthEmailClaimAvailable(ctx, {
+        provider: "password",
+        normalizedEmail,
+        ...(currentAccountId ? { currentAccountId } : {}),
+        currentUserId: user._id,
+      });
+
+      if (!args.dryRun) {
+        const inserted = await ensureUserEmailClaimForUser(ctx, {
+          provider: "password",
+          normalizedEmail,
+          userId: user._id,
+          ...(currentAccountId ? { currentAccountId } : {}),
+        });
+        if (inserted) {
+          backfilledUserClaims += 1;
+        }
+      }
+    }
+
+    const isDone = accountsPage.isDone && usersPage.isDone;
+    if (!args.dryRun && isDone) {
       await markAuthEmailClaimsBackfillComplete(ctx);
     }
 
     return {
       dryRun: args.dryRun,
-      continueCursor: page.continueCursor,
-      isDone: page.isDone,
+      continueCursor: accountsPage.continueCursor,
+      usersContinueCursor: usersPage.continueCursor,
+      isDone,
       scannedAccounts,
       passwordAccounts,
       claimableAccounts,
       backfilledClaims,
+      scannedUsers,
+      userEmails,
+      claimableUserEmails,
+      backfilledUserClaims,
+      accounts: {
+        continueCursor: accountsPage.continueCursor,
+        isDone: accountsPage.isDone,
+      },
+      users: {
+        continueCursor: usersPage.continueCursor,
+        isDone: usersPage.isDone,
+      },
     };
   },
 });

--- a/convex/migrations/authEmailNormalization.ts
+++ b/convex/migrations/authEmailNormalization.ts
@@ -1,10 +1,14 @@
 import { v } from "convex/values";
 
 import type { Doc } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
 import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 
 type PasswordAccount = Doc<"authAccounts">;
+
+const DEFAULT_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 250;
 
 function isPasswordAccountWithEmail(
   account: Doc<"authAccounts">,
@@ -12,78 +16,125 @@ function isPasswordAccountWithEmail(
   return account.provider === "password" && typeof account.providerAccountId === "string";
 }
 
-function getNormalizedDuplicateGroupCount(
-  accounts: Array<PasswordAccount & { providerAccountId: string }>,
-) {
-  const byNormalizedEmail = new Map<
-    string,
-    Array<PasswordAccount & { providerAccountId: string }>
-  >();
-  for (const account of accounts) {
-    const normalizedEmail = normalizeAuthEmail(account.providerAccountId);
-    byNormalizedEmail.set(normalizedEmail, [
-      ...(byNormalizedEmail.get(normalizedEmail) ?? []),
-      account,
-    ]);
+function getBatchSize(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_BATCH_SIZE;
   }
-
-  return Array.from(byNormalizedEmail.values()).filter((group) => group.length > 1).length;
+  return Math.max(1, Math.min(MAX_BATCH_SIZE, Math.floor(value)));
 }
+
+async function hasLowercasePasswordAccountSibling(
+  ctx: MutationCtx,
+  account: PasswordAccount & { providerAccountId: string },
+  normalizedEmail: string,
+): Promise<boolean> {
+  const lowercaseSibling = await ctx.db
+    .query("authAccounts")
+    .withIndex("providerAndAccountId", (q) =>
+      q.eq("provider", "password").eq("providerAccountId", normalizedEmail),
+    )
+    .unique();
+
+  return Boolean(lowercaseSibling && lowercaseSibling._id !== account._id);
+}
+
+export const auditLegacyPasswordEmailsPage = internalMutation({
+  args: {
+    accountsCursor: v.union(v.string(), v.null()),
+    usersCursor: v.union(v.string(), v.null()),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const numItems = getBatchSize(args.numItems);
+    const [accountsPage, usersPage] = await Promise.all([
+      ctx.db.query("authAccounts").paginate({
+        cursor: args.accountsCursor,
+        numItems,
+      }),
+      ctx.db.query("users").paginate({
+        cursor: args.usersCursor,
+        numItems,
+      }),
+    ]);
+
+    let passwordAccounts = 0;
+    let mixedAccounts = 0;
+    let lowercaseSiblingCollisions = 0;
+
+    for (const account of accountsPage.page) {
+      if (!isPasswordAccountWithEmail(account)) {
+        continue;
+      }
+
+      passwordAccounts += 1;
+      const normalizedEmail = normalizeAuthEmail(account.providerAccountId);
+      if (account.providerAccountId === normalizedEmail) {
+        continue;
+      }
+
+      mixedAccounts += 1;
+      if (await hasLowercasePasswordAccountSibling(ctx, account, normalizedEmail)) {
+        lowercaseSiblingCollisions += 1;
+      }
+    }
+
+    let nonNormalizedUserEmails = 0;
+    for (const user of usersPage.page) {
+      if (typeof user.email === "string" && user.email !== normalizeAuthEmail(user.email)) {
+        nonNormalizedUserEmails += 1;
+      }
+    }
+
+    return {
+      accounts: {
+        continueCursor: accountsPage.continueCursor,
+        isDone: accountsPage.isDone,
+        passwordAccounts,
+        mixedAccounts,
+        lowercaseSiblingCollisions,
+      },
+      users: {
+        continueCursor: usersPage.continueCursor,
+        isDone: usersPage.isDone,
+        nonNormalizedUserEmails,
+      },
+    };
+  },
+});
 
 export const normalizeLegacyPasswordEmails = internalMutation({
   args: {
+    cursor: v.union(v.string(), v.null()),
     dryRun: v.boolean(),
-    expectedMixedAccounts: v.number(),
-    expectedNonNormalizedUserEmails: v.number(),
-    expectedNormalizedDuplicateGroups: v.number(),
-    expectedPasswordAccounts: v.number(),
+    numItems: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const allAccounts = await ctx.db.query("authAccounts").collect();
-    const passwordAccounts = allAccounts.filter(isPasswordAccountWithEmail);
-    const mixedAccounts = passwordAccounts.filter(
-      (account) => account.providerAccountId !== normalizeAuthEmail(account.providerAccountId),
-    );
-    const normalizedDuplicateGroups = getNormalizedDuplicateGroupCount(passwordAccounts);
-    const users = await ctx.db.query("users").collect();
-    const usersWithNonNormalizedEmail = users.filter(
-      (user) =>
-        typeof user.email === "string" && user.email !== normalizeAuthEmail(user.email),
-    );
+    const page = await ctx.db.query("authAccounts").paginate({
+      cursor: args.cursor,
+      numItems: getBatchSize(args.numItems),
+    });
 
-    const stats = {
-      passwordAccounts: passwordAccounts.length,
-      mixedAccounts: mixedAccounts.length,
-      nonNormalizedUserEmails: usersWithNonNormalizedEmail.length,
-      normalizedDuplicateGroups,
-    };
-
-    if (
-      stats.passwordAccounts !== args.expectedPasswordAccounts ||
-      stats.mixedAccounts !== args.expectedMixedAccounts ||
-      stats.nonNormalizedUserEmails !== args.expectedNonNormalizedUserEmails ||
-      stats.normalizedDuplicateGroups !== args.expectedNormalizedDuplicateGroups
-    ) {
-      throw new Error("Auth email normalization audit counts changed; aborting migration.");
-    }
-
-    if (stats.normalizedDuplicateGroups !== 0) {
-      throw new Error("Normalized password account duplicates exist; aborting migration.");
-    }
-
+    let scannedAccounts = 0;
+    let scannedPasswordAccounts = 0;
+    let mixedAccounts = 0;
     let migratedAccounts = 0;
     let migratedUsers = 0;
     let migratedEmailVerified = 0;
 
-    for (const account of mixedAccounts) {
+    for (const account of page.page) {
+      scannedAccounts += 1;
+      if (!isPasswordAccountWithEmail(account)) {
+        continue;
+      }
+
+      scannedPasswordAccounts += 1;
       const normalizedEmail = normalizeAuthEmail(account.providerAccountId);
-      const lowercaseSibling = await ctx.db
-        .query("authAccounts")
-        .withIndex("providerAndAccountId", (q) =>
-          q.eq("provider", "password").eq("providerAccountId", normalizedEmail),
-        )
-        .unique();
-      if (lowercaseSibling && lowercaseSibling._id !== account._id) {
+      if (account.providerAccountId === normalizedEmail) {
+        continue;
+      }
+
+      mixedAccounts += 1;
+      if (await hasLowercasePasswordAccountSibling(ctx, account, normalizedEmail)) {
         throw new Error("Lowercase password account sibling exists; aborting migration.");
       }
 
@@ -122,8 +173,12 @@ export const normalizeLegacyPasswordEmails = internalMutation({
 
     return {
       dryRun: args.dryRun,
-      ...stats,
-      migratableAccounts: mixedAccounts.length,
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      scannedAccounts,
+      scannedPasswordAccounts,
+      mixedAccounts,
+      migratableAccounts: mixedAccounts,
       migratedAccounts,
       migratedUsers,
       migratedEmailVerified,

--- a/convex/migrations/authEmailNormalization.ts
+++ b/convex/migrations/authEmailNormalization.ts
@@ -4,6 +4,10 @@ import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
+import {
+  assertAuthEmailClaimAvailable,
+  replaceAuthEmailClaimsForAccount,
+} from "../lib/authEmailClaims";
 
 type PasswordAccount = Doc<"authAccounts">;
 
@@ -152,6 +156,12 @@ export const normalizeLegacyPasswordEmails = internalMutation({
       }
 
       if (!args.dryRun) {
+        await assertAuthEmailClaimAvailable(ctx, {
+          provider: "password",
+          normalizedEmail,
+          currentAccountId: account._id,
+          currentUserId: user._id,
+        });
         await ctx.db.patch(account._id, {
           providerAccountId: normalizedEmail,
           ...(account.emailVerified === account.providerAccountId
@@ -164,6 +174,12 @@ export const normalizeLegacyPasswordEmails = internalMutation({
           await ctx.db.patch(user._id, { email: normalizedEmail });
           migratedUsers += 1;
         }
+        await replaceAuthEmailClaimsForAccount(ctx, {
+          provider: "password",
+          normalizedEmail,
+          accountId: account._id,
+          userId: user._id,
+        });
 
         if (account.emailVerified === account.providerAccountId) {
           migratedEmailVerified += 1;
@@ -182,6 +198,71 @@ export const normalizeLegacyPasswordEmails = internalMutation({
       migratedAccounts,
       migratedUsers,
       migratedEmailVerified,
+    };
+  },
+});
+
+export const backfillAuthEmailClaimsPage = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    dryRun: v.boolean(),
+    numItems: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db.query("authAccounts").paginate({
+      cursor: args.cursor,
+      numItems: getBatchSize(args.numItems),
+    });
+
+    let scannedAccounts = 0;
+    let passwordAccounts = 0;
+    let claimableAccounts = 0;
+    let backfilledClaims = 0;
+
+    for (const account of page.page) {
+      scannedAccounts += 1;
+      if (!isPasswordAccountWithEmail(account)) {
+        continue;
+      }
+
+      passwordAccounts += 1;
+      const normalizedEmail = normalizeAuthEmail(account.providerAccountId);
+      if (!normalizedEmail) {
+        continue;
+      }
+
+      const user = await ctx.db.get(account.userId);
+      if (!user) {
+        throw new Error("Linked user is missing; aborting claim backfill.");
+      }
+
+      claimableAccounts += 1;
+      await assertAuthEmailClaimAvailable(ctx, {
+        provider: "password",
+        normalizedEmail,
+        currentAccountId: account._id,
+        currentUserId: user._id,
+      });
+
+      if (!args.dryRun) {
+        await replaceAuthEmailClaimsForAccount(ctx, {
+          provider: "password",
+          normalizedEmail,
+          accountId: account._id,
+          userId: user._id,
+        });
+        backfilledClaims += 1;
+      }
+    }
+
+    return {
+      dryRun: args.dryRun,
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      scannedAccounts,
+      passwordAccounts,
+      claimableAccounts,
+      backfilledClaims,
     };
   },
 });

--- a/convex/migrations/authEmailNormalization.ts
+++ b/convex/migrations/authEmailNormalization.ts
@@ -1,0 +1,132 @@
+import { v } from "convex/values";
+
+import type { Doc } from "../_generated/dataModel";
+import { internalMutation } from "../_generated/server";
+import { normalizeAuthEmail } from "../../packages/shared/src/auth";
+
+type PasswordAccount = Doc<"authAccounts">;
+
+function isPasswordAccountWithEmail(
+  account: Doc<"authAccounts">,
+): account is PasswordAccount & { providerAccountId: string } {
+  return account.provider === "password" && typeof account.providerAccountId === "string";
+}
+
+function getNormalizedDuplicateGroupCount(
+  accounts: Array<PasswordAccount & { providerAccountId: string }>,
+) {
+  const byNormalizedEmail = new Map<
+    string,
+    Array<PasswordAccount & { providerAccountId: string }>
+  >();
+  for (const account of accounts) {
+    const normalizedEmail = normalizeAuthEmail(account.providerAccountId);
+    byNormalizedEmail.set(normalizedEmail, [
+      ...(byNormalizedEmail.get(normalizedEmail) ?? []),
+      account,
+    ]);
+  }
+
+  return Array.from(byNormalizedEmail.values()).filter((group) => group.length > 1).length;
+}
+
+export const normalizeLegacyPasswordEmails = internalMutation({
+  args: {
+    dryRun: v.boolean(),
+    expectedMixedAccounts: v.number(),
+    expectedNonNormalizedUserEmails: v.number(),
+    expectedNormalizedDuplicateGroups: v.number(),
+    expectedPasswordAccounts: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const allAccounts = await ctx.db.query("authAccounts").collect();
+    const passwordAccounts = allAccounts.filter(isPasswordAccountWithEmail);
+    const mixedAccounts = passwordAccounts.filter(
+      (account) => account.providerAccountId !== normalizeAuthEmail(account.providerAccountId),
+    );
+    const normalizedDuplicateGroups = getNormalizedDuplicateGroupCount(passwordAccounts);
+    const users = await ctx.db.query("users").collect();
+    const usersWithNonNormalizedEmail = users.filter(
+      (user) =>
+        typeof user.email === "string" && user.email !== normalizeAuthEmail(user.email),
+    );
+
+    const stats = {
+      passwordAccounts: passwordAccounts.length,
+      mixedAccounts: mixedAccounts.length,
+      nonNormalizedUserEmails: usersWithNonNormalizedEmail.length,
+      normalizedDuplicateGroups,
+    };
+
+    if (
+      stats.passwordAccounts !== args.expectedPasswordAccounts ||
+      stats.mixedAccounts !== args.expectedMixedAccounts ||
+      stats.nonNormalizedUserEmails !== args.expectedNonNormalizedUserEmails ||
+      stats.normalizedDuplicateGroups !== args.expectedNormalizedDuplicateGroups
+    ) {
+      throw new Error("Auth email normalization audit counts changed; aborting migration.");
+    }
+
+    if (stats.normalizedDuplicateGroups !== 0) {
+      throw new Error("Normalized password account duplicates exist; aborting migration.");
+    }
+
+    let migratedAccounts = 0;
+    let migratedUsers = 0;
+    let migratedEmailVerified = 0;
+
+    for (const account of mixedAccounts) {
+      const normalizedEmail = normalizeAuthEmail(account.providerAccountId);
+      const lowercaseSibling = await ctx.db
+        .query("authAccounts")
+        .withIndex("providerAndAccountId", (q) =>
+          q.eq("provider", "password").eq("providerAccountId", normalizedEmail),
+        )
+        .unique();
+      if (lowercaseSibling && lowercaseSibling._id !== account._id) {
+        throw new Error("Lowercase password account sibling exists; aborting migration.");
+      }
+
+      const user = await ctx.db.get(account.userId);
+      if (!user) {
+        throw new Error("Linked user is missing; aborting migration.");
+      }
+      if (
+        typeof user.email === "string" &&
+        normalizeAuthEmail(user.email) !== normalizedEmail
+      ) {
+        throw new Error(
+          "Linked user email does not normalize to account email; aborting migration.",
+        );
+      }
+
+      if (!args.dryRun) {
+        await ctx.db.patch(account._id, {
+          providerAccountId: normalizedEmail,
+          ...(account.emailVerified === account.providerAccountId
+            ? { emailVerified: normalizedEmail }
+            : {}),
+        });
+        migratedAccounts += 1;
+
+        if (typeof user.email === "string" && user.email !== normalizedEmail) {
+          await ctx.db.patch(user._id, { email: normalizedEmail });
+          migratedUsers += 1;
+        }
+
+        if (account.emailVerified === account.providerAccountId) {
+          migratedEmailVerified += 1;
+        }
+      }
+    }
+
+    return {
+      dryRun: args.dryRun,
+      ...stats,
+      migratableAccounts: mixedAccounts.length,
+      migratedAccounts,
+      migratedUsers,
+      migratedEmailVerified,
+    };
+  },
+});

--- a/convex/migrations/authEmailNormalization.ts
+++ b/convex/migrations/authEmailNormalization.ts
@@ -5,6 +5,7 @@ import type { MutationCtx } from "../_generated/server";
 import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 import {
+  AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY,
   assertAuthEmailClaimAvailable,
   replaceAuthEmailClaimsForAccount,
 } from "../lib/authEmailClaims";
@@ -40,6 +41,26 @@ async function hasLowercasePasswordAccountSibling(
     .unique();
 
   return Boolean(lowercaseSibling && lowercaseSibling._id !== account._id);
+}
+
+async function markAuthEmailClaimsBackfillComplete(ctx: MutationCtx): Promise<void> {
+  const completedAt = Date.now();
+  const existingState = await ctx.db
+    .query("auth_email_claim_backfill_state")
+    .withIndex("by_key", (q) =>
+      q.eq("key", AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY),
+    )
+    .unique();
+
+  if (existingState) {
+    await ctx.db.patch(existingState._id, { completedAt });
+    return;
+  }
+
+  await ctx.db.insert("auth_email_claim_backfill_state", {
+    key: AUTH_EMAIL_CLAIMS_BACKFILL_STATE_KEY,
+    completedAt,
+  });
 }
 
 export const auditLegacyPasswordEmailsPage = internalMutation({
@@ -253,6 +274,10 @@ export const backfillAuthEmailClaimsPage = internalMutation({
         });
         backfilledClaims += 1;
       }
+    }
+
+    if (!args.dryRun && page.isDone) {
+      await markAuthEmailClaimsBackfillComplete(ctx);
     }
 
     return {

--- a/convex/migrations/authEmailNormalization.ts
+++ b/convex/migrations/authEmailNormalization.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 
 import type { Doc } from "../_generated/dataModel";
-import { internalMutation } from "../_generated/server";
+import { observedInternalMutation as internalMutation } from "../telemetry/observedFunctions";
 import { normalizeAuthEmail } from "../../packages/shared/src/auth";
 
 type PasswordAccount = Doc<"authAccounts">;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -176,6 +176,23 @@ export default defineSchema({
     .index("by_account_id", ["accountId"])
     .index("by_code_hash", ["codeHash"]),
 
+  auth_email_claims: defineTable({
+    provider: v.string(),
+    normalizedEmail: v.string(),
+    accountId: v.id("authAccounts"),
+    userId: v.id("users"),
+  })
+    .index("by_provider_and_normalized_email", ["provider", "normalizedEmail"])
+    .index("by_account_id", ["accountId"])
+    .index("by_user_id", ["userId"]),
+
+  user_email_claims: defineTable({
+    normalizedEmail: v.string(),
+    userId: v.id("users"),
+  })
+    .index("by_normalized_email", ["normalizedEmail"])
+    .index("by_user_id", ["userId"]),
+
   businesses: defineTable({
     slug: v.string(),
     name: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -193,6 +193,11 @@ export default defineSchema({
     .index("by_normalized_email", ["normalizedEmail"])
     .index("by_user_id", ["userId"]),
 
+  auth_email_claim_backfill_state: defineTable({
+    key: v.string(),
+    completedAt: v.number(),
+  }).index("by_key", ["key"]),
+
   businesses: defineTable({
     slug: v.string(),
     name: v.string(),

--- a/convex/tests/accountCredentials.test.ts
+++ b/convex/tests/accountCredentials.test.ts
@@ -402,6 +402,109 @@ describe("account credential settings", () => {
     });
   });
 
+  it("does not create a pending email change for a mixed-case legacy target", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentPassword = "CurrentPass123!";
+    const currentSecret = await new Scrypt().hash(currentPassword);
+    const takenSecret = await new Scrypt().hash("AnotherPass123!");
+
+    const seeded = await t.run(async (ctx) => {
+      const ownerId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-owner",
+        email: "owner@example.com",
+      });
+      const otherId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-other",
+        email: "Taken@Example.com",
+      });
+
+      const ownerAccountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId: ownerId,
+        provider: "password",
+        providerAccountId: "owner@example.com",
+        secret: currentSecret,
+      });
+      await ctx.db.insert("authAccounts", {
+        userId: otherId,
+        provider: "password",
+        providerAccountId: "Taken@Example.com",
+        secret: takenSecret,
+      });
+
+      return { ownerAccountId };
+    });
+
+    const asOwner = t.withIdentity({ subject: "account-owner" });
+
+    await expect(
+      asOwner.action(api.businesses.catalog.changeEmail, {
+        currentPassword,
+        newEmail: "taken@example.com",
+      }),
+    ).resolves.toEqual({ email: "taken@example.com" });
+
+    await t.run(async (ctx) => {
+      const ownerPendingEmailChange = await ctx.db
+        .query("pending_email_changes")
+        .withIndex("by_account_id", (q) => q.eq("accountId", seeded.ownerAccountId))
+        .unique();
+
+      expect(ownerPendingEmailChange).toBeNull();
+    });
+  });
+
+  it("does not confirm an email change over a mixed-case legacy target", async () => {
+    const t = convexTest(schema, convexModules);
+    const confirmationCode = "confirm-email-change";
+
+    const seeded = await t.run(async (ctx) => {
+      const ownerId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-owner",
+        email: "owner@example.com",
+      });
+      const otherId: Id<"users"> = await ctx.db.insert("users", {
+        authSubject: "account-other",
+        email: "Taken@Example.com",
+      });
+
+      const ownerAccountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
+        userId: ownerId,
+        provider: "password",
+        providerAccountId: "owner@example.com",
+        secret: "hashed-secret",
+      });
+      await ctx.db.insert("authAccounts", {
+        userId: otherId,
+        provider: "password",
+        providerAccountId: "Taken@Example.com",
+        secret: "other-hashed-secret",
+      });
+      await ctx.db.insert("pending_email_changes", {
+        accountId: ownerAccountId,
+        codeHash: await hashCode(confirmationCode),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        email: "taken@example.com",
+      });
+
+      return { ownerId, ownerAccountId };
+    });
+
+    await expect(
+      t.action(api.businesses.catalog.confirmEmailChange, {
+        code: confirmationCode,
+        email: "taken@example.com",
+      }),
+    ).rejects.toThrow("An account with that email already exists.");
+
+    await t.run(async (ctx) => {
+      const owner = await ctx.db.get(seeded.ownerId);
+      const ownerAccount = await ctx.db.get(seeded.ownerAccountId);
+
+      expect(owner?.email).toBe("owner@example.com");
+      expect(ownerAccount?.providerAccountId).toBe("owner@example.com");
+    });
+  });
+
   it("clears existing pending email changes when masking a taken target email", async () => {
     const t = convexTest(schema, convexModules);
     const currentPassword = "CurrentPass123!";

--- a/convex/tests/accountCredentials.test.ts
+++ b/convex/tests/accountCredentials.test.ts
@@ -424,11 +424,21 @@ describe("account credential settings", () => {
         providerAccountId: "owner@example.com",
         secret: currentSecret,
       });
-      await ctx.db.insert("authAccounts", {
+      const otherAccountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
         userId: otherId,
         provider: "password",
         providerAccountId: "Taken@Example.com",
         secret: takenSecret,
+      });
+      await ctx.db.insert("auth_email_claims", {
+        userId: otherId,
+        accountId: otherAccountId,
+        provider: "password",
+        normalizedEmail: "taken@example.com",
+      });
+      await ctx.db.insert("user_email_claims", {
+        userId: otherId,
+        normalizedEmail: "taken@example.com",
       });
 
       return { ownerAccountId };
@@ -473,11 +483,21 @@ describe("account credential settings", () => {
         providerAccountId: "owner@example.com",
         secret: "hashed-secret",
       });
-      await ctx.db.insert("authAccounts", {
+      const otherAccountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
         userId: otherId,
         provider: "password",
         providerAccountId: "Taken@Example.com",
         secret: "other-hashed-secret",
+      });
+      await ctx.db.insert("auth_email_claims", {
+        userId: otherId,
+        accountId: otherAccountId,
+        provider: "password",
+        normalizedEmail: "taken@example.com",
+      });
+      await ctx.db.insert("user_email_claims", {
+        userId: otherId,
+        normalizedEmail: "taken@example.com",
       });
       await ctx.db.insert("pending_email_changes", {
         accountId: ownerAccountId,

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -93,10 +93,12 @@ describe("password auth email normalization", () => {
     const legacyUserId = await seedPasswordAccount(t, {
       email: "Hello@lobbystack.com",
       password: legacyPassword,
+      createClaims: false,
     });
     const lowercaseUserId = await seedPasswordAccount(t, {
       email: "hello@lobbystack.com",
       password: lowercasePassword,
+      createClaims: false,
     });
 
     await expect(
@@ -132,10 +134,12 @@ describe("password auth email normalization", () => {
     const legacyUserId = await seedPasswordAccount(t, {
       email: "Hello@lobbystack.com",
       password: legacyPassword,
+      createClaims: false,
     });
     const lowercaseUserId = await seedPasswordAccount(t, {
       email: "hello@lobbystack.com",
       password: lowercasePassword,
+      createClaims: false,
     });
 
     await expect(
@@ -189,6 +193,22 @@ describe("password auth email normalization", () => {
       expect(account).not.toBeNull();
       expect(account?.providerAccountId).toBe("hello@lobbystack.com");
       expect((await ctx.db.get(account!.userId))?.email).toBe("hello@lobbystack.com");
+      expect(
+        await ctx.db
+          .query("auth_email_claims")
+          .withIndex("by_provider_and_normalized_email", (q) =>
+            q.eq("provider", "password").eq("normalizedEmail", "hello@lobbystack.com"),
+          )
+          .unique(),
+      ).toMatchObject({ accountId: account!._id });
+      expect(
+        await ctx.db
+          .query("user_email_claims")
+          .withIndex("by_normalized_email", (q) =>
+            q.eq("normalizedEmail", "hello@lobbystack.com"),
+          )
+          .unique(),
+      ).toMatchObject({ userId: account!.userId });
     });
   });
 
@@ -291,10 +311,12 @@ describe("password auth email normalization", () => {
     const legacyUserId = await seedPasswordAccount(t, {
       email: "Hello@lobbystack.com",
       password: "LegacyPass123!",
+      createClaims: false,
     });
     const lowercaseUserId = await seedPasswordAccount(t, {
       email: "hello@lobbystack.com",
       password: "LowercasePass123!",
+      createClaims: false,
     });
 
     await expect(
@@ -463,6 +485,7 @@ async function seedPasswordAccount(
   input: {
     email: string;
     password: string;
+    createClaims?: boolean;
   },
 ): Promise<Id<"users">> {
   const secret = await new Scrypt().hash(input.password);
@@ -472,12 +495,26 @@ async function seedPasswordAccount(
       email: input.email,
     });
 
-    await ctx.db.insert("authAccounts", {
+    const accountId: Id<"authAccounts"> = await ctx.db.insert("authAccounts", {
       userId,
       provider: "password",
       providerAccountId: input.email,
       secret,
     });
+
+    if (input.createClaims !== false) {
+      const normalizedEmail = input.email.trim().toLowerCase();
+      await ctx.db.insert("auth_email_claims", {
+        userId,
+        accountId,
+        provider: "password",
+        normalizedEmail,
+      });
+      await ctx.db.insert("user_email_claims", {
+        userId,
+        normalizedEmail,
+      });
+    }
 
     return userId;
   });

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -218,6 +218,32 @@ describe("password auth email normalization", () => {
     });
   });
 
+  it("does not create a lowercase duplicate for a mixed-case legacy account", async () => {
+    const t = convexTest(schema, convexModules);
+    await seedPasswordAccount(t, {
+      email: "Hello@lobbystack.com",
+      password: "CurrentPass123!",
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signUp",
+          email: "hello@lobbystack.com",
+          password: "CurrentPass123!",
+        },
+      }),
+    ).rejects.toThrow("Account already exists");
+
+    await t.run(async (ctx) => {
+      const accounts = await ctx.db.query("authAccounts").collect();
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]?.providerAccountId).toBe("Hello@lobbystack.com");
+    });
+  });
+
   it("creates a reset code for an uppercase email variant", async () => {
     const t = convexTest(schema, convexModules);
     const userId = await seedPasswordAccount(t, {

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -305,6 +305,57 @@ describe("password auth email normalization", () => {
     ).rejects.toThrow("Account already exists");
   });
 
+  it("blocks duplicates for user emails without password accounts after claim backfill completes", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        email: "Standalone@lobbystack.com",
+      });
+    });
+
+    await expect(
+      t.mutation(internal.migrations.authEmailNormalization.backfillAuthEmailClaimsPage, {
+        cursor: null,
+        usersCursor: null,
+        dryRun: false,
+        numItems: 100,
+      }),
+    ).resolves.toMatchObject({
+      backfilledClaims: 0,
+      backfilledUserClaims: 1,
+      isDone: true,
+    });
+
+    await t.run(async (ctx) => {
+      expect(
+        await ctx.db
+          .query("auth_email_claim_backfill_state")
+          .withIndex("by_key", (q) => q.eq("key", "password_claims_backfilled"))
+          .unique(),
+      ).toMatchObject({ completedAt: expect.any(Number) });
+      expect(
+        await ctx.db
+          .query("user_email_claims")
+          .withIndex("by_normalized_email", (q) =>
+            q.eq("normalizedEmail", "standalone@lobbystack.com"),
+          )
+          .unique(),
+      ).toMatchObject({ normalizedEmail: "standalone@lobbystack.com" });
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signUp",
+          email: "standalone@lobbystack.com",
+          password: "CurrentPass123!",
+        },
+      }),
+    ).rejects.toThrow("Account already exists");
+  });
+
   it("creates a reset code for an uppercase email variant", async () => {
     const t = convexTest(schema, convexModules);
     const userId = await seedPasswordAccount(t, {

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -1,0 +1,268 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { Scrypt } from "lucia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+const TEST_JWT_PRIVATE_KEY = [
+  "-----BEGIN PRIVATE KEY-----",
+  "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCKtYDI9Cz2QRxR",
+  "vVx4hihzK2gpApRmDcQiosAkEgBiQ3EIImYhxeZU+Kc1CTwsXO+RmVjBgxK3CfPP",
+  "Zf8f066Fc88W1KvYX3hsITYftd58CRqiKAL9O3Ws66zGCwonjUc+IRGoeDXdPkcc",
+  "sU3to3w06io8f5znXzXi0A6+CFmFM5iGSDWlY9AzOv+jNv63Lj6ChF7sVa0lbpQu",
+  "Z+dTw5p6gxp75lSpHMiQtaOmhYDf0TCosyUJMR9H588pse8Q/HvqFYAWfreWRcnR",
+  "oL1bhJ1uSS+5nIUSddy25CqAOycc6FMbZjpvS6sd1Lc08X0zh++ChxQyTzoe915W",
+  "gA5jIuFhAgMBAAECggEAD/enYNqs71cc87Lk+XHWJ7XcOnZTz3Cvvp32GODinu0t",
+  "DpbpI2Ok6WyrUOFkhiXXpS7eJv6X8a6pXJtc9FS5nx6u/O2T76dD1Uy4bouQ1j31",
+  "DSwmdfC5keOaYrzkGRv8EsSbRAW8i6Cu7nhhpGTAuFWpcYfuL7tH2HmDbPBIn9re",
+  "gXijFij06ZaNRP9Gmm0aV2gId5Id6uxC/csdKzmCAEb46MPaesYjVZ6LlIGBUG8i",
+  "CBe3mwbslrEyJrUS9RoYtmUQAOc5q0LspPuIL/y2tUqiPY9j3JI0NZ4pfJq/t0Zb",
+  "6eQKEnAnK8OgGv1zTZ+MoONcrM9NLjFuP1kYm9Sj7QKBgQDCBgtTUlmdkx07PcmE",
+  "SrZuj17Z7wcfp6wadVADxBB7Wv5GBCJnxTRlrFJr/qUYskeuJv777EqOTM908wc0",
+  "nw0csCIFYyyIHURJ3d5cBi2TnohaifCuAP/mAPtfVOx4E3gfzYib+QTsHf4VkVPP",
+  "4ajFjO76+oTc6X0fwZCisSPN5QKBgQC3BDLsOQdT9Gp1+8rTKRQMXg6gnbKJfFzB",
+  "XvaeZxE4DeZl+ThD6E58xj34EmPI/+hJQyXn/KeZd/nx9REH9ZXUKQSCOe85urst",
+  "NZvpRv1YsFyraG/bg8d+2Q0sxM3p4nR+uqGm5SmEedxAc2L2d/mj4hmRdm6MxDAg",
+  "x27bptLtzQKBgH6i4Ut96V3uwlqDRn8hIJdi3l7SI00m7C7MuO/sTXGl/2aFlksy",
+  "rLNb2OQB7ZID8sMZUr3tCPB98736TY6r7Sv3Tg1EILGqoIKx3EsmASNjis3FUKDR",
+  "qDRgGbGsRTdORc5EIVDkJLFUFh3Pn+uD9tsR1H1de9CQWQmcFiIKCjt9AoGAJGPS",
+  "WEPyoA/eRz1ck+X8FYVyNR+GC25N5ykhsldeBh5FbItEU8RSLt8gHT5S1vmDT2Xp",
+  "mJoVHR/M8/49d66uLvRE8DvixEDLzO525Mh3wXW3x2FJtIUcWq1/wCIVq2aasUQc",
+  "tlmkirHMSIho6gbq/VoMqW66BoVP6ISfF0+xaxUCgYEAnJ7Q+zMO2ZxoTnhrJAJb",
+  "6GEFJtqXc1CO2OtpSoJS+jNLi5LPARbRwNOmgbJG5WsOvWPe0F8Zj1kv/VV/zdWW",
+  "L0XZ8eKYdfovQPpciHjArSC283qlvYGESLXinu/z314GweAX1ss8906uPFR0ZwDE",
+  "+36r5R01lqAKjXxgv63EkbQ=",
+  "-----END PRIVATE KEY-----",
+].join(" ");
+
+const { sendTransactionalEmailMock } = vi.hoisted(() => ({
+  sendTransactionalEmailMock: vi.fn(async () => ({ messageId: "test-message" })),
+}));
+
+vi.mock("../lib/providers/email", () => ({
+  sendTransactionalEmail: sendTransactionalEmailMock,
+}));
+
+const convexModules = modules;
+type ConvexHarness = TestConvex<typeof schema>;
+
+describe("password auth email normalization", () => {
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_SITE_URL", "http://localhost:3210");
+    vi.stubEnv("JWT_PRIVATE_KEY", TEST_JWT_PRIVATE_KEY);
+    vi.stubEnv("SITE_URL", "http://localhost:5173");
+    sendTransactionalEmailMock.mockClear();
+  });
+
+  it("signs in with an uppercase email when the password account is lowercase", async () => {
+    const t = convexTest(schema, convexModules);
+    const password = "CurrentPass123!";
+    const userId = await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password,
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signIn",
+          email: "HELLO@lobbystack.com",
+          password,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await t.run(async (ctx) => {
+      const sessions = await ctx.db
+        .query("authSessions")
+        .withIndex("userId", (q) => q.eq("userId", userId))
+        .collect();
+
+      expect(sessions).toHaveLength(1);
+    });
+  });
+
+  it("stores signup email and password account id in lowercase", async () => {
+    const t = convexTest(schema, convexModules);
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signUp",
+          email: "HELLO@lobbystack.com",
+          password: "CurrentPass123!",
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await t.run(async (ctx) => {
+      const account = await ctx.db
+        .query("authAccounts")
+        .withIndex("providerAndAccountId", (q) =>
+          q.eq("provider", "password").eq("providerAccountId", "hello@lobbystack.com"),
+        )
+        .unique();
+
+      expect(account).not.toBeNull();
+      expect(account?.providerAccountId).toBe("hello@lobbystack.com");
+      expect((await ctx.db.get(account!.userId))?.email).toBe("hello@lobbystack.com");
+    });
+  });
+
+  it("does not create a duplicate account for an uppercase signup variant", async () => {
+    const t = convexTest(schema, convexModules);
+    await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password: "CurrentPass123!",
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signUp",
+          email: "HELLO@lobbystack.com",
+          password: "CurrentPass123!",
+        },
+      }),
+    ).rejects.toThrow("Account already exists");
+
+    await t.run(async (ctx) => {
+      const accounts = await ctx.db.query("authAccounts").collect();
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]?.providerAccountId).toBe("hello@lobbystack.com");
+    });
+  });
+
+  it("creates a reset code for an uppercase email variant", async () => {
+    const t = convexTest(schema, convexModules);
+    const userId = await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password: "CurrentPass123!",
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "reset",
+          email: "HELLO@lobbystack.com",
+        },
+      }),
+    ).resolves.toEqual({ tokens: null });
+
+    await t.run(async (ctx) => {
+      const account = await ctx.db
+        .query("authAccounts")
+        .withIndex("userIdAndProvider", (q) =>
+          q.eq("userId", userId).eq("provider", "password"),
+        )
+        .unique();
+      const resetCode = await ctx.db
+        .query("authVerificationCodes")
+        .withIndex("accountId", (q) => q.eq("accountId", account!._id))
+        .unique();
+
+      expect(resetCode).not.toBeNull();
+      expect(resetCode?.provider).toBe("email");
+      expect(resetCode?.emailVerified).toBe("hello@lobbystack.com");
+    });
+    expect(sendTransactionalEmailMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        template: "password_reset",
+        to: "hello@lobbystack.com",
+      }),
+    );
+  });
+
+  it("verifies a reset code with an uppercase email and updates the lowercase account", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentPassword = "CurrentPass123!";
+    const newPassword = "ChangedPass123!";
+    const resetCode = "12345678";
+    const userId = await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password: currentPassword,
+    });
+
+    await t.run(async (ctx) => {
+      const account = await ctx.db
+        .query("authAccounts")
+        .withIndex("userIdAndProvider", (q) =>
+          q.eq("userId", userId).eq("provider", "password"),
+        )
+        .unique();
+
+      await ctx.db.insert("authVerificationCodes", {
+        accountId: account!._id,
+        provider: "email",
+        code: await hashCode(resetCode),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        emailVerified: "hello@lobbystack.com",
+      });
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "reset-verification",
+          email: "HELLO@lobbystack.com",
+          code: resetCode,
+          newPassword,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signIn",
+          email: "HELLO@lobbystack.com",
+          password: newPassword,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+  });
+});
+
+async function seedPasswordAccount(
+  t: ConvexHarness,
+  input: {
+    email: string;
+    password: string;
+  },
+): Promise<Id<"users">> {
+  const secret = await new Scrypt().hash(input.password);
+
+  return await t.run(async (ctx) => {
+    const userId: Id<"users"> = await ctx.db.insert("users", {
+      email: input.email,
+    });
+
+    await ctx.db.insert("authAccounts", {
+      userId,
+      provider: "password",
+      providerAccountId: input.email,
+      secret,
+    });
+
+    return userId;
+  });
+}
+
+async function hashCode(code: string): Promise<string> {
+  const encoded = new TextEncoder().encode(code);
+  const hash = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(hash), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -2,7 +2,7 @@ import { convexTest, type TestConvex } from "convex-test";
 import { Scrypt } from "lucia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import schema from "../schema";
 import { modules } from "../test.setup";
@@ -243,6 +243,7 @@ describe("password auth email normalization", () => {
     await seedPasswordAccount(t, {
       email: "Hello@lobbystack.com",
       password: "CurrentPass123!",
+      createClaims: false,
     });
 
     await expect(
@@ -262,6 +263,46 @@ describe("password auth email normalization", () => {
       expect(accounts).toHaveLength(1);
       expect(accounts[0]?.providerAccountId).toBe("Hello@lobbystack.com");
     });
+  });
+
+  it("blocks duplicates through claim rows after claim backfill completes", async () => {
+    const t = convexTest(schema, convexModules);
+    await seedPasswordAccount(t, {
+      email: "Backfill@lobbystack.com",
+      password: "CurrentPass123!",
+      createClaims: false,
+    });
+
+    await expect(
+      t.mutation(internal.migrations.authEmailNormalization.backfillAuthEmailClaimsPage, {
+        cursor: null,
+        dryRun: false,
+        numItems: 100,
+      }),
+    ).resolves.toMatchObject({
+      backfilledClaims: 1,
+      isDone: true,
+    });
+
+    await t.run(async (ctx) => {
+      expect(
+        await ctx.db
+          .query("auth_email_claim_backfill_state")
+          .withIndex("by_key", (q) => q.eq("key", "password_claims_backfilled"))
+          .unique(),
+      ).toMatchObject({ completedAt: expect.any(Number) });
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signUp",
+          email: "backfill@lobbystack.com",
+          password: "CurrentPass123!",
+        },
+      }),
+    ).rejects.toThrow("Account already exists");
   });
 
   it("creates a reset code for an uppercase email variant", async () => {

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -366,6 +366,70 @@ describe("password auth email normalization", () => {
       }),
     ).resolves.toMatchObject({ tokens: expect.any(Object) });
   });
+
+  it("verifies a reset code for an exact mixed-case legacy account", async () => {
+    const t = convexTest(schema, convexModules);
+    const currentPassword = "CurrentPass123!";
+    const newPassword = "ChangedPass123!";
+    const resetCode = "12345678";
+    const userId = await seedPasswordAccount(t, {
+      email: "Hello@lobbystack.com",
+      password: currentPassword,
+    });
+
+    await t.run(async (ctx) => {
+      const account = await ctx.db
+        .query("authAccounts")
+        .withIndex("userIdAndProvider", (q) =>
+          q.eq("userId", userId).eq("provider", "password"),
+        )
+        .unique();
+
+      await ctx.db.insert("authVerificationCodes", {
+        accountId: account!._id,
+        provider: "email",
+        code: await hashCode(resetCode),
+        expirationTime: Date.now() + 5 * 60 * 1000,
+        emailVerified: "hello@lobbystack.com",
+      });
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "reset-verification",
+          email: "Hello@lobbystack.com",
+          code: resetCode,
+          newPassword,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signIn",
+          email: "Hello@lobbystack.com",
+          password: newPassword,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await t.run(async (ctx) => {
+      const account = await ctx.db
+        .query("authAccounts")
+        .withIndex("userIdAndProvider", (q) =>
+          q.eq("userId", userId).eq("provider", "password"),
+        )
+        .unique();
+      const user = await ctx.db.get(userId);
+
+      expect(account?.providerAccountId).toBe("Hello@lobbystack.com");
+      expect(user?.email).toBe("hello@lobbystack.com");
+    });
+  });
 });
 
 async function seedPasswordAccount(

--- a/convex/tests/passwordAuthEmailNormalization.test.ts
+++ b/convex/tests/passwordAuthEmailNormalization.test.ts
@@ -86,6 +86,84 @@ describe("password auth email normalization", () => {
     });
   });
 
+  it("signs in to an exact mixed-case legacy account before normalized fallback", async () => {
+    const t = convexTest(schema, convexModules);
+    const legacyPassword = "LegacyPass123!";
+    const lowercasePassword = "LowercasePass123!";
+    const legacyUserId = await seedPasswordAccount(t, {
+      email: "Hello@lobbystack.com",
+      password: legacyPassword,
+    });
+    const lowercaseUserId = await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password: lowercasePassword,
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signIn",
+          email: "Hello@lobbystack.com",
+          password: legacyPassword,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await t.run(async (ctx) => {
+      const legacySessions = await ctx.db
+        .query("authSessions")
+        .withIndex("userId", (q) => q.eq("userId", legacyUserId))
+        .collect();
+      const lowercaseSessions = await ctx.db
+        .query("authSessions")
+        .withIndex("userId", (q) => q.eq("userId", lowercaseUserId))
+        .collect();
+
+      expect(legacySessions).toHaveLength(1);
+      expect(lowercaseSessions).toHaveLength(0);
+    });
+  });
+
+  it("signs in to the lowercase account when both mixed-case and lowercase accounts exist", async () => {
+    const t = convexTest(schema, convexModules);
+    const legacyPassword = "LegacyPass123!";
+    const lowercasePassword = "LowercasePass123!";
+    const legacyUserId = await seedPasswordAccount(t, {
+      email: "Hello@lobbystack.com",
+      password: legacyPassword,
+    });
+    const lowercaseUserId = await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password: lowercasePassword,
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "signIn",
+          email: "hello@lobbystack.com",
+          password: lowercasePassword,
+        },
+      }),
+    ).resolves.toMatchObject({ tokens: expect.any(Object) });
+
+    await t.run(async (ctx) => {
+      const legacySessions = await ctx.db
+        .query("authSessions")
+        .withIndex("userId", (q) => q.eq("userId", legacyUserId))
+        .collect();
+      const lowercaseSessions = await ctx.db
+        .query("authSessions")
+        .withIndex("userId", (q) => q.eq("userId", lowercaseUserId))
+        .collect();
+
+      expect(legacySessions).toHaveLength(0);
+      expect(lowercaseSessions).toHaveLength(1);
+    });
+  });
+
   it("stores signup email and password account id in lowercase", async () => {
     const t = convexTest(schema, convexModules);
 
@@ -172,6 +250,62 @@ describe("password auth email normalization", () => {
       expect(resetCode).not.toBeNull();
       expect(resetCode?.provider).toBe("email");
       expect(resetCode?.emailVerified).toBe("hello@lobbystack.com");
+    });
+    expect(sendTransactionalEmailMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        template: "password_reset",
+        to: "hello@lobbystack.com",
+      }),
+    );
+  });
+
+  it("creates a reset code for an exact mixed-case legacy account before normalized fallback", async () => {
+    const t = convexTest(schema, convexModules);
+    const legacyUserId = await seedPasswordAccount(t, {
+      email: "Hello@lobbystack.com",
+      password: "LegacyPass123!",
+    });
+    const lowercaseUserId = await seedPasswordAccount(t, {
+      email: "hello@lobbystack.com",
+      password: "LowercasePass123!",
+    });
+
+    await expect(
+      t.action(api.auth.signIn, {
+        provider: "password",
+        params: {
+          flow: "reset",
+          email: "Hello@lobbystack.com",
+        },
+      }),
+    ).resolves.toEqual({ tokens: null });
+
+    await t.run(async (ctx) => {
+      const legacyAccount = await ctx.db
+        .query("authAccounts")
+        .withIndex("userIdAndProvider", (q) =>
+          q.eq("userId", legacyUserId).eq("provider", "password"),
+        )
+        .unique();
+      const lowercaseAccount = await ctx.db
+        .query("authAccounts")
+        .withIndex("userIdAndProvider", (q) =>
+          q.eq("userId", lowercaseUserId).eq("provider", "password"),
+        )
+        .unique();
+      const legacyResetCode = await ctx.db
+        .query("authVerificationCodes")
+        .withIndex("accountId", (q) => q.eq("accountId", legacyAccount!._id))
+        .unique();
+      const lowercaseResetCode = await ctx.db
+        .query("authVerificationCodes")
+        .withIndex("accountId", (q) => q.eq("accountId", lowercaseAccount!._id))
+        .unique();
+
+      expect(legacyResetCode).not.toBeNull();
+      expect(legacyResetCode?.emailVerified).toBe("hello@lobbystack.com");
+      expect(lowercaseResetCode).toBeNull();
     });
     expect(sendTransactionalEmailMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/docs/auth-email-normalization-audit.md
+++ b/docs/auth-email-normalization-audit.md
@@ -13,7 +13,10 @@ Follow-up production audit:
 3. If no lowercase collision exists, migrate the mixed-case
    `providerAccountId` to lowercase and also lowercase the linked `users.email`
    value when present.
-4. If a lowercase collision exists, do not auto-migrate. Review both accounts
+4. Backfill `auth_email_claims` and `user_email_claims` with
+   `migrations/authEmailNormalization:backfillAuthEmailClaimsPage` so runtime
+   duplicate checks use indexed normalized-email lookups.
+5. If a lowercase collision exists, do not auto-migrate. Review both accounts
    manually and decide which user record should own the normalized email.
 
 The runtime fallback keeps sign-in and password reset working for exact

--- a/docs/auth-email-normalization-audit.md
+++ b/docs/auth-email-normalization-audit.md
@@ -15,9 +15,11 @@ Follow-up production audit:
    value when present.
 4. Backfill `auth_email_claims` and `user_email_claims` with
    `migrations/authEmailNormalization:backfillAuthEmailClaimsPage` so runtime
-   duplicate checks use indexed normalized-email lookups. The final non-dry-run
-   page records backfill completion and disables the temporary legacy scan on
-   normal auth paths.
+   duplicate checks use indexed normalized-email lookups. Pass the returned
+   `continueCursor` and `usersContinueCursor` into the next page as `cursor`
+   and `usersCursor`; the final non-dry-run page records backfill completion
+   only after both account and user pages are done, then disables the temporary
+   legacy scan on normal auth paths.
 5. If a lowercase collision exists, do not auto-migrate. Review both accounts
    manually and decide which user record should own the normalized email.
 

--- a/docs/auth-email-normalization-audit.md
+++ b/docs/auth-email-normalization-audit.md
@@ -15,7 +15,9 @@ Follow-up production audit:
    value when present.
 4. Backfill `auth_email_claims` and `user_email_claims` with
    `migrations/authEmailNormalization:backfillAuthEmailClaimsPage` so runtime
-   duplicate checks use indexed normalized-email lookups.
+   duplicate checks use indexed normalized-email lookups. The final non-dry-run
+   page records backfill completion and disables the temporary legacy scan on
+   normal auth paths.
 5. If a lowercase collision exists, do not auto-migrate. Review both accounts
    manually and decide which user record should own the normalized email.
 

--- a/docs/auth-email-normalization-audit.md
+++ b/docs/auth-email-normalization-audit.md
@@ -1,0 +1,21 @@
+# Auth Email Normalization Audit
+
+Password auth now normalizes submitted email addresses with `trim().toLowerCase()`
+before creating new password accounts, looking up login credentials, and starting
+or verifying password reset flows.
+
+Follow-up production audit:
+
+1. Query `authAccounts` where `provider === "password"` and
+   `providerAccountId !== providerAccountId.toLowerCase()`.
+2. For each mixed-case `providerAccountId`, check whether a lowercase
+   `providerAccountId` already exists for the password provider.
+3. If no lowercase collision exists, migrate the mixed-case
+   `providerAccountId` to lowercase and also lowercase the linked `users.email`
+   value when present.
+4. If a lowercase collision exists, do not auto-migrate. Review both accounts
+   manually and decide which user record should own the normalized email.
+
+The runtime fallback keeps sign-in and password reset working for exact
+legacy mixed-case account IDs while the audit is pending. New password account
+writes use lowercase email identifiers going forward.

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -1,0 +1,3 @@
+export function normalizeAuthEmail(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -237,3 +237,4 @@ export type {
   SmsMessageStatus,
 } from "./twilioMessageStatus";
 export * from "./billing";
+export { normalizeAuthEmail } from "./auth";


### PR DESCRIPTION
## Summary
- Preserve the user-entered email on the web auth forms while keeping canonical lowercase normalization on the backend.
- Update password auth lookup order so exact legacy mixed-case accounts still resolve before normalized fallback.
- Add coverage for mixed-case login, signup, and password reset flows, plus a guarded Convex migration for the one production account that needed cleanup.
- Refresh auth copy and audit notes to reflect the rollout.

## Testing
- Added and updated Convex tests for legacy mixed-case handling, normalized writes, and collision fallback behavior.
- Updated web auth tests to verify the submitted form data and reset-flow UI behavior.
- Ran `pnpm test:convex`, targeted web auth tests, and `pnpm typecheck` successfully.