### PR TITLE
Canonicalize the landing host and clean up brand signals

### DIFF
--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -119,7 +119,7 @@ export default defineConfig({
         "default-src 'self'",
         "connect-src 'self' https://app.cal.com https://voice.lobbystack.com https://voice-dev.lobbystack.com https://lobbystack-voice-prod.fly.dev https://ai-receptionist-voice-dev-raphael.fly.dev http://localhost:3001 http://127.0.0.1:3001 https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
         "frame-src 'self' https://app.cal.com",
-        "img-src 'self' data: https://app.cal.com https://images.unsplash.com https://i.pravatar.cc https://media.theresanaiforthat.com https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
+        "img-src 'self' data: https://app.cal.com https://images.unsplash.com https://i.pravatar.cc https://ts.lobbystack.com https://us.i.posthog.com https://us-assets.i.posthog.com",
       ],
     },
   },

--- a/apps/landing/functions/_middleware.js
+++ b/apps/landing/functions/_middleware.js
@@ -1,5 +1,7 @@
 const MARKDOWN_TOKEN_COUNT = "120"
 const CONTENT_SIGNAL = "ai-train=yes, search=yes, ai-input=yes"
+const CANONICAL_HOST = "lobbystack.com"
+const WWW_HOST = "www.lobbystack.com"
 const POSTHOG_PROXY_HOST = "ts.lobbystack.com"
 const POSTHOG_API_HOST = "us.i.posthog.com"
 const POSTHOG_ASSET_HOST = "us-assets.i.posthog.com"
@@ -37,6 +39,7 @@ const ALLOWED_POSTHOG_PROXY_ORIGINS = new Set([
 ])
 
 const isPostHogProxyRequest = (url) => url.hostname === POSTHOG_PROXY_HOST
+const isWwwHost = (url) => url.hostname === WWW_HOST
 
 const normalizePath = (pathname) => {
   if (pathname === "") return "/"
@@ -92,6 +95,20 @@ const shouldRedirectToFrench = (request, url) => {
   return (
     TRANSLATED_PATHS.has(normalizedPath) && preferredLocale(request) === "fr"
   )
+}
+
+const redirectToCanonicalHost = (url) => {
+  const redirectUrl = new URL(url)
+  redirectUrl.hostname = CANONICAL_HOST
+  redirectUrl.protocol = "https:"
+
+  return new Response(null, {
+    status: 301,
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      Location: redirectUrl.toString(),
+    },
+  })
 }
 
 const redirectToFrench = (request, url) => {
@@ -250,6 +267,10 @@ const proxyPostHogRequest = async (context, url) => {
 
 export async function onRequest(context) {
   const url = new URL(context.request.url)
+
+  if (isWwwHost(url)) {
+    return redirectToCanonicalHost(url)
+  }
 
   if (isPostHogProxyRequest(url)) {
     return proxyPostHogRequest(context, url)

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -80,11 +80,10 @@ const footerSections = (locale: Locale) => {
 }
 
 type FooterProps = {
-  showTaaftBadge?: boolean
   locale?: Locale
 }
 
-export function Footer({ showTaaftBadge = false, locale = "en" }: FooterProps) {
+export function Footer({ locale = "en" }: FooterProps) {
   const copy = footerCopy[locale]
 
   return (
@@ -145,23 +144,6 @@ export function Footer({ showTaaftBadge = false, locale = "en" }: FooterProps) {
               </ul>
             </div>
           ))}
-          {showTaaftBadge ? (
-            <div className="col-span-2 flex flex-col items-start md:col-span-1 md:items-end">
-              <a
-                href="https://theresanaiforthat.com/ai/lobbystack/?ref=featured&v=10669742"
-                target="_blank"
-                rel="nofollow noopener noreferrer"
-              >
-                <img
-                  width={300}
-                  src="https://media.theresanaiforthat.com/featured-on-taaft.png?width=600"
-                  alt="Featured on There's An AI For That"
-                  loading="lazy"
-                  decoding="async"
-                />
-              </a>
-            </div>
-          ) : null}
         </div>
 
       </div>

--- a/apps/landing/src/components/HeroSection.tsx
+++ b/apps/landing/src/components/HeroSection.tsx
@@ -29,9 +29,9 @@ export function HeroSection({ children }: { children?: ReactNode }) {
             </a>
 
             <h1 className="animate-fade-up display-heading delay-100">
-              LobbyStack is your{" "}
+              Stop losing revenue to{" "}
               <span className="underline decoration-2 underline-offset-4">
-                open-source AI receptionist
+                missed calls
               </span>
               .
             </h1>

--- a/apps/landing/src/components/HeroSection.tsx
+++ b/apps/landing/src/components/HeroSection.tsx
@@ -37,9 +37,9 @@ export function HeroSection({ children }: { children?: ReactNode }) {
             </h1>
 
             <p className="animate-fade-up body-copy mt-6 max-w-[65ch] delay-200 md:text-lg">
-              LobbyStack answers calls, qualifies leads, replies by SMS, and
-              books appointments 24/7. Use it for every inbound call, or just
-              the ones you miss when your team is busy.
+              LobbyStack answers calls, qualifies leads, and books appointments
+              24/7. Use it for every inbound call, or just the ones you miss
+              when your team is busy.
             </p>
 
             <div className="animate-fade-up mt-8 flex items-center gap-4 delay-300">

--- a/apps/landing/src/components/HeroSection.tsx
+++ b/apps/landing/src/components/HeroSection.tsx
@@ -29,18 +29,17 @@ export function HeroSection({ children }: { children?: ReactNode }) {
             </a>
 
             <h1 className="animate-fade-up display-heading delay-100">
-              Stop losing revenue to{" "}
+              LobbyStack is your{" "}
               <span className="underline decoration-2 underline-offset-4">
-                missed calls
+                open-source AI receptionist
               </span>
               .
             </h1>
 
             <p className="animate-fade-up body-copy mt-6 max-w-[65ch] delay-200 md:text-lg">
-              An AI receptionist that answers all your calls, or only those you
-              can't take when you're busy. Instantly qualify leads, answer
-              caller questions, and book paying customers directly into your
-              calendar.
+              LobbyStack answers calls, qualifies leads, replies by SMS, and
+              books appointments 24/7. Use it for every inbound call, or just
+              the ones you miss when your team is busy.
             </p>
 
             <div className="animate-fade-up mt-8 flex items-center gap-4 delay-300">

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -48,5 +48,5 @@ import {
     <FaqSection />
     <CtaSection />
   </main>
-  <Footer showTaaftBadge />
+  <Footer />
 </Layout>


### PR DESCRIPTION
## Summary
- Redirect `www.lobbystack.com` to the apex domain with a canonical-host middleware redirect
- Remove the third-party “Featured on TAAFT” badge and its image CSP allowance
- Tighten the homepage hero copy to align with the current product positioning

## Testing
- `pnpm landing:typecheck`
- `pnpm landing:build`
- Verified the middleware returns a 301 redirect from `www.lobbystack.com` to `lobbystack.com`