### PR TITLE
Add a setup guide sidebar and persist onboarding progress

### DIFF
--- a/apps/web/public/locales/en/nav.json
+++ b/apps/web/public/locales/en/nav.json
@@ -27,6 +27,8 @@
     "setupGuide": {
       "title": "Getting started",
       "open": "Open setup guide",
+      "skip": "Skip tutorial",
+      "skipStep": "Skip",
       "progress": "{{completed}} / {{total}} completed",
       "description": "{{completed}} of {{total}} setup steps complete.",
       "steps": {

--- a/apps/web/public/locales/en/nav.json
+++ b/apps/web/public/locales/en/nav.json
@@ -35,6 +35,20 @@
         "calendar": "Connect your calendar",
         "services": "Add your Services",
         "rules": "Define Rules"
+      },
+      "stepDescriptions": {
+        "website": "Import your public website so your receptionist can learn the basics.",
+        "sources": "Upload a document with policies, FAQs, pricing, or other details your receptionist should know.",
+        "calendar": "Connect a calendar so appointment times stay in sync.",
+        "services": "Add the services customers can ask about and book.",
+        "rules": "Define the instructions your receptionist should follow during calls and messages."
+      },
+      "stepActions": {
+        "website": "Add website",
+        "sources": "Upload document",
+        "calendar": "Connect calendar",
+        "services": "Add service",
+        "rules": "Add rule"
       }
     }
   }

--- a/apps/web/public/locales/en/nav.json
+++ b/apps/web/public/locales/en/nav.json
@@ -23,6 +23,19 @@
     "upgradeToPro": "Upgrade to Pro",
     "account": "Account",
     "toggleTheme": "Toggle theme",
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "setupGuide": {
+      "title": "Getting started",
+      "open": "Open setup guide",
+      "progress": "{{completed}} / {{total}} completed",
+      "description": "{{completed}} of {{total}} setup steps complete.",
+      "steps": {
+        "website": "Add your website",
+        "sources": "Add more sources",
+        "calendar": "Connect your calendar",
+        "services": "Add your Services",
+        "rules": "Define Rules"
+      }
+    }
   }
 }

--- a/apps/web/public/locales/fr/nav.json
+++ b/apps/web/public/locales/fr/nav.json
@@ -35,6 +35,20 @@
         "calendar": "Connecter votre calendrier",
         "services": "Ajouter vos services",
         "rules": "Définir les règles"
+      },
+      "stepDescriptions": {
+        "website": "Importez votre site public pour que votre réceptionniste apprenne les bases.",
+        "sources": "Téléversez un document avec vos politiques, FAQ, tarifs ou autres détails utiles.",
+        "calendar": "Connectez un calendrier pour garder les disponibilités à jour.",
+        "services": "Ajoutez les services que les clients peuvent demander et réserver.",
+        "rules": "Définissez les consignes que votre réceptionniste doit suivre pendant les appels et messages."
+      },
+      "stepActions": {
+        "website": "Ajouter le site",
+        "sources": "Téléverser un document",
+        "calendar": "Connecter le calendrier",
+        "services": "Ajouter un service",
+        "rules": "Ajouter une règle"
       }
     }
   }

--- a/apps/web/public/locales/fr/nav.json
+++ b/apps/web/public/locales/fr/nav.json
@@ -23,6 +23,19 @@
     "upgradeToPro": "Passer à Pro",
     "account": "Compte",
     "toggleTheme": "Changer le thème",
-    "signOut": "Se déconnecter"
+    "signOut": "Se déconnecter",
+    "setupGuide": {
+      "title": "Premiers pas",
+      "open": "Ouvrir le guide de configuration",
+      "progress": "{{completed}} / {{total}} complétés",
+      "description": "{{completed}} étape(s) sur {{total}} complétée(s).",
+      "steps": {
+        "website": "Ajouter votre site web",
+        "sources": "Ajouter plus de sources",
+        "calendar": "Connecter votre calendrier",
+        "services": "Ajouter vos services",
+        "rules": "Définir les règles"
+      }
+    }
   }
 }

--- a/apps/web/public/locales/fr/nav.json
+++ b/apps/web/public/locales/fr/nav.json
@@ -27,6 +27,8 @@
     "setupGuide": {
       "title": "Premiers pas",
       "open": "Ouvrir le guide de configuration",
+      "skip": "Ignorer le tutoriel",
+      "skipStep": "Ignorer",
       "progress": "{{completed}} / {{total}} complétés",
       "description": "{{completed}} étape(s) sur {{total}} complétée(s).",
       "steps": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -56,6 +56,7 @@ import { OnboardingVerifyPhoneCodePage } from "@/features/onboarding/OnboardingV
 import { OnboardingVerifyPhonePage } from "@/features/onboarding/OnboardingVerifyPhonePage";
 import { OnboardingWebsitePage } from "@/features/onboarding/OnboardingWebsitePage";
 import { OnboardingShell } from "@/features/onboarding/components/OnboardingShell";
+import { SetupGuidePage } from "@/features/setup/SetupGuidePage";
 import {
   captureAnalyticsEvent,
   identifyOperator,
@@ -546,6 +547,16 @@ function WorkspaceShell() {
                 )
               }
               path="/integrations"
+            />
+            <Route
+              element={
+                businessId && canManageTenant ? (
+                  <SetupGuidePage businessId={businessId} />
+                ) : (
+                  <Navigate replace to="/" />
+                )
+              }
+              path="/setup-guide"
             />
             <Route element={<ContactsPage {...(businessId ? { businessId } : {})} />} path="/contacts" />
             <Route

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -319,6 +319,8 @@ function WorkspaceShell() {
   const onboardingTarget = activeBusiness
     ? onboardingRouteForStage(activeBusiness.onboardingStage)
     : null;
+  const showSetupGuide =
+    !isBootstrapLoading && Boolean(businessId && canManageTenant && !onboardingTarget);
   const shouldShowSetupPending =
     !isBootstrapLoading && Boolean(activeBusiness && onboardingTarget && !canManageTenant);
   const shouldBridgeOnboardingCheckoutSuccess =
@@ -430,6 +432,7 @@ function WorkspaceShell() {
           : {}
       )}
       showUpgradeToPro={showUpgradeToPro}
+      showSetupGuide={showSetupGuide}
     >
       <Main className="flex flex-1 flex-col" fixed={usesFixedMain}>
         {isBootstrapLoading ? (

--- a/apps/web/src/components/app-sidebar.test.tsx
+++ b/apps/web/src/components/app-sidebar.test.tsx
@@ -323,7 +323,7 @@ describe("AppSidebar", () => {
     expect(screen.queryByRole("button", { name: "Open setup guide" })).toBeNull();
   });
 
-  it("shows setup guide progress and navigates to checklist targets", async () => {
+  it("shows setup guide progress and navigates to the setup guide page", async () => {
     setupProgress(["website", "services"]);
     const user = userEvent.setup();
 
@@ -345,11 +345,8 @@ describe("AppSidebar", () => {
     expect(screen.getByText("2 / 5 completed")).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: "Open setup guide" }));
-    await user.click(await screen.findByRole("button", { name: /Add more sources/i }));
 
-    expect(screen.getByTestId("location").textContent).toBe(
-      "/agent/knowledge?setup=upload",
-    );
+    expect(screen.getByTestId("location").textContent).toBe("/setup-guide");
   });
 
   it("supports repeated mobile navigation between general, agent, and manage links", async () => {

--- a/apps/web/src/components/app-sidebar.test.tsx
+++ b/apps/web/src/components/app-sidebar.test.tsx
@@ -11,6 +11,20 @@ const themeState = vi.hoisted(() => ({
   setTheme: vi.fn(),
 }));
 
+const setupGuideQueryState = vi.hoisted(() => ({
+  progress: undefined as
+    | {
+        steps: Array<{
+          id: "website" | "sources" | "calendar" | "services" | "rules";
+          completed: boolean;
+        }>;
+        completedSteps: number;
+        totalSteps: number;
+        allCompleted: boolean;
+      }
+    | undefined,
+}));
+
 vi.mock("next-themes", () => ({
   useTheme: () => ({
     resolvedTheme: themeState.resolvedTheme,
@@ -19,9 +33,13 @@ vi.mock("next-themes", () => ({
   }),
 }));
 
+vi.mock("convex/react", () => ({
+  useQuery: () => setupGuideQueryState.progress,
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, options?: Record<string, number>) => {
       const translations: Record<string, string> = {
         "nav:sidebar.general": "General",
         "nav:sidebar.agent": "Agent",
@@ -37,6 +55,15 @@ vi.mock("react-i18next", () => ({
         "sidebar.account": "Account",
         "sidebar.toggleTheme": "Toggle theme",
         "sidebar.signOut": "Sign out",
+        "sidebar.setupGuide.title": "Getting started",
+        "sidebar.setupGuide.open": "Open setup guide",
+        "sidebar.setupGuide.progress": `${options?.completed ?? 0} / ${options?.total ?? 5} completed`,
+        "sidebar.setupGuide.description": `${options?.completed ?? 0} of ${options?.total ?? 5} setup steps complete.`,
+        "sidebar.setupGuide.steps.website": "Add your website",
+        "sidebar.setupGuide.steps.sources": "Add more sources",
+        "sidebar.setupGuide.steps.calendar": "Connect your calendar",
+        "sidebar.setupGuide.steps.services": "Add your Services",
+        "sidebar.setupGuide.steps.rules": "Define Rules",
         "settings:sections.integrations": "Integrations",
         "agent:sections.basicSettings.title": "AI settings",
         "agent:sections.knowledge.title": "Knowledge",
@@ -53,6 +80,7 @@ describe("AppSidebar", () => {
   beforeEach(() => {
     themeState.resolvedTheme = "dark";
     themeState.setTheme.mockReset();
+    setupGuideQueryState.progress = undefined;
     window.innerWidth = 1280;
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -81,6 +109,27 @@ describe("AppSidebar", () => {
         <div data-testid="pathname">{location.pathname}</div>
       </>
     );
+  }
+
+  function LocationProbe() {
+    const location = useLocation();
+
+    return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+  }
+
+  function setupProgress(completedIds: Array<"website" | "sources" | "calendar" | "services" | "rules">) {
+    const steps = (["website", "sources", "calendar", "services", "rules"] as const).map(
+      (id) => ({
+        id,
+        completed: completedIds.includes(id),
+      }),
+    );
+    setupGuideQueryState.progress = {
+      steps,
+      completedSteps: completedIds.length,
+      totalSteps: steps.length,
+      allCompleted: completedIds.length === steps.length,
+    };
   }
 
   it("groups Agent pages into their own section between General and Manage", () => {
@@ -233,6 +282,74 @@ describe("AppSidebar", () => {
 
     expect(themeState.setTheme).toHaveBeenCalledWith("light");
     expect(screen.getByRole("menuitem", { name: "Toggle theme" })).toBeTruthy();
+  });
+
+  it("hides the setup guide when the workspace is not eligible", () => {
+    setupProgress(["website"]);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <SidebarProvider>
+          <AppSidebar
+            businessId={"business-1" as any}
+            businessName="LobbyStack"
+            onSignOut={() => {}}
+            operatorEmail="operator@example.com"
+          />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Open setup guide" })).toBeNull();
+  });
+
+  it("hides the setup guide when all steps are complete", () => {
+    setupProgress(["website", "sources", "calendar", "services", "rules"]);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <SidebarProvider>
+          <AppSidebar
+            businessId={"business-1" as any}
+            businessName="LobbyStack"
+            onSignOut={() => {}}
+            operatorEmail="operator@example.com"
+            showSetupGuide
+          />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Open setup guide" })).toBeNull();
+  });
+
+  it("shows setup guide progress and navigates to checklist targets", async () => {
+    setupProgress(["website", "services"]);
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <SidebarProvider>
+          <AppSidebar
+            businessId={"business-1" as any}
+            businessName="LobbyStack"
+            onSignOut={() => {}}
+            operatorEmail="operator@example.com"
+            showSetupGuide
+          />
+          <LocationProbe />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("2 / 5 completed")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Open setup guide" }));
+    await user.click(await screen.findByRole("button", { name: /Add more sources/i }));
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/agent/knowledge?setup=upload",
+    );
   });
 
   it("supports repeated mobile navigation between general, agent, and manage links", async () => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import { NavGroup } from "@/components/layout/nav-group";
 import { NavUser } from "@/components/layout/nav-user";
 import type { SidebarData } from "@/components/layout/sidebar-types";
 import { TeamSwitcher } from "@/components/layout/team-switcher";
+import type { Id } from "../../../../convex/_generated/dataModel";
 import { BookTextIcon } from "@/components/ui/book-text";
 import { BlocksIcon } from "@/components/ui/blocks";
 import { ChartColumnIncreasingIcon } from "@/components/ui/chart-column-increasing";
@@ -28,8 +29,10 @@ import { WorkflowIcon } from "@/components/ui/workflow";
 import { AI_SMS_DASHBOARD_ENABLED } from "@/lib/release-flags";
 import { cn } from "@/lib/utils";
 import type { SidebarIconProps } from "@/components/layout/sidebar-types";
+import { SetupGuideCard } from "@/components/setup-guide-card";
 
 type AppSidebarProps = {
+  businessId?: Id<"businesses">;
   businessName?: string;
   onUpgradeToPro?: () => void;
   onSignOut: () => void;
@@ -37,6 +40,7 @@ type AppSidebarProps = {
   operatorEmail?: string;
   operatorName?: string;
   showUpgradeToPro?: boolean;
+  showSetupGuide?: boolean;
   isLoading?: boolean;
 };
 
@@ -79,12 +83,14 @@ const AnimatedCallsIcon = createAnimatedSidebarIcon(PhoneAnimatedIcon);
 
 export function AppSidebar({
   businessName,
+  businessId,
   onUpgradeToPro,
   onSignOut,
   operatorAvatar,
   operatorEmail,
   operatorName,
   showUpgradeToPro = false,
+  showSetupGuide = false,
   isLoading = false,
   ...props
 }: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
@@ -183,6 +189,9 @@ export function AppSidebar({
         ))}
       </SidebarContent>
       <SidebarFooter>
+        {businessId && showSetupGuide && !isLoading ? (
+          <SetupGuideCard businessId={businessId} />
+        ) : null}
         <NavUser
           isLoading={isLoading}
           onSignOut={onSignOut}

--- a/apps/web/src/components/layout/authenticated-layout.tsx
+++ b/apps/web/src/components/layout/authenticated-layout.tsx
@@ -33,6 +33,7 @@ type AuthenticatedLayoutProps = {
   operatorEmail?: string;
   operatorName?: string;
   showUpgradeToPro?: boolean;
+  showSetupGuide?: boolean;
   isLoading?: boolean;
 };
 
@@ -108,6 +109,7 @@ export function AuthenticatedLayout({
   operatorEmail,
   operatorName,
   showUpgradeToPro = false,
+  showSetupGuide = false,
   isLoading = false,
 }: AuthenticatedLayoutProps) {
   const { t } = useTranslation("settings");
@@ -172,10 +174,12 @@ export function AuthenticatedLayout({
             }
           : {})}
         {...(businessName ? { businessName } : {})}
+        {...(businessId ? { businessId } : {})}
         {...(operatorAvatar ? { operatorAvatar } : {})}
         {...(operatorEmail ? { operatorEmail } : {})}
         {...(operatorName ? { operatorName } : {})}
         showUpgradeToPro={showUpgradeToPro}
+        showSetupGuide={showSetupGuide}
       />
       {businessId && billingStatus ? (
         <UpgradePlanDialog

--- a/apps/web/src/components/setup-guide-card.tsx
+++ b/apps/web/src/components/setup-guide-card.tsx
@@ -1,20 +1,11 @@
 import { useQuery } from "convex/react";
-import { Check, ChevronRight } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 type SetupGuideStepId = "website" | "sources" | "calendar" | "services" | "rules";
@@ -31,27 +22,6 @@ type SetupGuideProgress = {
   allCompleted: boolean;
 };
 
-const stepTargets: Record<SetupGuideStepId, string> = {
-  website: "/agent/knowledge?setup=website",
-  sources: "/agent/knowledge?setup=upload",
-  calendar: "/integrations?setup=calendar",
-  services: "/agent/services?setup=service",
-  rules: "/agent/rules?setup=rule",
-};
-
-const stepOrder: Array<SetupGuideStepId> = [
-  "website",
-  "sources",
-  "calendar",
-  "services",
-  "rules",
-];
-
-function getOrderedSteps(progress: SetupGuideProgress): Array<SetupGuideStepProgress> {
-  const byId = new Map(progress.steps.map((step) => [step.id, step]));
-  return stepOrder.map((id) => byId.get(id) ?? { id, completed: false });
-}
-
 export function SetupGuideCard({
   businessId,
 }: {
@@ -59,109 +29,52 @@ export function SetupGuideCard({
 }) {
   const { t } = useTranslation("nav");
   const navigate = useNavigate();
-  const [open, setOpen] = useState(false);
   const progress = useQuery(api.businesses.setupGuide.getProgress, {
     businessId,
   }) as SetupGuideProgress | undefined;
-  const steps = useMemo(
-    () => (progress ? getOrderedSteps(progress) : []),
-    [progress],
-  );
 
   if (!progress || progress.allCompleted) {
     return null;
   }
 
-  function handleStepClick(stepId: SetupGuideStepId): void {
-    setOpen(false);
-    navigate(stepTargets[stepId]);
-  }
-
   return (
     <div className="px-2 pb-1 group-data-[collapsible=icon]:hidden">
-      <Popover onOpenChange={setOpen} open={open}>
-        <PopoverTrigger
-          render={
-            <Button
-              aria-label={t("sidebar.setupGuide.open")}
-              className="h-auto w-full justify-start rounded-xl bg-foreground px-4 py-3 text-background shadow-sm hover:bg-foreground/90 hover:text-background"
-              type="button"
-              variant="ghost"
-            />
-          }
-        >
-          <span className="flex min-w-0 flex-1 flex-col items-start gap-2 text-left">
-            <span className="flex w-full items-center gap-2">
-              <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                {t("sidebar.setupGuide.title")}
-              </span>
-              <ChevronRight data-icon="inline-end" />
+      <Button
+        aria-label={t("sidebar.setupGuide.open")}
+        className="h-auto w-full justify-start rounded-xl bg-foreground px-4 py-3 text-background shadow-sm hover:!bg-foreground hover:!text-background focus-visible:!bg-foreground focus-visible:!text-background active:!bg-foreground active:!text-background"
+        onClick={() => navigate("/setup-guide")}
+        type="button"
+        variant="ghost"
+      >
+        <span className="flex min-w-0 flex-1 flex-col items-start gap-2 text-left">
+          <span className="flex w-full items-center gap-2">
+            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+              {t("sidebar.setupGuide.title")}
             </span>
-            <span className="text-xs text-background/70">
-              {t("sidebar.setupGuide.progress", {
-                completed: progress.completedSteps,
-                total: progress.totalSteps,
-              })}
-            </span>
-            <span
-              aria-hidden="true"
-              className="grid w-full grid-cols-5 gap-1"
-            >
-              {steps.map((step) => (
-                <span
-                  className={cn(
-                    "h-1 rounded-full bg-background/20",
-                    step.completed && "bg-background",
-                  )}
-                  key={step.id}
-                />
-              ))}
-            </span>
+            <ChevronRight data-icon="inline-end" />
           </span>
-        </PopoverTrigger>
-        <PopoverContent
-          align="start"
-          className="w-80 max-w-[calc(100vw-2rem)] rounded-xl p-3"
-          side="right"
-          sideOffset={12}
-        >
-          <PopoverHeader className="gap-1 px-1">
-            <PopoverTitle>{t("sidebar.setupGuide.title")}</PopoverTitle>
-            <PopoverDescription>
-              {t("sidebar.setupGuide.description", {
-                completed: progress.completedSteps,
-                total: progress.totalSteps,
-              })}
-            </PopoverDescription>
-          </PopoverHeader>
-          <div className="flex flex-col gap-1">
-            {steps.map((step) => (
-              <Button
-                className="h-auto justify-start gap-3 rounded-xl px-3 py-2.5 text-left"
+          <span className="text-xs text-background/70">
+            {t("sidebar.setupGuide.progress", {
+              completed: progress.completedSteps,
+              total: progress.totalSteps,
+            })}
+          </span>
+          <span
+            aria-hidden="true"
+            className="grid w-full grid-cols-5 gap-1"
+          >
+            {progress.steps.map((step) => (
+              <span
+                className={cn(
+                  "h-1 rounded-full bg-background/20",
+                  step.completed && "bg-background",
+                )}
                 key={step.id}
-                onClick={() => handleStepClick(step.id)}
-                type="button"
-                variant="ghost"
-              >
-                <span
-                  className={cn(
-                    "flex size-6 shrink-0 items-center justify-center rounded-full border text-xs",
-                    step.completed
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-border text-muted-foreground",
-                  )}
-                >
-                  {step.completed ? <Check /> : stepOrder.indexOf(step.id) + 1}
-                </span>
-                <span className="min-w-0 flex-1 whitespace-normal">
-                  {t(`sidebar.setupGuide.steps.${step.id}`)}
-                </span>
-                <ChevronRight data-icon="inline-end" />
-              </Button>
+              />
             ))}
-          </div>
-        </PopoverContent>
-      </Popover>
+          </span>
+        </span>
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/components/setup-guide-card.tsx
+++ b/apps/web/src/components/setup-guide-card.tsx
@@ -41,7 +41,7 @@ export function SetupGuideCard({
     <div className="px-2 pb-1 group-data-[collapsible=icon]:hidden">
       <Button
         aria-label={t("sidebar.setupGuide.open")}
-        className="h-auto w-full justify-start rounded-xl bg-foreground px-4 py-3 text-background shadow-sm hover:!bg-foreground hover:!text-background focus-visible:!bg-foreground focus-visible:!text-background active:!bg-foreground active:!text-background"
+        className="h-auto w-full justify-start rounded-xl bg-foreground px-4 py-3 text-background hover:!bg-foreground hover:!text-background focus-visible:!bg-foreground focus-visible:!text-background active:!bg-foreground active:!text-background"
         onClick={() => navigate("/setup-guide")}
         type="button"
         variant="ghost"

--- a/apps/web/src/components/setup-guide-card.tsx
+++ b/apps/web/src/components/setup-guide-card.tsx
@@ -1,0 +1,167 @@
+import { useQuery } from "convex/react";
+import { Check, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+type SetupGuideStepId = "website" | "sources" | "calendar" | "services" | "rules";
+
+type SetupGuideStepProgress = {
+  id: SetupGuideStepId;
+  completed: boolean;
+};
+
+type SetupGuideProgress = {
+  steps: Array<SetupGuideStepProgress>;
+  completedSteps: number;
+  totalSteps: number;
+  allCompleted: boolean;
+};
+
+const stepTargets: Record<SetupGuideStepId, string> = {
+  website: "/agent/knowledge?setup=website",
+  sources: "/agent/knowledge?setup=upload",
+  calendar: "/integrations?setup=calendar",
+  services: "/agent/services?setup=service",
+  rules: "/agent/rules?setup=rule",
+};
+
+const stepOrder: Array<SetupGuideStepId> = [
+  "website",
+  "sources",
+  "calendar",
+  "services",
+  "rules",
+];
+
+function getOrderedSteps(progress: SetupGuideProgress): Array<SetupGuideStepProgress> {
+  const byId = new Map(progress.steps.map((step) => [step.id, step]));
+  return stepOrder.map((id) => byId.get(id) ?? { id, completed: false });
+}
+
+export function SetupGuideCard({
+  businessId,
+}: {
+  businessId: Id<"businesses">;
+}) {
+  const { t } = useTranslation("nav");
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const progress = useQuery(api.businesses.setupGuide.getProgress, {
+    businessId,
+  }) as SetupGuideProgress | undefined;
+  const steps = useMemo(
+    () => (progress ? getOrderedSteps(progress) : []),
+    [progress],
+  );
+
+  if (!progress || progress.allCompleted) {
+    return null;
+  }
+
+  function handleStepClick(stepId: SetupGuideStepId): void {
+    setOpen(false);
+    navigate(stepTargets[stepId]);
+  }
+
+  return (
+    <div className="px-2 pb-1 group-data-[collapsible=icon]:hidden">
+      <Popover onOpenChange={setOpen} open={open}>
+        <PopoverTrigger
+          render={
+            <Button
+              aria-label={t("sidebar.setupGuide.open")}
+              className="h-auto w-full justify-start rounded-xl bg-foreground px-4 py-3 text-background shadow-sm hover:bg-foreground/90 hover:text-background"
+              type="button"
+              variant="ghost"
+            />
+          }
+        >
+          <span className="flex min-w-0 flex-1 flex-col items-start gap-2 text-left">
+            <span className="flex w-full items-center gap-2">
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                {t("sidebar.setupGuide.title")}
+              </span>
+              <ChevronRight data-icon="inline-end" />
+            </span>
+            <span className="text-xs text-background/70">
+              {t("sidebar.setupGuide.progress", {
+                completed: progress.completedSteps,
+                total: progress.totalSteps,
+              })}
+            </span>
+            <span
+              aria-hidden="true"
+              className="grid w-full grid-cols-5 gap-1"
+            >
+              {steps.map((step) => (
+                <span
+                  className={cn(
+                    "h-1 rounded-full bg-background/20",
+                    step.completed && "bg-background",
+                  )}
+                  key={step.id}
+                />
+              ))}
+            </span>
+          </span>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-80 max-w-[calc(100vw-2rem)] rounded-xl p-3"
+          side="right"
+          sideOffset={12}
+        >
+          <PopoverHeader className="gap-1 px-1">
+            <PopoverTitle>{t("sidebar.setupGuide.title")}</PopoverTitle>
+            <PopoverDescription>
+              {t("sidebar.setupGuide.description", {
+                completed: progress.completedSteps,
+                total: progress.totalSteps,
+              })}
+            </PopoverDescription>
+          </PopoverHeader>
+          <div className="flex flex-col gap-1">
+            {steps.map((step) => (
+              <Button
+                className="h-auto justify-start gap-3 rounded-xl px-3 py-2.5 text-left"
+                key={step.id}
+                onClick={() => handleStepClick(step.id)}
+                type="button"
+                variant="ghost"
+              >
+                <span
+                  className={cn(
+                    "flex size-6 shrink-0 items-center justify-center rounded-full border text-xs",
+                    step.completed
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {step.completed ? <Check /> : stepOrder.indexOf(step.id) + 1}
+                </span>
+                <span className="min-w-0 flex-1 whitespace-normal">
+                  {t(`sidebar.setupGuide.steps.${step.id}`)}
+                </span>
+                <ChevronRight data-icon="inline-end" />
+              </Button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/accordion.tsx
+++ b/apps/web/src/components/ui/accordion.tsx
@@ -1,0 +1,67 @@
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Accordion({ className, ...props }: AccordionPrimitive.Root.Props) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("flex w-full flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b border-border last:border-b-0", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: AccordionPrimitive.Trigger.Props) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group/accordion-trigger flex flex-1 cursor-pointer items-center justify-between gap-4 px-5 py-4 text-left text-sm font-medium outline-none transition-colors focus-visible:bg-muted/40 aria-disabled:pointer-events-none aria-disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDown
+          data-icon="inline-end"
+          className="shrink-0 text-muted-foreground transition-transform group-aria-expanded/accordion-trigger:rotate-180"
+        />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: AccordionPrimitive.Panel.Props) {
+  return (
+    <AccordionPrimitive.Panel
+      data-slot="accordion-content"
+      className="AccordionContent overflow-hidden"
+      {...props}
+    >
+      <div className={cn("px-5 pb-5", className)}>{children}</div>
+    </AccordionPrimitive.Panel>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/apps/web/src/features/agent/AgentLayout.test.tsx
+++ b/apps/web/src/features/agent/AgentLayout.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useOutletContext,
+} from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentLayout } from "./AgentLayout";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("./AddKnowledgeSheet", () => ({
+  AddKnowledgeSheet: ({ open }: { open?: boolean }) =>
+    open ? <div>rule-dialog-open</div> : null,
+}));
+
+vi.mock("./KnowledgeActionsMenu", () => ({
+  KnowledgeActionsMenu: () => <div>knowledge-actions</div>,
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function RulesOutlet() {
+  const context = useOutletContext<{ headerActions?: React.ReactNode }>();
+
+  return (
+    <div>
+      <div>Rules page</div>
+      {context.headerActions}
+    </div>
+  );
+}
+
+describe("AgentLayout setup links", () => {
+  it("opens the Add Rule dialog from the setup param and consumes it", async () => {
+    render(
+      <MemoryRouter initialEntries={["/agent/rules?setup=rule"]}>
+        <Routes>
+          <Route
+            element={
+              <>
+                <AgentLayout
+                  businessId={"business-1" as any}
+                  canManageTenant
+                />
+                <LocationProbe />
+              </>
+            }
+            path="/agent/*"
+          >
+            <Route element={<RulesOutlet />} path="rules" />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("rule-dialog-open")).toBeTruthy();
+    expect(screen.getByTestId("location").textContent).toBe("/agent/rules");
+  });
+});

--- a/apps/web/src/features/agent/AgentLayout.tsx
+++ b/apps/web/src/features/agent/AgentLayout.tsx
@@ -1,4 +1,6 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Outlet, useLocation, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 
@@ -7,6 +9,7 @@ import { AddKnowledgeSheet } from "./AddKnowledgeSheet";
 import { KnowledgeActionsMenu } from "./KnowledgeActionsMenu";
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import { getAgentSectionFromPathname } from "./sections";
+import { Button } from "@/components/ui/button";
 
 type AgentLayoutProps = {
   businessId?: Id<"businesses">;
@@ -20,6 +23,8 @@ type AgentLayoutOutletContext = {
 export function AgentLayout({ businessId, canManageTenant }: AgentLayoutProps) {
   const { t } = useTranslation("agent");
   const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [isRuleDialogOpen, setIsRuleDialogOpen] = useState(false);
   const section = getAgentSectionFromPathname(location.pathname);
   const isBasicSettingsRoute =
     location.pathname === "/agent/basic-settings" || location.pathname === "/agent";
@@ -56,14 +61,36 @@ export function AgentLayout({ businessId, canManageTenant }: AgentLayoutProps) {
     };
   }
 
+  useEffect(() => {
+    if (section !== "rules" || searchParams.get("setup") !== "rule") {
+      return;
+    }
+
+    setIsRuleDialogOpen(true);
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.delete("setup");
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [searchParams, section, setSearchParams]);
+
   const headerActions =
     canManageTenant && !isBasicSettingsRoute && isKnowledgeRoute ? (
       <>
         {section === "knowledge" ? (
           <KnowledgeActionsMenu businessId={businessId} />
         ) : null}
-        {section !== "knowledge" ? (
-          <AddKnowledgeSheet businessId={businessId} section={section} />
+        {section === "rules" ? (
+          <>
+            <Button onClick={() => setIsRuleDialogOpen(true)} type="button">
+              <Plus data-icon="inline-start" />
+              {t("sections.rules.addKnowledge")}
+            </Button>
+            <AddKnowledgeSheet
+              businessId={businessId}
+              onOpenChange={setIsRuleDialogOpen}
+              open={isRuleDialogOpen}
+              section="rules"
+            />
+          </>
         ) : null}
       </>
     ) : undefined;

--- a/apps/web/src/features/agent/AgentServicesPage.test.tsx
+++ b/apps/web/src/features/agent/AgentServicesPage.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentServicesPage } from "./AgentServicesPage";
+
+vi.mock("convex/react", () => ({
+  useQuery: () => ({
+    services: [],
+  }),
+}));
+
+vi.mock("@/lib/observed-convex", () => ({
+  useObservedAction: () => vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    i18n: {
+      language: "en",
+      resolvedLanguage: "en",
+    },
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react");
+  const DialogContext = ReactModule.createContext({ open: false });
+
+  function Dialog({
+    children,
+    open = false,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+  }) {
+    return (
+      <DialogContext.Provider value={{ open }}>
+        {children}
+      </DialogContext.Provider>
+    );
+  }
+
+  function DialogContent({ children }: { children: React.ReactNode }) {
+    const { open } = ReactModule.useContext(DialogContext);
+
+    return open ? <div>{children}</div> : null;
+  }
+
+  return {
+    Dialog,
+    DialogContent,
+    DialogDescription: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTrigger: ({ render }: { render?: React.ReactNode }) => <>{render}</>,
+  };
+});
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+describe("AgentServicesPage setup links", () => {
+  it("opens the Add Service dialog from the setup param and consumes it", async () => {
+    render(
+      <MemoryRouter initialEntries={["/agent/services?setup=service"]}>
+        <AgentServicesPage
+          businessId={"business-1" as any}
+          canManageTenant
+        />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("sections.services.addKnowledgeDescription")).toBeTruthy();
+    expect(screen.getByTestId("location").textContent).toBe("/agent/services");
+  });
+});

--- a/apps/web/src/features/agent/AgentServicesPage.tsx
+++ b/apps/web/src/features/agent/AgentServicesPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "convex/react";
 import { Fragment, useEffect, useId, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
 import {
   flexRender,
   getCoreRowModel,
@@ -358,12 +359,14 @@ export function AgentServicesPage({
     businessId,
   });
   const upsertService = useObservedAction(api.businesses.catalog.upsertService);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [searchValue, setSearchValue] = useState("");
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 10,
   });
   const [editingService, setEditingService] = useState<ServiceRow | null>(null);
+  const [isCreateServiceOpen, setIsCreateServiceOpen] = useState(false);
   const [togglingServiceId, setTogglingServiceId] = useState<string | null>(null);
   const services = useMemo(
     () => [...(configuration?.services ?? [])].sort((left, right) => right._creationTime - left._creationTime),
@@ -526,6 +529,17 @@ export function AgentServicesPage({
     }
   }, [editingService, services]);
 
+  useEffect(() => {
+    if (searchParams.get("setup") !== "service") {
+      return;
+    }
+
+    setIsCreateServiceOpen(true);
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.delete("setup");
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [searchParams, setSearchParams]);
+
   const emptyMessage =
     searchValue.trim().length > 0 ? t("table.empty") : t("sections.services.emptyState");
 
@@ -543,7 +557,16 @@ export function AgentServicesPage({
         </div>
         {canManageTenant ? (
           <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <ServiceDialog businessId={businessId} mode="create" />
+            <Button onClick={() => setIsCreateServiceOpen(true)} type="button">
+              <Plus data-icon="inline-start" />
+              {t("sections.services.addKnowledge")}
+            </Button>
+            <ServiceDialog
+              businessId={businessId}
+              mode="create"
+              onOpenChange={setIsCreateServiceOpen}
+              open={isCreateServiceOpen}
+            />
           </div>
         ) : null}
       </div>

--- a/apps/web/src/features/agent/KnowledgeActionsMenu.test.tsx
+++ b/apps/web/src/features/agent/KnowledgeActionsMenu.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import { KnowledgeActionsMenu } from "./KnowledgeActionsMenu";
@@ -97,7 +98,11 @@ vi.mock("./AddKnowledgeSheet", () => ({
 
 describe("KnowledgeActionsMenu", () => {
   it("opens upload, website, and text flows from the add knowledge dropdown", async () => {
-    render(<KnowledgeActionsMenu businessId={"business-1" as never} />);
+    render(
+      <MemoryRouter>
+        <KnowledgeActionsMenu businessId={"business-1" as never} />
+      </MemoryRouter>,
+    );
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "sections.knowledge.addKnowledge" }));
@@ -138,5 +143,35 @@ describe("KnowledgeActionsMenu", () => {
       }),
     );
     expect(screen.getByText("text-sheet-open")).toBeTruthy();
+  });
+
+  it("opens setup-targeted knowledge dialogs and removes the setup param", async () => {
+    function LocationProbe() {
+      const location = useLocation();
+
+      return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+    }
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/agent/knowledge?setup=upload"]}>
+        <KnowledgeActionsMenu businessId={"business-1" as never} />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("upload-sheet-open")).toBeTruthy();
+    expect(screen.getByTestId("location").textContent).toBe("/agent/knowledge");
+
+    unmount();
+
+    render(
+      <MemoryRouter initialEntries={["/agent/knowledge?setup=website"]}>
+        <KnowledgeActionsMenu businessId={"business-1" as never} />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("website-sheet-open")).toBeTruthy();
+    expect(screen.getByTestId("location").textContent).toBe("/agent/knowledge");
   });
 });

--- a/apps/web/src/features/agent/KnowledgeActionsMenu.tsx
+++ b/apps/web/src/features/agent/KnowledgeActionsMenu.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChevronDown, FileText, Globe, Plus, Upload } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
 
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
@@ -21,9 +22,27 @@ export function KnowledgeActionsMenu({
   businessId: Id<"businesses">;
 }) {
   const { t } = useTranslation("agent");
+  const [searchParams, setSearchParams] = useSearchParams();
   const [isUploadOpen, setIsUploadOpen] = useState(false);
   const [isWebsiteOpen, setIsWebsiteOpen] = useState(false);
   const [isTextOpen, setIsTextOpen] = useState(false);
+
+  useEffect(() => {
+    const setupTarget = searchParams.get("setup");
+    if (setupTarget !== "upload" && setupTarget !== "website") {
+      return;
+    }
+
+    if (setupTarget === "upload") {
+      setIsUploadOpen(true);
+    } else {
+      setIsWebsiteOpen(true);
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.delete("setup");
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   return (
     <>

--- a/apps/web/src/features/settings/IntegrationsPage.test.tsx
+++ b/apps/web/src/features/settings/IntegrationsPage.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { IntegrationsPage } from "./IntegrationsPage";
+
+vi.mock("convex/react", () => ({
+  useQuery: () => [],
+}));
+
+vi.mock("@/lib/observed-convex", () => ({
+  useObservedAction: () => vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  captureAnalyticsEvent: vi.fn(),
+  captureAnalyticsException: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    i18n: {
+      language: "en",
+      resolvedLanguage: "en",
+    },
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react");
+  const DialogContext = ReactModule.createContext({ open: false });
+
+  function Dialog({
+    children,
+    open = false,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+  }) {
+    return (
+      <DialogContext.Provider value={{ open }}>
+        {children}
+      </DialogContext.Provider>
+    );
+  }
+
+  function DialogContent({ children }: { children: React.ReactNode }) {
+    const { open } = ReactModule.useContext(DialogContext);
+
+    return open ? <div>{children}</div> : null;
+  }
+
+  return {
+    Dialog,
+    DialogContent,
+    DialogDescription: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+describe("IntegrationsPage setup links", () => {
+  it("opens the calendar dialog from the setup param and consumes it", async () => {
+    render(
+      <MemoryRouter initialEntries={["/integrations?setup=calendar"]}>
+        <IntegrationsPage businessId={"business-1" as any} />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("integrations.google.sheetDescription")).toBeTruthy();
+    expect(screen.getByTestId("location").textContent).toBe("/integrations");
+  });
+});

--- a/apps/web/src/features/settings/IntegrationsPage.tsx
+++ b/apps/web/src/features/settings/IntegrationsPage.tsx
@@ -258,6 +258,19 @@ export function IntegrationsPage({ businessId }: IntegrationsPageProps) {
   const [isLoadingCalendars, setIsLoadingCalendars] = useState(false);
   const [isSavingCalendar, setIsSavingCalendar] = useState(false);
   const [googleSheetOpen, setGoogleSheetOpen] = useState(false);
+
+  useEffect(() => {
+    if (searchParams.get("setup") !== "calendar") {
+      return;
+    }
+
+    setSelectedCalendarId(selectedConnectionCalendarId);
+    setGoogleSheetOpen(true);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("setup");
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, selectedConnectionCalendarId, setSearchParams]);
+
   useEffect(() => {
     const calendar = searchParams.get("calendar");
     const status = searchParams.get("status");

--- a/apps/web/src/features/setup/SetupGuidePage.test.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.test.tsx
@@ -162,9 +162,12 @@ describe("SetupGuidePage", () => {
 
     renderPage();
 
+    const completedStep = screen.getByRole("button", { name: /Add your website/i });
+    expect(completedStep.getAttribute("aria-disabled")).toBe("true");
+    expect(completedStep.className).toContain("cursor-default");
     expect(screen.getByText("Upload a document.")).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: /Add your website/i }));
+    await user.click(completedStep);
 
     expect(screen.queryByText("Import your public website.")).toBeNull();
     expect(screen.getByText("Upload a document.")).toBeTruthy();

--- a/apps/web/src/features/setup/SetupGuidePage.test.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.test.tsx
@@ -18,9 +18,16 @@ const setupGuideQueryState = vi.hoisted(() => ({
       }
     | undefined,
 }));
+const setupGuideMutationState = vi.hoisted(() => ({
+  skipStep: vi.fn(),
+}));
 
 vi.mock("convex/react", () => ({
   useQuery: () => setupGuideQueryState.progress,
+}));
+
+vi.mock("@/lib/observed-convex", () => ({
+  useObservedMutation: () => setupGuideMutationState.skipStep,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -29,6 +36,8 @@ vi.mock("react-i18next", () => ({
       const translations: Record<string, string> = {
         "sidebar.setupGuide.title": "Getting started",
         "sidebar.setupGuide.description": `${options?.completed ?? 0} of ${options?.total ?? 5} setup steps complete.`,
+        "sidebar.setupGuide.skip": "Skip tutorial",
+        "sidebar.setupGuide.skipStep": "Skip",
         "sidebar.setupGuide.steps.website": "Add your website",
         "sidebar.setupGuide.steps.sources": "Add more sources",
         "sidebar.setupGuide.steps.calendar": "Connect your calendar",
@@ -97,6 +106,8 @@ function renderPage() {
 describe("SetupGuidePage", () => {
   beforeEach(() => {
     setupGuideQueryState.progress = undefined;
+    setupGuideMutationState.skipStep.mockReset();
+    setupGuideMutationState.skipStep.mockResolvedValue({ stepId: "sources" });
   });
 
   it("renders the full setup checklist layout with the active incomplete step expanded", () => {
@@ -105,6 +116,7 @@ describe("SetupGuidePage", () => {
     renderPage();
 
     expect(screen.getByRole("heading", { name: "Getting started" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Skip tutorial" })).toBeTruthy();
     expect(screen.getByText("2 of 5 setup steps complete.")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Add your website/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Add more sources/i })).toBeTruthy();
@@ -113,6 +125,35 @@ describe("SetupGuidePage", () => {
     expect(screen.getByRole("button", { name: /Define Rules/i })).toBeTruthy();
     expect(screen.getByText("Upload a document.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Upload document" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Skip" })).toBeTruthy();
+  });
+
+  it("leaves the setup guide when the tutorial is skipped", async () => {
+    const user = userEvent.setup();
+    setupProgress(["website", "services"]);
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Skip tutorial" }));
+
+    expect(screen.getByTestId("location").textContent).toBe("/");
+  });
+
+  it("marks an individual step skipped and advances to the next accordion item", async () => {
+    const user = userEvent.setup();
+    setupProgress(["website", "services"]);
+
+    renderPage();
+
+    expect(screen.getByText("Upload a document.")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(setupGuideMutationState.skipStep).toHaveBeenCalledWith({
+      businessId: "business-1",
+      stepId: "sources",
+    });
+    expect(screen.getByText("Connect a calendar.")).toBeTruthy();
   });
 
   it.each([

--- a/apps/web/src/features/setup/SetupGuidePage.test.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.test.tsx
@@ -156,6 +156,20 @@ describe("SetupGuidePage", () => {
     expect(screen.getByText("Connect a calendar.")).toBeTruthy();
   });
 
+  it("keeps completed setup steps closed when clicked", async () => {
+    const user = userEvent.setup();
+    setupProgress(["website", "services"]);
+
+    renderPage();
+
+    expect(screen.getByText("Upload a document.")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /Add your website/i }));
+
+    expect(screen.queryByText("Import your public website.")).toBeNull();
+    expect(screen.getByText("Upload a document.")).toBeTruthy();
+  });
+
   it.each([
     ["website", "Add website", "/agent/knowledge?setup=website"],
     ["sources", "Upload document", "/agent/knowledge?setup=upload"],

--- a/apps/web/src/features/setup/SetupGuidePage.test.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SetupGuidePage } from "./SetupGuidePage";
+
+const setupGuideQueryState = vi.hoisted(() => ({
+  progress: undefined as
+    | {
+        steps: Array<{
+          id: "website" | "sources" | "calendar" | "services" | "rules";
+          completed: boolean;
+        }>;
+        completedSteps: number;
+        totalSteps: number;
+        allCompleted: boolean;
+      }
+    | undefined,
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: () => setupGuideQueryState.progress,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, number>) => {
+      const translations: Record<string, string> = {
+        "sidebar.setupGuide.title": "Getting started",
+        "sidebar.setupGuide.description": `${options?.completed ?? 0} of ${options?.total ?? 5} setup steps complete.`,
+        "sidebar.setupGuide.steps.website": "Add your website",
+        "sidebar.setupGuide.steps.sources": "Add more sources",
+        "sidebar.setupGuide.steps.calendar": "Connect your calendar",
+        "sidebar.setupGuide.steps.services": "Add your Services",
+        "sidebar.setupGuide.steps.rules": "Define Rules",
+        "sidebar.setupGuide.stepDescriptions.website": "Import your public website.",
+        "sidebar.setupGuide.stepDescriptions.sources": "Upload a document.",
+        "sidebar.setupGuide.stepDescriptions.calendar": "Connect a calendar.",
+        "sidebar.setupGuide.stepDescriptions.services": "Add services.",
+        "sidebar.setupGuide.stepDescriptions.rules": "Define instructions.",
+        "sidebar.setupGuide.stepActions.website": "Add website",
+        "sidebar.setupGuide.stepActions.sources": "Upload document",
+        "sidebar.setupGuide.stepActions.calendar": "Connect calendar",
+        "sidebar.setupGuide.stepActions.services": "Add service",
+        "sidebar.setupGuide.stepActions.rules": "Add rule",
+      };
+
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+type StepId = "website" | "sources" | "calendar" | "services" | "rules";
+
+const stepIds: Array<StepId> = [
+  "website",
+  "sources",
+  "calendar",
+  "services",
+  "rules",
+];
+
+function setupProgress(completedIds: Array<StepId>) {
+  const steps = stepIds.map((id) => ({
+    id,
+    completed: completedIds.includes(id),
+  }));
+  setupGuideQueryState.progress = {
+    steps,
+    completedSteps: completedIds.length,
+    totalSteps: steps.length,
+    allCompleted: completedIds.length === steps.length,
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/setup-guide"]}>
+      <Routes>
+        <Route
+          element={<SetupGuidePage businessId={"business-1" as any} />}
+          path="/setup-guide"
+        />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+describe("SetupGuidePage", () => {
+  beforeEach(() => {
+    setupGuideQueryState.progress = undefined;
+  });
+
+  it("renders the full setup checklist layout with the active incomplete step expanded", () => {
+    setupProgress(["website", "services"]);
+
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "Getting started" })).toBeTruthy();
+    expect(screen.getByText("2 of 5 setup steps complete.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Add your website/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Add more sources/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Connect your calendar/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Add your Services/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Define Rules/i })).toBeTruthy();
+    expect(screen.getByText("Upload a document.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Upload document" })).toBeTruthy();
+  });
+
+  it.each([
+    ["website", "Add website", "/agent/knowledge?setup=website"],
+    ["sources", "Upload document", "/agent/knowledge?setup=upload"],
+    ["calendar", "Connect calendar", "/integrations?setup=calendar"],
+    ["services", "Add service", "/agent/services?setup=service"],
+    ["rules", "Add rule", "/agent/rules?setup=rule"],
+  ] as const)("navigates the %s action to its setup target", async (step, action, target) => {
+    const user = userEvent.setup();
+    const completedIds = stepIds.slice(0, stepIds.indexOf(step));
+    setupProgress(completedIds);
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: action }));
+
+    expect(screen.getByTestId("location").textContent).toBe(target);
+  });
+
+  it("redirects away once every setup step is complete", () => {
+    setupProgress(["website", "sources", "calendar", "services", "rules"]);
+
+    renderPage();
+
+    expect(screen.getByTestId("location").textContent).toBe("/");
+  });
+});

--- a/apps/web/src/features/setup/SetupGuidePage.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.tsx
@@ -103,10 +103,8 @@ function ProgressRing({
 
 function StepMarker({
   completed,
-  index,
 }: {
   completed: boolean;
-  index: number;
 }) {
   if (completed) {
     return (
@@ -118,12 +116,12 @@ function StepMarker({
 
   const radius = 10.5;
   const circumference = 2 * Math.PI * radius;
-  const segmentLength = circumference / 8;
+  const segmentLength = circumference / 6;
   const dashLength = segmentLength * 0.62;
   const gapLength = segmentLength - dashLength;
 
   return (
-    <span className="relative flex size-6 shrink-0 items-center justify-center bg-background text-sm text-foreground">
+    <span className="relative flex size-6 shrink-0 items-center justify-center bg-background">
       <svg aria-hidden="true" className="absolute inset-0 size-6" viewBox="0 0 24 24">
         <circle
           className="stroke-foreground"
@@ -136,7 +134,6 @@ function StepMarker({
           strokeWidth="1.5"
         />
       </svg>
-      <span className="relative">{index + 1}</span>
     </span>
   );
 }
@@ -238,11 +235,11 @@ export function SetupGuidePage({
             }}
             value={[openStepId]}
           >
-            {steps.map((step, index) => (
+            {steps.map((step) => (
               <AccordionItem key={step.id} value={step.id}>
                 <AccordionTrigger className="min-h-16 px-6">
                   <span className="flex min-w-0 items-center gap-4">
-                    <StepMarker completed={step.completed} index={index} />
+                    <StepMarker completed={step.completed} />
                     <span
                       className={
                         step.completed

--- a/apps/web/src/features/setup/SetupGuidePage.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.tsx
@@ -239,7 +239,15 @@ export function SetupGuidePage({
           >
             {steps.map((step) => (
               <AccordionItem key={step.id} value={step.id}>
-                <AccordionTrigger className="min-h-16 px-6">
+                <AccordionTrigger
+                  aria-disabled={step.completed || undefined}
+                  className={
+                    step.completed
+                      ? "min-h-16 cursor-default px-6 [&_[data-icon=inline-end]]:opacity-0"
+                      : "min-h-16 px-6"
+                  }
+                  tabIndex={step.completed ? -1 : undefined}
+                >
                   <span className="flex min-w-0 items-center gap-4">
                     <StepMarker completed={step.completed} />
                     <span

--- a/apps/web/src/features/setup/SetupGuidePage.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.tsx
@@ -1,0 +1,195 @@
+import { useQuery } from "convex/react";
+import { Check, ChevronDown, ChevronRight, Circle } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Navigate, useNavigate } from "react-router-dom";
+
+import { api } from "../../../../../convex/_generated/api";
+import type { Id } from "../../../../../convex/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+type SetupGuideStepId = "website" | "sources" | "calendar" | "services" | "rules";
+
+type SetupGuideStepProgress = {
+  id: SetupGuideStepId;
+  completed: boolean;
+};
+
+type SetupGuideProgress = {
+  steps: Array<SetupGuideStepProgress>;
+  completedSteps: number;
+  totalSteps: number;
+  allCompleted: boolean;
+};
+
+const stepOrder: Array<SetupGuideStepId> = [
+  "website",
+  "sources",
+  "calendar",
+  "services",
+  "rules",
+];
+
+const stepTargets: Record<SetupGuideStepId, string> = {
+  website: "/agent/knowledge?setup=website",
+  sources: "/agent/knowledge?setup=upload",
+  calendar: "/integrations?setup=calendar",
+  services: "/agent/services?setup=service",
+  rules: "/agent/rules?setup=rule",
+};
+
+function getOrderedSteps(progress: SetupGuideProgress): Array<SetupGuideStepProgress> {
+  const byId = new Map(progress.steps.map((step) => [step.id, step]));
+  return stepOrder.map((id) => byId.get(id) ?? { id, completed: false });
+}
+
+function StepMarker({
+  completed,
+  index,
+}: {
+  completed: boolean;
+  index: number;
+}) {
+  if (completed) {
+    return (
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-background">
+        <Check />
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border bg-background text-sm text-muted-foreground">
+      {index + 1}
+    </span>
+  );
+}
+
+export function SetupGuidePage({
+  businessId,
+}: {
+  businessId: Id<"businesses">;
+}) {
+  const { t } = useTranslation("nav");
+  const navigate = useNavigate();
+  const progress = useQuery(api.businesses.setupGuide.getProgress, {
+    businessId,
+  }) as SetupGuideProgress | undefined;
+  const steps = useMemo(
+    () => (progress ? getOrderedSteps(progress) : []),
+    [progress],
+  );
+  const activeStepId =
+    steps.find((step) => !step.completed)?.id ?? steps[0]?.id ?? "website";
+
+  if (progress?.allCompleted) {
+    return <Navigate replace to="/" />;
+  }
+
+  if (!progress) {
+    return (
+      <section className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-10">
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-9 w-64" />
+          <Skeleton className="h-6 w-72" />
+        </div>
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,36rem)_1fr]">
+          <div className="flex flex-col gap-3 rounded-xl bg-muted/20 p-3">
+            {stepOrder.map((stepId) => (
+              <Skeleton className="h-20 rounded-xl" key={stepId} />
+            ))}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-10">
+      <div className="flex flex-col gap-3">
+        <h1 className="type-page-title">{t("sidebar.setupGuide.title")}</h1>
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <Circle className="size-4" />
+          <p className="text-base">
+            {t("sidebar.setupGuide.description", {
+              completed: progress.completedSteps,
+              total: progress.totalSteps,
+            })}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,38rem)_1fr]">
+        <div className="flex flex-col gap-3 rounded-xl bg-muted/20 p-3">
+          {steps.map((step, index) => {
+            const isActive = step.id === activeStepId;
+
+            return (
+              <Card
+                className={cn(
+                  "gap-0 overflow-hidden py-0",
+                  isActive ? "bg-background" : "bg-background/80",
+                )}
+                key={step.id}
+                size="sm"
+              >
+                <button
+                  className="flex w-full items-center gap-4 px-5 py-5 text-left outline-none transition-colors hover:bg-muted/30 focus-visible:bg-muted/30"
+                  onClick={() => {
+                    if (!isActive || step.completed) {
+                      navigate(stepTargets[step.id]);
+                    }
+                  }}
+                  type="button"
+                >
+                  <StepMarker completed={step.completed} index={index} />
+                  <span className="min-w-0 flex-1 truncate text-base font-medium">
+                    {t(`sidebar.setupGuide.steps.${step.id}`)}
+                  </span>
+                  {isActive && !step.completed ? (
+                    <ChevronDown className="text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="text-muted-foreground" />
+                  )}
+                </button>
+                {isActive && !step.completed ? (
+                  <>
+                    <CardHeader className="px-5 pb-0 pt-0">
+                      <CardTitle className="sr-only">
+                        {t(`sidebar.setupGuide.steps.${step.id}`)}
+                      </CardTitle>
+                      <div className="flex gap-4">
+                        <span aria-hidden="true" className="size-9 shrink-0" />
+                        <CardDescription className="text-base leading-6">
+                          {t(`sidebar.setupGuide.stepDescriptions.${step.id}`)}
+                        </CardDescription>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="px-5 pb-5 pt-5">
+                      <div className="flex gap-4">
+                        <span aria-hidden="true" className="size-9 shrink-0" />
+                        <Button onClick={() => navigate(stepTargets[step.id])} type="button">
+                          {t(`sidebar.setupGuide.stepActions.${step.id}`)}
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </>
+                ) : null}
+              </Card>
+            );
+          })}
+        </div>
+        <div className="hidden lg:block" aria-hidden="true" />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/setup/SetupGuidePage.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.tsx
@@ -229,8 +229,10 @@ export function SetupGuidePage({
           <Accordion
             onValueChange={(value) => {
               const nextValue = value[0];
-              if (stepOrder.includes(nextValue as SetupGuideStepId)) {
-                setOpenStepId(nextValue as SetupGuideStepId);
+              const nextStep = steps.find((step) => step.id === nextValue);
+
+              if (nextStep && !nextStep.completed) {
+                setOpenStepId(nextStep.id);
               }
             }}
             value={[openStepId]}

--- a/apps/web/src/features/setup/SetupGuidePage.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.tsx
@@ -1,21 +1,22 @@
 import { useQuery } from "convex/react";
-import { Check, ChevronDown, ChevronRight, Circle } from "lucide-react";
-import { useMemo } from "react";
+import { Check } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useNavigate } from "react-router-dom";
 
 import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
-import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/page-header";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { cn } from "@/lib/utils";
+import { Surface } from "@/components/ui/surface";
+import { useObservedMutation } from "@/lib/observed-convex";
 
 type SetupGuideStepId = "website" | "sources" | "calendar" | "services" | "rules";
 
@@ -47,9 +48,57 @@ const stepTargets: Record<SetupGuideStepId, string> = {
   rules: "/agent/rules?setup=rule",
 };
 
+function getNextStepId(stepId: SetupGuideStepId): SetupGuideStepId | null {
+  const index = stepOrder.indexOf(stepId);
+  const nextStep = stepOrder[index + 1];
+
+  return nextStep ?? null;
+}
+
 function getOrderedSteps(progress: SetupGuideProgress): Array<SetupGuideStepProgress> {
   const byId = new Map(progress.steps.map((step) => [step.id, step]));
   return stepOrder.map((id) => byId.get(id) ?? { id, completed: false });
+}
+
+function ProgressRing({
+  completed,
+  total,
+}: {
+  completed: number;
+  total: number;
+}) {
+  const radius = 7;
+  const circumference = 2 * Math.PI * radius;
+  const progress = total > 0 ? Math.min(completed / total, 1) : 0;
+  const offset = circumference * (1 - progress);
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-5 shrink-0 -rotate-90"
+      viewBox="0 0 20 20"
+    >
+      <circle
+        className="stroke-border"
+        cx="10"
+        cy="10"
+        fill="none"
+        r={radius}
+        strokeWidth="1.75"
+      />
+      <circle
+        className="stroke-foreground transition-[stroke-dashoffset] duration-300 ease-out"
+        cx="10"
+        cy="10"
+        fill="none"
+        r={radius}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        strokeWidth="1.75"
+      />
+    </svg>
+  );
 }
 
 function StepMarker({
@@ -61,14 +110,14 @@ function StepMarker({
 }) {
   if (completed) {
     return (
-      <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-background">
-        <Check />
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted-foreground/70 text-background">
+        <Check className="size-4" />
       </span>
     );
   }
 
   return (
-    <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border bg-background text-sm text-muted-foreground">
+    <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-foreground bg-background text-sm text-foreground">
       {index + 1}
     </span>
   );
@@ -84,12 +133,37 @@ export function SetupGuidePage({
   const progress = useQuery(api.businesses.setupGuide.getProgress, {
     businessId,
   }) as SetupGuideProgress | undefined;
+  const skipStep = useObservedMutation(api.businesses.setupGuide.skipStep);
   const steps = useMemo(
     () => (progress ? getOrderedSteps(progress) : []),
     [progress],
   );
   const activeStepId =
     steps.find((step) => !step.completed)?.id ?? steps[0]?.id ?? "website";
+  const [openStepId, setOpenStepId] = useState<SetupGuideStepId>(activeStepId);
+  const [skippingStepId, setSkippingStepId] = useState<SetupGuideStepId | null>(null);
+
+  useEffect(() => {
+    setOpenStepId(activeStepId);
+  }, [activeStepId]);
+
+  async function handleSkipStep(stepId: SetupGuideStepId) {
+    setSkippingStepId(stepId);
+
+    try {
+      await skipStep({ businessId, stepId });
+
+      const nextStepId = getNextStepId(stepId);
+      if (nextStepId) {
+        setOpenStepId(nextStepId);
+        return;
+      }
+
+      navigate("/");
+    } finally {
+      setSkippingStepId(null);
+    }
+  }
 
   if (progress?.allCompleted) {
     return <Navigate replace to="/" />;
@@ -97,98 +171,102 @@ export function SetupGuidePage({
 
   if (!progress) {
     return (
-      <section className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-10">
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-9 w-64" />
-          <Skeleton className="h-6 w-72" />
-        </div>
-        <div className="grid gap-8 lg:grid-cols-[minmax(0,36rem)_1fr]">
-          <div className="flex flex-col gap-3 rounded-xl bg-muted/20 p-3">
-            {stepOrder.map((stepId) => (
-              <Skeleton className="h-20 rounded-xl" key={stepId} />
-            ))}
+      <section className="flex flex-1 flex-col gap-6">
+        <PageHeader title={t("sidebar.setupGuide.title")} />
+        <div className="flex w-full flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Skeleton className="h-6 w-72" />
+            <Button onClick={() => navigate("/")} type="button" variant="outline">
+              {t("sidebar.setupGuide.skip")}
+            </Button>
           </div>
+          <Surface className="p-3">
+            {stepOrder.map((stepId) => (
+              <Skeleton className="mb-2 h-16 rounded-xl last:mb-0" key={stepId} />
+            ))}
+          </Surface>
         </div>
       </section>
     );
   }
 
   return (
-    <section className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-10">
-      <div className="flex flex-col gap-3">
-        <h1 className="type-page-title">{t("sidebar.setupGuide.title")}</h1>
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <Circle className="size-4" />
-          <p className="text-base">
-            {t("sidebar.setupGuide.description", {
-              completed: progress.completedSteps,
-              total: progress.totalSteps,
-            })}
-          </p>
+    <section className="flex flex-1 flex-col gap-6">
+      <PageHeader title={t("sidebar.setupGuide.title")} />
+
+      <div className="flex w-full flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3 text-muted-foreground">
+            <ProgressRing completed={progress.completedSteps} total={progress.totalSteps} />
+            <p className="text-base">
+              {t("sidebar.setupGuide.description", {
+                completed: progress.completedSteps,
+                total: progress.totalSteps,
+              })}
+            </p>
+          </div>
+          <Button onClick={() => navigate("/")} type="button" variant="outline">
+            {t("sidebar.setupGuide.skip")}
+          </Button>
         </div>
-      </div>
 
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,38rem)_1fr]">
-        <div className="flex flex-col gap-3 rounded-xl bg-muted/20 p-3">
-          {steps.map((step, index) => {
-            const isActive = step.id === activeStepId;
-
-            return (
-              <Card
-                className={cn(
-                  "gap-0 overflow-hidden py-0",
-                  isActive ? "bg-background" : "bg-background/80",
-                )}
-                key={step.id}
-                size="sm"
-              >
-                <button
-                  className="flex w-full items-center gap-4 px-5 py-5 text-left outline-none transition-colors hover:bg-muted/30 focus-visible:bg-muted/30"
-                  onClick={() => {
-                    if (!isActive || step.completed) {
-                      navigate(stepTargets[step.id]);
-                    }
-                  }}
-                  type="button"
-                >
-                  <StepMarker completed={step.completed} index={index} />
-                  <span className="min-w-0 flex-1 truncate text-base font-medium">
-                    {t(`sidebar.setupGuide.steps.${step.id}`)}
+        <Surface>
+          <Accordion
+            onValueChange={(value) => {
+              const nextValue = value[0];
+              if (stepOrder.includes(nextValue as SetupGuideStepId)) {
+                setOpenStepId(nextValue as SetupGuideStepId);
+              }
+            }}
+            value={[openStepId]}
+          >
+            {steps.map((step, index) => (
+              <AccordionItem key={step.id} value={step.id}>
+                <AccordionTrigger className="min-h-16 px-6">
+                  <span className="flex min-w-0 items-center gap-4">
+                    <StepMarker completed={step.completed} index={index} />
+                    <span
+                      className={
+                        step.completed
+                          ? "truncate text-base text-muted-foreground line-through decoration-muted-foreground/70"
+                          : "truncate text-base"
+                      }
+                    >
+                      {t(`sidebar.setupGuide.steps.${step.id}`)}
+                    </span>
                   </span>
-                  {isActive && !step.completed ? (
-                    <ChevronDown className="text-muted-foreground" />
-                  ) : (
-                    <ChevronRight className="text-muted-foreground" />
-                  )}
-                </button>
-                {isActive && !step.completed ? (
-                  <>
-                    <CardHeader className="px-5 pb-0 pt-0">
-                      <CardTitle className="sr-only">
-                        {t(`sidebar.setupGuide.steps.${step.id}`)}
-                      </CardTitle>
-                      <div className="flex gap-4">
-                        <span aria-hidden="true" className="size-9 shrink-0" />
-                        <CardDescription className="text-base leading-6">
-                          {t(`sidebar.setupGuide.stepDescriptions.${step.id}`)}
-                        </CardDescription>
-                      </div>
-                    </CardHeader>
-                    <CardContent className="px-5 pb-5 pt-5">
-                      <div className="flex gap-4">
-                        <span aria-hidden="true" className="size-9 shrink-0" />
-                        <Button onClick={() => navigate(stepTargets[step.id])} type="button">
+                </AccordionTrigger>
+                <AccordionContent className="px-6">
+                  <div className="flex gap-4">
+                    <span aria-hidden="true" className="size-6 shrink-0" />
+                    <div className="flex min-w-0 flex-1 flex-col gap-4">
+                      <p className="max-w-lg text-base leading-6 text-muted-foreground">
+                        {t(`sidebar.setupGuide.stepDescriptions.${step.id}`)}
+                      </p>
+                      <div className="flex items-center justify-between gap-4">
+                        <Button
+                          onClick={() => navigate(stepTargets[step.id])}
+                          type="button"
+                        >
                           {t(`sidebar.setupGuide.stepActions.${step.id}`)}
                         </Button>
+                        <Button
+                          className="h-auto px-0 underline underline-offset-4"
+                          disabled={skippingStepId === step.id}
+                          onClick={() => void handleSkipStep(step.id)}
+                          type="button"
+                          variant="link"
+                        >
+                          {t("sidebar.setupGuide.skipStep")}
+                        </Button>
                       </div>
-                    </CardContent>
-                  </>
-                ) : null}
-              </Card>
-            );
-          })}
-        </div>
-        <div className="hidden lg:block" aria-hidden="true" />
+                    </div>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </Surface>
       </div>
     </section>
   );

--- a/apps/web/src/features/setup/SetupGuidePage.tsx
+++ b/apps/web/src/features/setup/SetupGuidePage.tsx
@@ -116,9 +116,27 @@ function StepMarker({
     );
   }
 
+  const radius = 10.5;
+  const circumference = 2 * Math.PI * radius;
+  const segmentLength = circumference / 8;
+  const dashLength = segmentLength * 0.62;
+  const gapLength = segmentLength - dashLength;
+
   return (
-    <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-foreground bg-background text-sm text-foreground">
-      {index + 1}
+    <span className="relative flex size-6 shrink-0 items-center justify-center bg-background text-sm text-foreground">
+      <svg aria-hidden="true" className="absolute inset-0 size-6" viewBox="0 0 24 24">
+        <circle
+          className="stroke-foreground"
+          cx="12"
+          cy="12"
+          fill="none"
+          r={radius}
+          strokeDasharray={`${dashLength} ${gapLength}`}
+          strokeLinecap="round"
+          strokeWidth="1.5"
+        />
+      </svg>
+      <span className="relative">{index + 1}</span>
     </span>
   );
 }

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -236,14 +236,17 @@
   @apply after:pointer-events-none after:absolute after:start-0 after:bottom-0 after:hidden after:h-32 after:w-full after:rounded-b-2xl after:bg-[linear-gradient(180deg,transparent_10%,var(--background)_70%)] md:after:block;
 }
 
+.AccordionContent,
 .CollapsibleContent {
   overflow: hidden;
 }
 
+.AccordionContent[data-open],
 .CollapsibleContent[data-open] {
   animation: slideDown 300ms ease-out;
 }
 
+.AccordionContent[data-closed],
 .CollapsibleContent[data-closed] {
   animation: slideUp 300ms ease-out;
 }
@@ -254,13 +257,13 @@
   }
 
   to {
-    height: var(--collapsible-panel-height, auto);
+    height: var(--accordion-panel-height, var(--collapsible-panel-height, auto));
   }
 }
 
 @keyframes slideUp {
   from {
-    height: var(--collapsible-panel-height, auto);
+    height: var(--accordion-panel-height, var(--collapsible-panel-height, auto));
   }
 
   to {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as auth from "../auth.js";
 import type * as billing from "../billing.js";
 import type * as businesses_admin from "../businesses/admin.js";
 import type * as businesses_catalog from "../businesses/catalog.js";
+import type * as businesses_setupGuide from "../businesses/setupGuide.js";
 import type * as conversations_sessions from "../conversations/sessions.js";
 import type * as conversations_webhooks from "../conversations/webhooks.js";
 import type * as crons from "../crons.js";
@@ -136,6 +137,7 @@ declare const fullApi: ApiFromModules<{
   billing: typeof billing;
   "businesses/admin": typeof businesses_admin;
   "businesses/catalog": typeof businesses_catalog;
+  "businesses/setupGuide": typeof businesses_setupGuide;
   "conversations/sessions": typeof conversations_sessions;
   "conversations/webhooks": typeof conversations_webhooks;
   crons: typeof crons;

--- a/convex/businesses/setupGuide.ts
+++ b/convex/businesses/setupGuide.ts
@@ -4,8 +4,16 @@ import { query, type QueryCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
 import { requireMembership, requireTenantAdminAccess } from "../lib/auth";
 import { resolveKnowledgeSection } from "../lib/knowledgeSections";
+import { observedMutation as mutation } from "../telemetry/observedFunctions";
 
 const setupGuideStepIds = ["website", "sources", "calendar", "services", "rules"] as const;
+const setupGuideStepIdValidator = v.union(
+  v.literal("website"),
+  v.literal("sources"),
+  v.literal("calendar"),
+  v.literal("services"),
+  v.literal("rules"),
+);
 
 type SetupGuideStepId = (typeof setupGuideStepIds)[number];
 
@@ -100,13 +108,14 @@ export const getProgress = query({
         hasActiveService(ctx, args.businessId),
         hasActiveRule(ctx, args.businessId),
       ]);
+    const skippedStepIds = new Set<SetupGuideStepId>(business?.setupGuideSkippedSteps ?? []);
 
     const steps: Array<SetupGuideStep> = [
-      { id: "website", completed: Boolean(business?.websiteUrl) },
-      { id: "sources", completed: sourcesCompleted },
-      { id: "calendar", completed: calendarCompleted },
-      { id: "services", completed: servicesCompleted },
-      { id: "rules", completed: rulesCompleted },
+      { id: "website", completed: Boolean(business?.websiteUrl) || skippedStepIds.has("website") },
+      { id: "sources", completed: sourcesCompleted || skippedStepIds.has("sources") },
+      { id: "calendar", completed: calendarCompleted || skippedStepIds.has("calendar") },
+      { id: "services", completed: servicesCompleted || skippedStepIds.has("services") },
+      { id: "rules", completed: rulesCompleted || skippedStepIds.has("rules") },
     ];
     const completedSteps = steps.filter((step) => step.completed).length;
     const totalSteps = setupGuideStepIds.length;
@@ -117,5 +126,30 @@ export const getProgress = query({
       totalSteps,
       allCompleted: completedSteps === totalSteps,
     };
+  },
+});
+
+export const skipStep = mutation({
+  args: {
+    businessId: v.id("businesses"),
+    stepId: setupGuideStepIdValidator,
+  },
+  handler: async (ctx, args) => {
+    const membership = await requireMembership(ctx, args.businessId);
+    requireTenantAdminAccess(membership.role);
+
+    const business = await ctx.db.get(args.businessId);
+    if (!business) {
+      throw new Error("Business not found");
+    }
+
+    const skippedSteps = business.setupGuideSkippedSteps ?? [];
+    if (!skippedSteps.includes(args.stepId)) {
+      await ctx.db.patch(args.businessId, {
+        setupGuideSkippedSteps: [...skippedSteps, args.stepId],
+      });
+    }
+
+    return { stepId: args.stepId };
   },
 });

--- a/convex/businesses/setupGuide.ts
+++ b/convex/businesses/setupGuide.ts
@@ -1,0 +1,121 @@
+import { v } from "convex/values";
+
+import { query, type QueryCtx } from "../_generated/server";
+import type { Doc, Id } from "../_generated/dataModel";
+import { requireMembership, requireTenantAdminAccess } from "../lib/auth";
+import { resolveKnowledgeSection } from "../lib/knowledgeSections";
+
+const setupGuideStepIds = ["website", "sources", "calendar", "services", "rules"] as const;
+
+type SetupGuideStepId = (typeof setupGuideStepIds)[number];
+
+type SetupGuideStep = {
+  id: SetupGuideStepId;
+  completed: boolean;
+};
+
+function isActiveKnowledgeDocument(document: Doc<"knowledge_documents">): boolean {
+  return document.active !== false && document.status !== "error";
+}
+
+function isUploadedKnowledgeSource(document: Doc<"knowledge_documents">): boolean {
+  return (
+    document.sourceType === "upload" &&
+    resolveKnowledgeSection(document.section) === "knowledge" &&
+    isActiveKnowledgeDocument(document)
+  );
+}
+
+function isConnectedCalendar(connection: Doc<"calendar_connections">): boolean {
+  return connection.status === "connected" && Boolean(connection.selectedCalendarId);
+}
+
+async function hasUploadedKnowledgeSource(
+  ctx: QueryCtx,
+  businessId: Id<"businesses">,
+): Promise<boolean> {
+  const documents = await ctx.db
+    .query("knowledge_documents")
+    .withIndex("by_business_id_and_source_type", (q) =>
+      q.eq("businessId", businessId).eq("sourceType", "upload"),
+    )
+    .collect();
+
+  return documents.some(isUploadedKnowledgeSource);
+}
+
+async function hasConnectedCalendar(
+  ctx: QueryCtx,
+  businessId: Id<"businesses">,
+): Promise<boolean> {
+  const connections = await ctx.db
+    .query("calendar_connections")
+    .withIndex("by_business_id_and_status", (q) =>
+      q.eq("businessId", businessId).eq("status", "connected"),
+    )
+    .collect();
+
+  return connections.some(isConnectedCalendar);
+}
+
+async function hasActiveService(
+  ctx: QueryCtx,
+  businessId: Id<"businesses">,
+): Promise<boolean> {
+  const services = await ctx.db
+    .query("services")
+    .withIndex("by_business_id", (q) => q.eq("businessId", businessId))
+    .collect();
+
+  return services.some((service) => service.active);
+}
+
+async function hasActiveRule(
+  ctx: QueryCtx,
+  businessId: Id<"businesses">,
+): Promise<boolean> {
+  const snippets = await ctx.db
+    .query("knowledge_snippets")
+    .withIndex("by_business_id_and_active", (q) =>
+      q.eq("businessId", businessId).eq("active", true),
+    )
+    .collect();
+
+  return snippets.some((snippet) => resolveKnowledgeSection(snippet.section) === "rules");
+}
+
+export const getProgress = query({
+  args: {
+    businessId: v.id("businesses"),
+  },
+  handler: async (ctx, args) => {
+    const membership = await requireMembership(ctx, args.businessId);
+    requireTenantAdminAccess(membership.role);
+
+    const [business, sourcesCompleted, calendarCompleted, servicesCompleted, rulesCompleted] =
+      await Promise.all([
+        ctx.db.get(args.businessId),
+        hasUploadedKnowledgeSource(ctx, args.businessId),
+        hasConnectedCalendar(ctx, args.businessId),
+        hasActiveService(ctx, args.businessId),
+        hasActiveRule(ctx, args.businessId),
+      ]);
+
+    const steps: Array<SetupGuideStep> = [
+      { id: "website", completed: Boolean(business?.websiteUrl) },
+      { id: "sources", completed: sourcesCompleted },
+      { id: "calendar", completed: calendarCompleted },
+      { id: "services", completed: servicesCompleted },
+      { id: "rules", completed: rulesCompleted },
+    ];
+    const completedSteps = steps.filter((step) => step.completed).length;
+    const totalSteps = setupGuideStepIds.length;
+
+    return {
+      steps,
+      completedSteps,
+      totalSteps,
+      allCompleted: completedSteps === totalSteps,
+    };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -72,6 +72,13 @@ const messageMediaValidator = v.object({
 });
 
 const retentionStatusValidator = v.union(v.literal("active"), v.literal("expired"));
+const setupGuideStepIdValidator = v.union(
+  v.literal("website"),
+  v.literal("sources"),
+  v.literal("calendar"),
+  v.literal("services"),
+  v.literal("rules"),
+);
 
 const conversationSessionSummaryKindValidator = v.union(
   v.literal("booked"),
@@ -208,6 +215,7 @@ export default defineSchema({
     defaultLocale: v.optional(runtimeLocaleValidator),
     websiteUrl: v.optional(v.string()),
     onboardingStage: v.optional(v.string()),
+    setupGuideSkippedSteps: v.optional(v.array(setupGuideStepIdValidator)),
     businessType: v.string(),
     deploymentMode: v.string(),
     status: v.string(),

--- a/convex/tests/setupGuide.test.ts
+++ b/convex/tests/setupGuide.test.ts
@@ -1,0 +1,179 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+import { modules } from "../test.setup";
+
+type ConvexHarness = TestConvex<typeof schema>;
+
+function createConvexHarness() {
+  return convexTest(schema, modules);
+}
+
+async function seedBusinessOwner(input: {
+  t: ConvexHarness;
+  subject: string;
+  websiteUrl?: string;
+}) {
+  return await input.t.run(async (ctx) => {
+    const businessId = await ctx.db.insert("businesses", {
+      slug: `${input.subject}-business`,
+      name: `${input.subject} Business`,
+      timezone: "America/Toronto",
+      defaultLocale: "en",
+      ...(input.websiteUrl ? { websiteUrl: input.websiteUrl } : {}),
+      onboardingStage: "completed",
+      businessType: "clinic",
+      deploymentMode: "manual",
+      status: "active",
+    });
+    const userId = await ctx.db.insert("users", {
+      authSubject: input.subject,
+      email: `${input.subject}@example.com`,
+    });
+    await ctx.db.insert("business_memberships", {
+      businessId,
+      userId,
+      role: "business_owner",
+      status: "active",
+    });
+
+    return { businessId, userId };
+  });
+}
+
+async function addUploadedSource(t: ConvexHarness, businessId: Id<"businesses">) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("knowledge_documents", {
+      businessId,
+      section: "knowledge",
+      active: true,
+      sourceType: "upload",
+      title: "Menu",
+      status: "indexed",
+      tags: [],
+      importance: 75,
+    });
+  });
+}
+
+async function addConnectedCalendar(t: ConvexHarness, businessId: Id<"businesses">) {
+  await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      authSubject: "calendar-owner",
+      email: "calendar-owner@example.com",
+    });
+    await ctx.db.insert("calendar_connections", {
+      businessId,
+      provider: "google",
+      ownerUserId: userId,
+      externalAccountId: "google-account",
+      selectedCalendarId: "primary",
+      selectedCalendarSummary: "Primary",
+      status: "connected",
+    });
+  });
+}
+
+async function addActiveService(t: ConvexHarness, businessId: Id<"businesses">) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("services", {
+      businessId,
+      name: "Consultation",
+      slug: "consultation",
+      description: "Initial appointment.",
+      durationMinutes: 30,
+      active: true,
+    });
+  });
+}
+
+async function addActiveRule(t: ConvexHarness, businessId: Id<"businesses">) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("knowledge_snippets", {
+      businessId,
+      section: "rules",
+      title: "Escalations",
+      content: "Transfer urgent billing questions.",
+      tags: [],
+      priority: 75,
+      active: true,
+    });
+  });
+}
+
+describe("setup guide progress", () => {
+  it("returns no completed steps for an empty completed workspace", async () => {
+    const t = createConvexHarness();
+    const subject = "setup-guide-empty";
+    const { businessId } = await seedBusinessOwner({ t, subject });
+
+    const progress = await t.withIdentity({ subject }).query(
+      api.businesses.setupGuide.getProgress,
+      { businessId },
+    );
+
+    expect(progress.completedSteps).toBe(0);
+    expect(progress.totalSteps).toBe(5);
+    expect(progress.allCompleted).toBe(false);
+    expect(progress.steps.map((step) => [step.id, step.completed])).toEqual([
+      ["website", false],
+      ["sources", false],
+      ["calendar", false],
+      ["services", false],
+      ["rules", false],
+    ]);
+  });
+
+  it("counts only the setup records that exist", async () => {
+    const t = createConvexHarness();
+    const subject = "setup-guide-partial";
+    const { businessId } = await seedBusinessOwner({
+      t,
+      subject,
+      websiteUrl: "https://example.com",
+    });
+    await addUploadedSource(t, businessId);
+    await addActiveService(t, businessId);
+
+    const progress = await t.withIdentity({ subject }).query(
+      api.businesses.setupGuide.getProgress,
+      { businessId },
+    );
+
+    expect(progress.completedSteps).toBe(3);
+    expect(progress.allCompleted).toBe(false);
+    expect(progress.steps.map((step) => [step.id, step.completed])).toEqual([
+      ["website", true],
+      ["sources", true],
+      ["calendar", false],
+      ["services", true],
+      ["rules", false],
+    ]);
+  });
+
+  it("marks the guide complete when all setup records exist", async () => {
+    const t = createConvexHarness();
+    const subject = "setup-guide-complete";
+    const { businessId } = await seedBusinessOwner({
+      t,
+      subject,
+      websiteUrl: "https://example.com",
+    });
+    await addUploadedSource(t, businessId);
+    await addConnectedCalendar(t, businessId);
+    await addActiveService(t, businessId);
+    await addActiveRule(t, businessId);
+
+    const progress = await t.withIdentity({ subject }).query(
+      api.businesses.setupGuide.getProgress,
+      { businessId },
+    );
+
+    expect(progress.completedSteps).toBe(5);
+    expect(progress.allCompleted).toBe(true);
+    expect(progress.steps.every((step) => step.completed)).toBe(true);
+  });
+});

--- a/convex/tests/setupGuide.test.ts
+++ b/convex/tests/setupGuide.test.ts
@@ -154,6 +154,34 @@ describe("setup guide progress", () => {
     ]);
   });
 
+  it("counts skipped setup steps as completed", async () => {
+    const t = createConvexHarness();
+    const subject = "setup-guide-skipped";
+    const { businessId } = await seedBusinessOwner({ t, subject });
+
+    await t.withIdentity({ subject }).mutation(api.businesses.setupGuide.skipStep, {
+      businessId,
+      stepId: "calendar",
+    });
+
+    const progress = await t.withIdentity({ subject }).query(
+      api.businesses.setupGuide.getProgress,
+      { businessId },
+    );
+    const business = await t.run((ctx) => ctx.db.get(businessId));
+
+    expect(progress.completedSteps).toBe(1);
+    expect(progress.allCompleted).toBe(false);
+    expect(progress.steps.map((step) => [step.id, step.completed])).toEqual([
+      ["website", false],
+      ["sources", false],
+      ["calendar", true],
+      ["services", false],
+      ["rules", false],
+    ]);
+    expect(business?.setupGuideSkippedSteps).toEqual(["calendar"]);
+  });
+
   it("marks the guide complete when all setup records exist", async () => {
     const t = createConvexHarness();
     const subject = "setup-guide-complete";


### PR DESCRIPTION
## Summary
- Add a setup guide sidebar/card to surface onboarding steps across the authenticated app.
- Persist setup guide state in Convex so completion can be tracked per business.
- Update agent, settings, and setup guide screens to use the new shared UI and localized nav copy.
- Add/expand tests for the sidebar, setup guide page, and Convex setup guide behavior.

## Testing
- Added and updated unit/integration tests for the new sidebar, layout integration, and setup guide flows.
- Added Convex regression coverage for setup guide state handling.
- Not run (not requested)