### PR TITLE
Fix setup rule dialog hook order

### DIFF
--- a/apps/web/src/features/agent/AgentLayout.test.tsx
+++ b/apps/web/src/features/agent/AgentLayout.test.tsx
@@ -68,4 +68,45 @@ describe("AgentLayout setup links", () => {
     expect(await screen.findByText("rule-dialog-open")).toBeTruthy();
     expect(screen.getByTestId("location").textContent).toBe("/agent/rules");
   });
+
+  it("keeps hook order stable when the business loads after the first render", async () => {
+    const { rerender } = render(
+      <MemoryRouter initialEntries={["/agent/rules?setup=rule"]}>
+        <Routes>
+          <Route
+            element={
+              <>
+                <AgentLayout canManageTenant />
+                <LocationProbe />
+              </>
+            }
+            path="/agent/*"
+          >
+            <Route element={<RulesOutlet />} path="rules" />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    rerender(
+      <MemoryRouter initialEntries={["/agent/rules"]}>
+        <Routes>
+          <Route
+            element={
+              <>
+                <AgentLayout businessId={"business-1" as any} canManageTenant />
+                <LocationProbe />
+              </>
+            }
+            path="/agent/*"
+          >
+            <Route element={<RulesOutlet />} path="rules" />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("rule-dialog-open")).toBeTruthy();
+    expect(screen.getByTestId("location").textContent).toBe("/agent/rules");
+  });
 });

--- a/apps/web/src/features/agent/AgentLayout.tsx
+++ b/apps/web/src/features/agent/AgentLayout.tsx
@@ -30,6 +30,17 @@ export function AgentLayout({ businessId, canManageTenant }: AgentLayoutProps) {
     location.pathname === "/agent/basic-settings" || location.pathname === "/agent";
   const isKnowledgeRoute = section === "knowledge" || section === "services" || section === "rules";
 
+  useEffect(() => {
+    if (section !== "rules" || searchParams.get("setup") !== "rule") {
+      return;
+    }
+
+    setIsRuleDialogOpen(true);
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.delete("setup");
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [searchParams, section, setSearchParams]);
+
   if (!businessId) {
     return null;
   }
@@ -60,17 +71,6 @@ export function AgentLayout({ businessId, canManageTenant }: AgentLayoutProps) {
       description: t("sections.rules.description"),
     };
   }
-
-  useEffect(() => {
-    if (section !== "rules" || searchParams.get("setup") !== "rule") {
-      return;
-    }
-
-    setIsRuleDialogOpen(true);
-    const nextSearchParams = new URLSearchParams(searchParams);
-    nextSearchParams.delete("setup");
-    setSearchParams(nextSearchParams, { replace: true });
-  }, [searchParams, section, setSearchParams]);
 
   const headerActions =
     canManageTenant && !isBasicSettingsRoute && isKnowledgeRoute ? (


### PR DESCRIPTION
## Summary
- Move the setup rule dialog effect before the AgentLayout businessId early return so hook order stays stable while workspace data resolves.
- Add a regression test for the delayed businessId render path.

## Verification
- pnpm --filter @lobbystack/web exec vitest run --config vite.config.ts src/features/agent/AgentLayout.test.tsx
- pnpm typecheck