### PR TITLE
Refresh landing page SEO metadata and schema markup

### DIFF
--- a/.github/workflows/landing-link-check.yml
+++ b/.github/workflows/landing-link-check.yml
@@ -21,11 +21,14 @@ jobs:
           args: >-
             --verbose
             --no-progress
+            --base-url https://lobbystack.com
             --exclude '^https://app\.lobbystack\.com/'
             --exclude '^https://voice\.lobbystack\.com/web-call/'
             --exclude '^https://voice-dev\.lobbystack\.com/web-call/'
             --exclude '^https://.*\.fly\.dev/web-call/'
             --exclude '^https://theresanaiforthat\.com/ai/lobbystack/'
+            --exclude '^https://www\.bls\.gov/ooh/Office-and-Administrative-Support/Receptionists\.htm$'
+            --exclude '^https://www\.hhs\.gov/hipaa/for-professionals/special-topics/health-information-technology/cloud-computing/$'
             './apps/landing/src/**/*.astro'
             './apps/landing/src/**/*.tsx'
             './apps/landing/src/content/**/*.md'

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -9,6 +9,7 @@ import { createLogger } from "vite"
 
 const SITE_URL = "https://lobbystack.com"
 const INDEXNOW_KEY = process.env.INDEXNOW_KEY
+const NOINDEX_PATHS = new Set(["/404/", "/privacy/", "/terms/", "/search/"])
 const SEO_GRAPH_SOURCEMAP_WARN_RE =
   /Sourcemap for ".+@jdevalk[\\/+]astro-seo-graph.+?" points to missing source files/
 
@@ -62,6 +63,16 @@ const sourceForUrl = (url) => {
 
   return undefined
 }
+
+const normalizePath = (pathname) => {
+  if (!pathname || pathname === "/") return "/"
+  return pathname.endsWith("/") ? pathname : `${pathname}/`
+}
+
+const indexingPath = (pathname) =>
+  normalizePath(normalizePath(pathname).replace(/^\/fr(?=\/|$)/, "") || "/")
+
+const isNoindexPath = (pathname) => NOINDEX_PATHS.has(indexingPath(pathname))
 
 const lastmodForUrl = (url) => {
   const source = sourceForUrl(url)
@@ -153,13 +164,11 @@ export default defineConfig({
               filter: (url) => {
                 const pathname = new URL(url).pathname
                 return (
+                  !isNoindexPath(pathname) &&
                   !pathname.startsWith("/api/") &&
                   !pathname.startsWith("/schema/") &&
                   !pathname.startsWith("/.well-known/") &&
-                  !pathname.endsWith(".md") &&
-                  !["/404/", "/privacy/", "/terms/", "/search/"].includes(
-                    pathname
-                  )
+                  !pathname.endsWith(".md")
                 )
               },
             },
@@ -170,7 +179,7 @@ export default defineConfig({
       entryLimit: 1000,
       filter: (page) => {
         const pathname = new URL(page).pathname
-        return !["/404/", "/privacy/", "/terms/", "/search/"].includes(pathname)
+        return !isNoindexPath(pathname)
       },
       serialize(item) {
         item.lastmod = lastmodForUrl(item.url)

--- a/apps/landing/public/_headers
+++ b/apps/landing/public/_headers
@@ -39,6 +39,12 @@
 /terms/
   X-Robots-Tag: noindex, follow
 
+/fr/privacy/
+  X-Robots-Tag: noindex, follow
+
+/fr/terms/
+  X-Robots-Tag: noindex, follow
+
 /index.md
   Content-Type: text/markdown; charset=utf-8
   X-Robots-Tag: noindex, follow

--- a/apps/landing/src/components/HeroSection.tsx
+++ b/apps/landing/src/components/HeroSection.tsx
@@ -29,11 +29,11 @@ export function HeroSection({ children }: { children?: ReactNode }) {
             </a>
 
             <h1 className="animate-fade-up display-heading delay-100">
-              Stop losing revenue to{" "}
+              LobbyStack turns{" "}
               <span className="underline decoration-2 underline-offset-4">
                 missed calls
-              </span>
-              .
+              </span>{" "}
+              into booked work.
             </h1>
 
             <p className="animate-fade-up body-copy mt-6 max-w-[65ch] delay-200 md:text-lg">

--- a/apps/landing/src/lib/agent-discovery.ts
+++ b/apps/landing/src/lib/agent-discovery.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto"
-import { DEFAULT_DESCRIPTION, SITE_URL, absoluteUrl } from "@/lib/seo"
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_TITLE,
+  SITE_URL,
+  absoluteUrl,
+} from "@/lib/seo"
 import { seoLandingPageByPath } from "@/lib/seo-landing-pages"
 
 export const CONTENT_SIGNAL = "ai-train=yes, search=yes, ai-input=yes"
@@ -504,7 +509,7 @@ export const agentSkillsIndex = {
 }
 
 export const homepageMarkdown = `---
-title: LobbyStack - Open-Source AI Receptionist
+title: ${DEFAULT_TITLE}
 description: ${DEFAULT_DESCRIPTION}
 url: ${absoluteUrl("/")}
 ---

--- a/apps/landing/src/lib/fr-pages.ts
+++ b/apps/landing/src/lib/fr-pages.ts
@@ -86,7 +86,7 @@ export const frenchPages: FrenchPage[] = [
     description:
       "Ne manquez plus d'appels avec LobbyStack, la réceptionniste IA open source qui répond, qualifie les prospects, prend des rendez-vous et route les appels urgents.",
     eyebrow: "Réceptionniste IA pour petites entreprises",
-    h1: "Arrêtez de perdre du revenu à cause des appels manqués.",
+    h1: "LobbyStack transforme les appels manqués en rendez-vous réservés.",
     intro:
       "LobbyStack répond à tous vos appels, ou seulement à ceux que vous ne pouvez pas prendre. L'IA qualifie les prospects, répond aux questions et réserve les clients directement dans votre calendrier.",
     primaryCta: "Essayer gratuitement",

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -2,10 +2,10 @@ export const SITE_URL = "https://lobbystack.com"
 
 export const SITE_NAME = "LobbyStack"
 
-export const DEFAULT_TITLE = "LobbyStack - Open-Source AI Receptionist"
+export const DEFAULT_TITLE = "LobbyStack | Open-Source AI Receptionist"
 
 export const DEFAULT_DESCRIPTION =
-  "Never miss a call with LobbyStack, the open-source AI receptionist. Answer questions, qualify leads, book appointments, and route urgent calls 24/7."
+  "LobbyStack is the open-source AI receptionist that answers calls, qualifies leads, books appointments, and routes urgent requests 24/7."
 
 export const DEFAULT_OG_IMAGE = "/og/index.jpg"
 
@@ -14,6 +14,18 @@ export const OG_IMAGE_WIDTH = 1200
 export const OG_IMAGE_HEIGHT = 675
 
 export const SEARCH_PATH = "/search/"
+
+const BRAND_ALIASES = [
+  "lobbystack",
+  "Lobby Stack",
+  "LobbyStack AI receptionist",
+  "LobbyStack open-source AI receptionist",
+]
+
+const BRAND_SAME_AS = [
+  "https://github.com/lobbystack",
+  "https://github.com/lobbystack/lobbystack",
+]
 
 export type JsonLd = Record<string, unknown>
 
@@ -103,6 +115,8 @@ export const organizationJsonLd = (): JsonLd => ({
   "@type": "Organization",
   "@id": absoluteUrl("/#organization"),
   name: SITE_NAME,
+  legalName: "Lobbystack Inc.",
+  alternateName: BRAND_ALIASES,
   url: absoluteUrl("/"),
   logo: {
     "@type": "ImageObject",
@@ -113,15 +127,33 @@ export const organizationJsonLd = (): JsonLd => ({
   },
   description:
     "LobbyStack is an open-source AI receptionist platform for small businesses that answers calls, books appointments, captures caller details, and routes urgent requests.",
-  sameAs: ["https://github.com/lobbystack/lobbystack"],
+  sameAs: BRAND_SAME_AS,
+  knowsAbout: [
+    "AI receptionist software",
+    "AI phone answering",
+    "appointment booking automation",
+    "missed call follow-up",
+    "self-hosted receptionist software",
+  ],
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "customer support",
+    email: "support@lobbystack.com",
+    url: "https://docs.lobbystack.com",
+  },
 })
 
 export const webSiteJsonLd = (): JsonLd => ({
   "@type": "WebSite",
   "@id": absoluteUrl("/#website"),
   name: SITE_NAME,
+  alternateName: BRAND_ALIASES,
   url: absoluteUrl("/"),
   description: DEFAULT_DESCRIPTION,
+  inLanguage: "en",
+  about: {
+    "@id": absoluteUrl("/#software"),
+  },
   publisher: {
     "@id": absoluteUrl("/#organization"),
   },
@@ -153,6 +185,16 @@ export const webPageJsonLd = ({
     name: title,
     url,
     description,
+    ...(path === "/"
+      ? {
+          about: {
+            "@id": absoluteUrl("/#software"),
+          },
+          mainEntity: {
+            "@id": absoluteUrl("/#product"),
+          },
+        }
+      : {}),
     isPartOf: {
       "@id": absoluteUrl("/#website"),
     },
@@ -192,14 +234,40 @@ export const softwareApplicationJsonLd = (): JsonLd => ({
   "@type": "SoftwareApplication",
   "@id": absoluteUrl("/#software"),
   name: SITE_NAME,
+  alternateName: BRAND_ALIASES,
   applicationCategory: "BusinessApplication",
   operatingSystem: "Web",
   url: absoluteUrl("/"),
   image: absoluteUrl(DEFAULT_OG_IMAGE),
   description: DEFAULT_DESCRIPTION,
+  isAccessibleForFree: true,
+  keywords:
+    "LobbyStack, lobbystack, AI receptionist, open-source AI receptionist, AI phone answering, appointment scheduler",
+  brand: {
+    "@id": absoluteUrl("/#organization"),
+  },
+  creator: {
+    "@id": absoluteUrl("/#organization"),
+  },
+  maintainer: {
+    "@id": absoluteUrl("/#organization"),
+  },
   publisher: {
     "@id": absoluteUrl("/#organization"),
   },
+  sameAs: BRAND_SAME_AS,
+  softwareHelp: {
+    "@type": "CreativeWork",
+    url: "https://docs.lobbystack.com",
+  },
+  featureList: [
+    "AI phone answering",
+    "appointment booking",
+    "lead qualification",
+    "call routing",
+    "SMS and call summaries",
+    "self-hosted deployment",
+  ],
   offers: [
     {
       "@type": "Offer",
@@ -232,6 +300,33 @@ export const softwareApplicationJsonLd = (): JsonLd => ({
       availability: "https://schema.org/InStock",
     },
   ],
+})
+
+export const productJsonLd = (): JsonLd => ({
+  "@type": "Product",
+  "@id": absoluteUrl("/#product"),
+  name: SITE_NAME,
+  alternateName: BRAND_ALIASES,
+  url: absoluteUrl("/"),
+  image: absoluteUrl(DEFAULT_OG_IMAGE),
+  description: DEFAULT_DESCRIPTION,
+  category: "AI receptionist software",
+  brand: {
+    "@id": absoluteUrl("/#organization"),
+  },
+  manufacturer: {
+    "@id": absoluteUrl("/#organization"),
+  },
+  sameAs: BRAND_SAME_AS,
+  offers: {
+    "@type": "AggregateOffer",
+    url: absoluteUrl("/pricing/"),
+    priceCurrency: "USD",
+    lowPrice: "0",
+    highPrice: "100",
+    offerCount: "3",
+    availability: "https://schema.org/InStock",
+  },
 })
 
 export const breadcrumbJsonLd = (

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -16,6 +16,7 @@ import { homeFaqs } from "@/lib/home-faqs"
 import {
   faqPageJsonLd,
   organizationJsonLd,
+  productJsonLd,
   softwareApplicationJsonLd,
   webSiteJsonLd,
 } from "@/lib/seo"
@@ -33,6 +34,7 @@ import {
       organizationJsonLd(),
       webSiteJsonLd(),
       softwareApplicationJsonLd(),
+      productJsonLd(),
       faqPageJsonLd({ path: "/", faqs: homeFaqs }),
     ],
   }}

--- a/apps/landing/src/pages/schema/page.json.ts
+++ b/apps/landing/src/pages/schema/page.json.ts
@@ -6,6 +6,8 @@ import {
   breadcrumbJsonLd,
   imageObjectJsonLd,
   organizationJsonLd,
+  productJsonLd,
+  softwareApplicationJsonLd,
   webPageJsonLd,
   webSiteJsonLd,
 } from "@/lib/seo"
@@ -16,6 +18,9 @@ export const GET = createSchemaEndpoint({
     [
       organizationJsonLd(),
       webSiteJsonLd(),
+      ...(page.path === "/"
+        ? [softwareApplicationJsonLd(), productJsonLd()]
+        : []),
       ...(page.path === "/blog/" ? [blogJsonLd()] : []),
       imageObjectJsonLd({
         path: page.path,


### PR DESCRIPTION
## Summary
- Updated the landing page hero and French homepage copy to better align with the new positioning.
- Added richer JSON-LD for `Organization`, `WebSite`, `SoftwareApplication`, and `Product` to improve brand and product discovery.
- Normalized sitemap/noindex handling for localized privacy and terms pages, including French variants.
- Switched homepage defaults to the shared site title and tightened the default description.

## Testing
- Not run (not requested)
- Verified the changes at a code level across landing page config, schema output, and localized metadata paths.