### PR TITLE
Add cookie consent policy and banner flow to the landing site

### DIFF
--- a/apps/landing/functions/_middleware.js
+++ b/apps/landing/functions/_middleware.js
@@ -39,6 +39,7 @@ const TRANSLATED_PATHS = new Set([
   "/blog/build-or-buy-ai-receptionist/",
   "/docs/api/",
   "/privacy/",
+  "/cookie-policy/",
   "/terms/",
   "/search/",
 ])

--- a/apps/landing/src/components/CookieConsentBanner.tsx
+++ b/apps/landing/src/components/CookieConsentBanner.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/item"
 import {
   COOKIE_PREFERENCES_TRIGGER_SELECTOR,
-  clearCookieConsent,
   clearPostHogClientStorage,
   readCookieConsent,
   writeCookieConsent,
@@ -69,7 +68,6 @@ export function CookieConsentBanner({
         target.closest(COOKIE_PREFERENCES_TRIGGER_SELECTOR)
       ) {
         event.preventDefault()
-        clearCookieConsent()
         setIsVisible(true)
       }
     }

--- a/apps/landing/src/components/CookieConsentBanner.tsx
+++ b/apps/landing/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from "@/components/ui/item"
+import {
+  COOKIE_PREFERENCES_TRIGGER_SELECTOR,
+  clearCookieConsent,
+  clearPostHogClientStorage,
+  readCookieConsent,
+  writeCookieConsent,
+} from "@/lib/cookie-consent"
+import { localizePath, type Locale } from "@/lib/i18n"
+
+const bannerCopy = {
+  en: {
+    title: "Cookie settings",
+    description:
+      "We use cookies to help this site function, understand service usage, and support marketing efforts.",
+    privacyPrefix: "Read our",
+    privacyLink: "Cookie Policy",
+    privacySuffix: ".",
+    reject: "Reject non-essential",
+    accept: "Accept all",
+  },
+  fr: {
+    title: "Paramètres des cookies",
+    description:
+      "Nous utilisons des cookies et des identifiants similaires pour faire fonctionner le site et, avec votre accord, mesurer son utilisation.",
+    privacyPrefix: "Consultez notre",
+    privacyLink: "Politique relative aux cookies",
+    privacySuffix: ".",
+    reject: "Refuser le non essentiel",
+    accept: "Tout accepter",
+  },
+} satisfies Record<Locale, Record<string, string>>
+
+let postHogModuleLoaded = false
+
+type CookieConsentBannerProps = {
+  locale?: Locale
+}
+
+export function CookieConsentBanner({
+  locale = "en",
+}: CookieConsentBannerProps) {
+  const [isVisible, setIsVisible] = useState(false)
+  const copy = bannerCopy[locale]
+
+  useEffect(() => {
+    const storedConsent = readCookieConsent()
+
+    setIsVisible(!storedConsent)
+
+    if (storedConsent?.analytics) {
+      void initializePostHog()
+    }
+
+    const handlePreferencesClick = (event: MouseEvent) => {
+      const target = event.target
+
+      if (
+        target instanceof Element &&
+        target.closest(COOKIE_PREFERENCES_TRIGGER_SELECTOR)
+      ) {
+        event.preventDefault()
+        clearCookieConsent()
+        setIsVisible(true)
+      }
+    }
+
+    document.addEventListener("click", handlePreferencesClick)
+    return () => document.removeEventListener("click", handlePreferencesClick)
+  }, [])
+
+  const rejectNonEssential = () => {
+    writeCookieConsent(false)
+    clearPostHogClientStorage()
+    void disablePostHog()
+    setIsVisible(false)
+  }
+
+  const acceptAll = () => {
+    writeCookieConsent(true)
+    setIsVisible(false)
+    void initializePostHog()
+  }
+
+  if (!isVisible) {
+    return null
+  }
+
+  return (
+    <aside
+      aria-label={copy.title}
+      className="fixed right-0 bottom-0 left-0 z-50 px-4 pb-4 sm:right-6 sm:bottom-6 sm:left-auto sm:w-[28rem] sm:px-0 sm:pb-0"
+    >
+      <Item
+        variant="outline"
+        className="gap-5 rounded-2xl border-border/70 bg-background/95 p-5 shadow-2xl shadow-foreground/10 backdrop-blur-xl"
+      >
+        <ItemContent className="gap-3">
+          <ItemTitle className="text-base">{copy.title}</ItemTitle>
+          <ItemDescription className="line-clamp-none">
+            {copy.description} {copy.privacyPrefix}{" "}
+            <a href={localizePath(locale, "/cookie-policy/")}>
+              {copy.privacyLink}
+            </a>
+            {copy.privacySuffix}
+          </ItemDescription>
+        </ItemContent>
+
+        <ItemActions className="w-full flex-col items-stretch gap-2 sm:flex-row sm:justify-end">
+          <Button variant="outline" onClick={rejectNonEssential} type="button">
+            {copy.reject}
+          </Button>
+          <Button onClick={acceptAll} type="button">
+            {copy.accept}
+          </Button>
+        </ItemActions>
+      </Item>
+    </aside>
+  )
+}
+
+async function initializePostHog() {
+  const { initializePostHog } = await import("@/lib/posthog")
+  postHogModuleLoaded = true
+  initializePostHog()
+}
+
+async function disablePostHog() {
+  if (!postHogModuleLoaded) {
+    return
+  }
+
+  const { disablePostHog } = await import("@/lib/posthog")
+  disablePostHog()
+}

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -16,10 +16,13 @@ const footerCopy = {
     about: "About",
     contact: "Contact",
     privacy: "Privacy Policy",
+    cookiePolicy: "Cookie Policy",
     terms: "Terms of Service",
     rights: "All rights reserved.",
     privacyShort: "Privacy",
+    cookiePolicyShort: "Cookie Policy",
     termsShort: "Terms",
+    cookiePreferences: "Cookie preferences",
   },
   fr: {
     product: "Produit",
@@ -35,10 +38,13 @@ const footerCopy = {
     about: "À propos",
     contact: "Contact",
     privacy: "Politique de confidentialité",
+    cookiePolicy: "Politique relative aux cookies",
     terms: "Conditions d'utilisation",
     rights: "Tous droits réservés.",
     privacyShort: "Confidentialité",
+    cookiePolicyShort: "Cookies",
     termsShort: "Conditions",
+    cookiePreferences: "Préférences cookies",
   },
 } satisfies Record<Locale, Record<string, string>>
 
@@ -76,6 +82,7 @@ const footerSections = (locale: Locale) => {
         { label: copy.about, href: "/about/" },
         { label: copy.contact, href: "mailto:support@lobbystack.com" },
         { label: copy.privacy, href: "/privacy/" },
+        { label: copy.cookiePolicy, href: "/cookie-policy/" },
         { label: copy.terms, href: "/terms/" },
       ],
     },
@@ -157,12 +164,25 @@ export function Footer({ locale = "en" }: FooterProps) {
           <p>
             © {new Date().getFullYear()} LobbyStack. {copy.rights}
           </p>
-          <div className="flex gap-6">
+          <div className="flex flex-wrap justify-center gap-6">
+            <button
+              type="button"
+              data-cookie-preferences-trigger
+              className="hover:text-foreground"
+            >
+              {copy.cookiePreferences}
+            </button>
             <a
               href={localizePath(locale, "/privacy/")}
               className="hover:text-foreground"
             >
               {copy.privacyShort}
+            </a>
+            <a
+              href={localizePath(locale, "/cookie-policy/")}
+              className="hover:text-foreground"
+            >
+              {copy.cookiePolicyShort}
             </a>
             <a
               href={localizePath(locale, "/terms/")}

--- a/apps/landing/src/components/pages/LegalPage.astro
+++ b/apps/landing/src/components/pages/LegalPage.astro
@@ -99,7 +99,7 @@ const legalCopy = {
           id: "rights",
           title: "7. Vos droits et choix",
           paragraphs: [
-            "Selon votre lieu, vous pouvez avoir le droit de demander accès, correction, suppression, portabilité, opposition ou limitation de certains traitements. Vous pouvez aussi contrôler certains cookies et communications.",
+            'Selon votre lieu, vous pouvez avoir le droit de demander accès, correction, suppression, portabilité, opposition ou limitation de certains traitements. Vous pouvez aussi contrôler certains cookies et communications. Consultez notre <a href="/fr/cookie-policy/">Politique relative aux cookies</a> pour plus de détails.',
             "Si une entreprise utilise LobbyStack pour communiquer avec vous, contactez d’abord cette entreprise pour les demandes relatives à ses propres pratiques.",
           ],
         },
@@ -295,7 +295,7 @@ const t = legalCopy.fr[kind]
             <section id={section.id}>
               <h2>{section.title}</h2>
               {section.paragraphs.map((paragraph) => (
-                <p>{paragraph}</p>
+                <p set:html={paragraph} />
               ))}
             </section>
           ))

--- a/apps/landing/src/components/ui/item.tsx
+++ b/apps/landing/src/components/ui/item.tsx
@@ -1,0 +1,214 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+const itemGroupVariants = cva("group/item-group flex w-full flex-col", {
+  variants: {
+    spacing: {
+      compact: "gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2",
+      section: "gap-8",
+    },
+  },
+  defaultVariants: {
+    spacing: "compact",
+  },
+})
+
+function ItemGroup({
+  className,
+  spacing = "compact",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemGroupVariants>) {
+  return (
+    <div
+      role="list"
+      data-slot="item-group"
+      className={cn(itemGroupVariants({ spacing }), className)}
+      {...props}
+    />
+  )
+}
+
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      className={cn("my-2", className)}
+      {...props}
+    />
+  )
+}
+
+const itemVariants = cva(
+  "group/item flex w-full flex-wrap items-center rounded-xl border text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-muted",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent",
+        outline: "border-border",
+        muted: "border-transparent bg-muted/50",
+      },
+      size: {
+        default: "gap-3.5 px-4 py-3.5",
+        sm: "gap-3.5 px-3.5 py-3",
+        xs: "gap-2.5 px-3 py-2.5 in-data-[slot=dropdown-menu-content]:p-0",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Item({
+  className,
+  variant = "default",
+  size = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & VariantProps<typeof itemVariants>) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(itemVariants({ variant, size, className })),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "item",
+      variant,
+      size,
+    },
+  })
+}
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start [&_svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "[&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 overflow-hidden rounded-lg group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 group-data-[size=xs]/item:rounded-md [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function ItemMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemMediaVariants>) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-content"
+      className={cn(
+        "flex flex-1 flex-col gap-1 group-data-[size=xs]/item:gap-0.5 [&+[data-slot=item-content]]:flex-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-title"
+      className={cn(
+        "font-heading line-clamp-1 flex w-fit items-center gap-2 text-sm leading-snug font-medium underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="item-description"
+      className={cn(
+        "line-clamp-2 text-left text-sm font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-actions"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-header"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-footer"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemActions,
+  ItemGroup,
+  ItemSeparator,
+  ItemTitle,
+  ItemDescription,
+  ItemHeader,
+  ItemFooter,
+}

--- a/apps/landing/src/components/web-voice/LobbyStackWebVoiceWidget.tsx
+++ b/apps/landing/src/components/web-voice/LobbyStackWebVoiceWidget.tsx
@@ -1,5 +1,6 @@
 import { WebVoiceWidget } from "@/components/web-voice/WebVoiceWidget"
 import { LobbyStackAuraVoiceDemo } from "@/components/web-voice/LobbyStackAuraVoiceDemo"
+import { hasAnalyticsConsent } from "@/lib/cookie-consent"
 
 const DEFAULT_WEB_CALL_ENDPOINT =
   "https://voice.lobbystack.com/web-call/sessions"
@@ -9,6 +10,10 @@ const DEFAULT_BUSINESS_SLUG = "lobbystack-mp35s9y1"
 const DEV_BUSINESS_SLUG = "lobbystack-qa-motd3txq"
 
 function capturePosthog(eventName: string, properties?: Record<string, unknown>) {
+  if (!hasAnalyticsConsent()) {
+    return
+  }
+
   void import("@/lib/posthog").then(({ posthog }) => {
     posthog.capture(eventName, properties)
   })

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -81,6 +81,11 @@ export const en = {
       description:
         "Privacy Policy for LobbyStack, including call, SMS, consent, appointment, account, billing, analytics, and support data.",
     },
+    "/cookie-policy/": {
+      title: "Cookie Policy - LobbyStack",
+      description:
+        "Cookie Policy for LobbyStack, including necessary cookies, analytics storage, browser controls, and cookie preferences.",
+    },
     "/terms/": {
       title: "Terms of Service - LobbyStack",
       description:

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -82,6 +82,11 @@ export const fr = {
       description:
         "Politique de confidentialité de LobbyStack, couvrant appels, SMS, consentement, rendez‑vous, comptes, facturation, analytique et support.",
     },
+    "/cookie-policy/": {
+      title: "Politique relative aux cookies - LobbyStack",
+      description:
+        "Politique relative aux cookies de LobbyStack, couvrant cookies nécessaires, stockage analytique, contrôles navigateur et préférences cookies.",
+    },
     "/terms/": {
       title: "Conditions d'utilisation - LobbyStack",
       description:

--- a/apps/landing/src/i18n/i18n.test.ts
+++ b/apps/landing/src/i18n/i18n.test.ts
@@ -55,6 +55,7 @@ describe("landing i18n route helpers", () => {
     expect(localizeHref("fr", "/pricing/?interval=year#plans")).toBe(
       "/fr/pricing/?interval=year#plans"
     )
+    expect(localizeHref("fr", "/cookie-policy/")).toBe("/fr/cookie-policy/")
     expect(localizeHref("fr", "https://docs.lobbystack.com/introduction")).toBe(
       "https://docs.lobbystack.com/introduction"
     )
@@ -69,6 +70,11 @@ describe("landing i18n route helpers", () => {
       { hrefLang: "en", href: "https://lobbystack.com/pricing/" },
       { hrefLang: "fr", href: "https://lobbystack.com/fr/pricing/" },
       { hrefLang: "x-default", href: "https://lobbystack.com/pricing/" },
+    ])
+    expect(alternateLocaleLinks("/cookie-policy/")).toEqual([
+      { hrefLang: "en", href: "https://lobbystack.com/cookie-policy/" },
+      { hrefLang: "fr", href: "https://lobbystack.com/fr/cookie-policy/" },
+      { hrefLang: "x-default", href: "https://lobbystack.com/cookie-policy/" },
     ])
   })
 })

--- a/apps/landing/src/i18n/routes.ts
+++ b/apps/landing/src/i18n/routes.ts
@@ -34,6 +34,7 @@ export const translatedBasePaths = [
   "/blog/build-or-buy-ai-receptionist/",
   "/docs/api/",
   "/privacy/",
+  "/cookie-policy/",
   "/terms/",
   "/search/",
 ] as const

--- a/apps/landing/src/layouts/main.astro
+++ b/apps/landing/src/layouts/main.astro
@@ -28,6 +28,7 @@ import {
   localeMeta,
   type Locale,
 } from "@/lib/i18n"
+import { CookieConsentBanner } from "@/components/CookieConsentBanner"
 
 interface Props {
   seo?: PageSeo
@@ -109,40 +110,6 @@ Astro.response.headers.set("Content-Signal", CONTENT_SIGNAL)
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <Font cssVariable="--font-geist" preload />
     <Font cssVariable="--font-geist-mono" preload />
-    <script>
-      const loadPosthog = () => import("@/lib/posthog")
-      const win = window as Window & {
-        requestIdleCallback?: (
-          callback: () => void,
-          options?: { timeout: number }
-        ) => number
-      }
-
-      const interactionEvents = ["pointerdown", "keydown", "touchstart"]
-      let posthogRequested = false
-      const loadOnce = () => {
-        if (posthogRequested) return
-
-        posthogRequested = true
-        interactionEvents.forEach((eventName) => {
-          window.removeEventListener(eventName, loadOnce)
-        })
-        loadPosthog()
-      }
-
-      interactionEvents.forEach((eventName) => {
-        window.addEventListener(eventName, loadOnce, {
-          once: true,
-          passive: true,
-        })
-      })
-
-      if (typeof win.requestIdleCallback === "function") {
-        win.requestIdleCallback(loadOnce, { timeout: 8000 })
-      } else {
-        setTimeout(loadOnce, 8000)
-      }
-    </script>
 
     <Seo
       title={title}
@@ -191,6 +158,7 @@ Astro.response.headers.set("Content-Signal", CONTENT_SIGNAL)
   <body class="antialiased">
     <a href="#main-content" class="skip-link">{skipLabel}</a>
     <slot />
+    <CookieConsentBanner locale={locale} client:load />
     <script is:inline src="/webmcp.js" defer></script>
   </body>
 </html>

--- a/apps/landing/src/lib/cookie-consent.test.ts
+++ b/apps/landing/src/lib/cookie-consent.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   COOKIE_CONSENT_STORAGE_KEY,
   clearCookieConsent,
+  clearPostHogClientStorage,
   createCookieConsent,
   hasAnalyticsConsent,
   parseCookieConsent,
@@ -23,6 +24,10 @@ function createStorage() {
     }),
   }
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe("landing cookie consent helpers", () => {
   it("treats missing consent as undecided", () => {
@@ -81,5 +86,28 @@ describe("landing cookie consent helpers", () => {
     clearCookieConsent(storage)
 
     expect(readCookieConsent(storage)).toBeNull()
+  })
+
+  it("ignores blocked browser storage when clearing PostHog storage", () => {
+    const blockedWindow = {
+      location: { hostname: "lobbystack.com" },
+    }
+
+    Object.defineProperties(blockedWindow, {
+      localStorage: {
+        get() {
+          throw new Error("localStorage blocked")
+        },
+      },
+      sessionStorage: {
+        get() {
+          throw new Error("sessionStorage blocked")
+        },
+      },
+    })
+
+    vi.stubGlobal("window", blockedWindow)
+
+    expect(() => clearPostHogClientStorage()).not.toThrow()
   })
 })

--- a/apps/landing/src/lib/cookie-consent.test.ts
+++ b/apps/landing/src/lib/cookie-consent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  clearCookieConsent,
+  createCookieConsent,
+  hasAnalyticsConsent,
+  parseCookieConsent,
+  readCookieConsent,
+  writeCookieConsent,
+} from "@/lib/cookie-consent"
+
+function createStorage() {
+  const values = new Map<string, string>()
+
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key)
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value)
+    }),
+  }
+}
+
+describe("landing cookie consent helpers", () => {
+  it("treats missing consent as undecided", () => {
+    const storage = createStorage()
+
+    expect(readCookieConsent(storage)).toBeNull()
+    expect(hasAnalyticsConsent(storage)).toBe(false)
+  })
+
+  it("stores analytics consent when accepting all", () => {
+    const storage = createStorage()
+    const consent = writeCookieConsent(true, storage)
+
+    expect(consent.analytics).toBe(true)
+    expect(hasAnalyticsConsent(storage)).toBe(true)
+    expect(readCookieConsent(storage)).toMatchObject({
+      analytics: true,
+      version: 1,
+    })
+  })
+
+  it("stores analytics rejection when rejecting non-essential cookies", () => {
+    const storage = createStorage()
+
+    writeCookieConsent(false, storage)
+
+    expect(hasAnalyticsConsent(storage)).toBe(false)
+    expect(readCookieConsent(storage)).toMatchObject({
+      analytics: false,
+      version: 1,
+    })
+  })
+
+  it("ignores malformed stored consent", () => {
+    expect(parseCookieConsent("not json")).toBeNull()
+    expect(parseCookieConsent(JSON.stringify({ analytics: true }))).toBeNull()
+    expect(
+      parseCookieConsent(
+        JSON.stringify({
+          analytics: "yes",
+          decidedAt: new Date().toISOString(),
+          version: 1,
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("clears stored consent", () => {
+    const storage = createStorage()
+
+    storage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify(createCookieConsent(true))
+    )
+
+    clearCookieConsent(storage)
+
+    expect(readCookieConsent(storage)).toBeNull()
+  })
+})

--- a/apps/landing/src/lib/cookie-consent.test.ts
+++ b/apps/landing/src/lib/cookie-consent.test.ts
@@ -61,6 +61,23 @@ describe("landing cookie consent helpers", () => {
     })
   })
 
+  it("returns consent when browser storage rejects writes", () => {
+    const storage = {
+      getItem: vi.fn(() => null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(() => {
+        throw new Error("storage blocked")
+      }),
+    }
+
+    const consent = writeCookieConsent(false, storage)
+
+    expect(consent).toMatchObject({
+      analytics: false,
+      version: 1,
+    })
+  })
+
   it("ignores malformed stored consent", () => {
     expect(parseCookieConsent("not json")).toBeNull()
     expect(parseCookieConsent(JSON.stringify({ analytics: true }))).toBeNull()

--- a/apps/landing/src/lib/cookie-consent.ts
+++ b/apps/landing/src/lib/cookie-consent.ts
@@ -66,7 +66,11 @@ export function writeCookieConsent(
   const consent = createCookieConsent(analytics)
 
   if (storage) {
-    storage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(consent))
+    try {
+      storage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(consent))
+    } catch {
+      // Storage can reject writes in private browsing or quota-limited contexts.
+    }
   }
 
   emitCookieConsentChanged(consent)

--- a/apps/landing/src/lib/cookie-consent.ts
+++ b/apps/landing/src/lib/cookie-consent.ts
@@ -110,8 +110,8 @@ export function clearPostHogClientStorage() {
     return
   }
 
-  removePostHogStorageKeys(window.localStorage)
-  removePostHogStorageKeys(window.sessionStorage)
+  removePostHogStorageKeysFromBrowser("localStorage")
+  removePostHogStorageKeysFromBrowser("sessionStorage")
   expirePostHogCookies()
 }
 
@@ -150,6 +150,16 @@ function removePostHogStorageKeys(storage: Storage) {
     }
   } catch {
     // Storage may be unavailable in private browsing or hardened contexts.
+  }
+}
+
+function removePostHogStorageKeysFromBrowser(
+  storageName: "localStorage" | "sessionStorage"
+) {
+  try {
+    removePostHogStorageKeys(window[storageName])
+  } catch {
+    // Reading the storage property itself can throw in hardened browsers.
   }
 }
 

--- a/apps/landing/src/lib/cookie-consent.ts
+++ b/apps/landing/src/lib/cookie-consent.ts
@@ -1,0 +1,189 @@
+export const COOKIE_CONSENT_STORAGE_KEY = "lobbystack.cookieConsent.v1"
+export const COOKIE_CONSENT_VERSION = 1
+export const COOKIE_CONSENT_CHANGED_EVENT = "lobbystack:cookie-consent-changed"
+export const COOKIE_PREFERENCES_TRIGGER_SELECTOR =
+  "[data-cookie-preferences-trigger]"
+
+export type CookieConsent = {
+  analytics: boolean
+  decidedAt: string
+  version: typeof COOKIE_CONSENT_VERSION
+}
+
+type StorageLike = Pick<Storage, "getItem" | "removeItem" | "setItem">
+
+type CookieConsentChangeDetail = {
+  consent: CookieConsent | null
+}
+
+export function parseCookieConsent(value: string | null): CookieConsent | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<CookieConsent>
+
+    if (
+      parsed.version !== COOKIE_CONSENT_VERSION ||
+      typeof parsed.analytics !== "boolean" ||
+      typeof parsed.decidedAt !== "string" ||
+      Number.isNaN(Date.parse(parsed.decidedAt))
+    ) {
+      return null
+    }
+
+    return {
+      analytics: parsed.analytics,
+      decidedAt: parsed.decidedAt,
+      version: COOKIE_CONSENT_VERSION,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function readCookieConsent(storage = getBrowserStorage()) {
+  if (!storage) {
+    return null
+  }
+
+  return parseCookieConsent(storage.getItem(COOKIE_CONSENT_STORAGE_KEY))
+}
+
+export function createCookieConsent(analytics: boolean): CookieConsent {
+  return {
+    analytics,
+    decidedAt: new Date().toISOString(),
+    version: COOKIE_CONSENT_VERSION,
+  }
+}
+
+export function writeCookieConsent(
+  analytics: boolean,
+  storage = getBrowserStorage()
+): CookieConsent {
+  const consent = createCookieConsent(analytics)
+
+  if (storage) {
+    storage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(consent))
+  }
+
+  emitCookieConsentChanged(consent)
+  return consent
+}
+
+export function clearCookieConsent(storage = getBrowserStorage()) {
+  if (storage) {
+    storage.removeItem(COOKIE_CONSENT_STORAGE_KEY)
+  }
+
+  emitCookieConsentChanged(null)
+}
+
+export function hasAnalyticsConsent(storage = getBrowserStorage()) {
+  return readCookieConsent(storage)?.analytics === true
+}
+
+export function onCookieConsentChanged(
+  handler: (consent: CookieConsent | null) => void
+) {
+  if (typeof window === "undefined") {
+    return () => undefined
+  }
+
+  const listener = (event: Event) => {
+    handler(
+      event instanceof CustomEvent
+        ? ((event.detail as CookieConsentChangeDetail | undefined)?.consent ??
+            null)
+        : null
+    )
+  }
+
+  window.addEventListener(COOKIE_CONSENT_CHANGED_EVENT, listener)
+  return () => window.removeEventListener(COOKIE_CONSENT_CHANGED_EVENT, listener)
+}
+
+export function clearPostHogClientStorage() {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  removePostHogStorageKeys(window.localStorage)
+  removePostHogStorageKeys(window.sessionStorage)
+  expirePostHogCookies()
+}
+
+function getBrowserStorage(): StorageLike | null {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function emitCookieConsentChanged(consent: CookieConsent | null) {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<CookieConsentChangeDetail>(COOKIE_CONSENT_CHANGED_EVENT, {
+      detail: { consent },
+    })
+  )
+}
+
+function removePostHogStorageKeys(storage: Storage) {
+  try {
+    for (let index = storage.length - 1; index >= 0; index -= 1) {
+      const key = storage.key(index)
+
+      if (key && isPostHogStorageKey(key)) {
+        storage.removeItem(key)
+      }
+    }
+  } catch {
+    // Storage may be unavailable in private browsing or hardened contexts.
+  }
+}
+
+function isPostHogStorageKey(key: string) {
+  const normalized = key.toLowerCase()
+  return normalized.includes("posthog") || normalized.startsWith("ph_")
+}
+
+function expirePostHogCookies() {
+  try {
+    const hostname = window.location.hostname
+    const parentDomain = hostname.split(".").slice(-2).join(".")
+    const domains = Array.from(new Set(["", hostname, `.${hostname}`, `.${parentDomain}`]))
+
+    document.cookie.split(";").forEach((cookie) => {
+      const name = cookie.split("=")[0]?.trim()
+
+      if (!name || !isPostHogStorageKey(name)) {
+        return
+      }
+
+      domains.forEach((domain) => {
+        document.cookie = [
+          `${name}=`,
+          "expires=Thu, 01 Jan 1970 00:00:00 GMT",
+          "path=/",
+          "SameSite=Lax",
+          domain ? `domain=${domain}` : "",
+        ]
+          .filter(Boolean)
+          .join("; ")
+      })
+    })
+  } catch {
+    // Cookie access can be blocked by browser settings.
+  }
+}

--- a/apps/landing/src/lib/posthog.ts
+++ b/apps/landing/src/lib/posthog.ts
@@ -1,5 +1,10 @@
 import posthog from "posthog-js"
 
+import {
+  clearPostHogClientStorage,
+  hasAnalyticsConsent,
+} from "@/lib/cookie-consent"
+
 const DEFAULT_POSTHOG_HOST = "https://ts.lobbystack.com"
 const DEFAULT_POSTHOG_UI_HOST = "https://us.posthog.com"
 const SIGNUP_CTA_SELECTOR = "[data-ph-signup-cta]"
@@ -10,6 +15,8 @@ const apiHost = import.meta.env.PUBLIC_POSTHOG_HOST || DEFAULT_POSTHOG_HOST
 const uiHost = import.meta.env.PUBLIC_POSTHOG_UI_HOST || DEFAULT_POSTHOG_UI_HOST
 const canCapture =
   typeof window !== "undefined" && isEnabled && Boolean(projectKey)
+let isInitialized = false
+let isSignupCtaListenerAttached = false
 
 type LandingSignupCtaClickProperties = {
   action?: string
@@ -32,7 +39,20 @@ const getSignupCtaProperties = (
   section: element.dataset.phCaptureAttributeSection || "unknown",
 })
 
-if (canCapture && projectKey) {
+export function initializePostHog() {
+  if (!canCapture || !projectKey || !hasAnalyticsConsent()) {
+    return false
+  }
+
+  if (isInitialized) {
+    const posthogWithOptIn = posthog as typeof posthog & {
+      opt_in_capturing?: () => void
+    }
+
+    posthogWithOptIn.opt_in_capturing?.()
+    return true
+  }
+
   posthog.init(projectKey, {
     api_host: apiHost,
     ui_host: uiHost,
@@ -50,19 +70,45 @@ if (canCapture && projectKey) {
     },
   })
 
-  window.document.addEventListener("click", (event) => {
-    if (!(event.target instanceof Element)) {
-      return
+  isInitialized = true
+
+  if (!isSignupCtaListenerAttached) {
+    isSignupCtaListenerAttached = true
+    window.document.addEventListener("click", (event) => {
+      if (!(event.target instanceof Element)) {
+        return
+      }
+
+      const signupCta = event.target.closest(SIGNUP_CTA_SELECTOR)
+
+      if (!(signupCta instanceof HTMLElement)) {
+        return
+      }
+
+      captureLandingSignupCtaClick(getSignupCtaProperties(signupCta))
+    })
+  }
+
+  return true
+}
+
+export function disablePostHog() {
+  if (canCapture && isInitialized) {
+    const posthogWithOptOut = posthog as typeof posthog & {
+      opt_out_capturing?: () => void
+      stopSessionRecording?: () => void
     }
 
-    const signupCta = event.target.closest(SIGNUP_CTA_SELECTOR)
+    posthogWithOptOut.opt_out_capturing?.()
+    posthogWithOptOut.stopSessionRecording?.()
+    posthog.reset()
+  }
 
-    if (!(signupCta instanceof HTMLElement)) {
-      return
-    }
+  clearPostHogClientStorage()
+}
 
-    captureLandingSignupCtaClick(getSignupCtaProperties(signupCta))
-  })
+if (canCapture && hasAnalyticsConsent()) {
+  initializePostHog()
 }
 
 export function captureLandingSignupCtaClick({
@@ -72,7 +118,7 @@ export function captureLandingSignupCtaClick({
   plan,
   section,
 }: LandingSignupCtaClickProperties) {
-  if (!canCapture) {
+  if (!canCapture || !initializePostHog()) {
     return
   }
 

--- a/apps/landing/src/lib/posthog.ts
+++ b/apps/landing/src/lib/posthog.ts
@@ -94,9 +94,9 @@ export function disablePostHog() {
       stopSessionRecording?: () => void
     }
 
-    posthogWithOptOut.opt_out_capturing?.()
     posthogWithOptOut.stopSessionRecording?.()
     posthog.reset()
+    posthogWithOptOut.opt_out_capturing?.()
   }
 
   clearPostHogClientStorage()

--- a/apps/landing/src/lib/posthog.ts
+++ b/apps/landing/src/lib/posthog.ts
@@ -45,11 +45,6 @@ export function initializePostHog() {
   }
 
   if (isInitialized) {
-    const posthogWithOptIn = posthog as typeof posthog & {
-      opt_in_capturing?: () => void
-    }
-
-    posthogWithOptIn.opt_in_capturing?.()
     return true
   }
 

--- a/apps/landing/src/lib/posthog.ts
+++ b/apps/landing/src/lib/posthog.ts
@@ -45,6 +45,15 @@ export function initializePostHog() {
   }
 
   if (isInitialized) {
+    const posthogWithOptIn = posthog as typeof posthog & {
+      has_opted_out_capturing?: () => boolean
+      opt_in_capturing?: (options?: { captureEventName?: false }) => void
+    }
+
+    if (posthogWithOptIn.has_opted_out_capturing?.()) {
+      posthogWithOptIn.opt_in_capturing?.({ captureEventName: false })
+    }
+
     return true
   }
 

--- a/apps/landing/src/pages/cookie-policy.astro
+++ b/apps/landing/src/pages/cookie-policy.astro
@@ -1,0 +1,258 @@
+---
+import Layout from "@/layouts/main.astro"
+import { Navbar } from "@/components/Navbar"
+import { Footer } from "@/components/Footer"
+import { absoluteUrl, breadcrumbJsonLd, organizationJsonLd } from "@/lib/seo"
+
+const updatedAt = "June 12, 2026"
+const cookieRows = [
+  {
+    category: "Necessary",
+    source: "LobbyStack",
+    name: "lobbystack.cookieConsent.v1",
+    duration: "Until cleared by the user",
+    purpose: "Stores whether you accepted or rejected optional analytics cookies.",
+    storage: "Local storage on lobbystack.com",
+  },
+  {
+    category: "Necessary",
+    source: "LobbyStack",
+    name: "lobbystack.webVoiceVisitorId",
+    duration: "Until cleared by the user",
+    purpose:
+      "Helps connect web voice demo sessions when you choose to start a browser-based call.",
+    storage: "Local storage on lobbystack.com",
+  },
+  {
+    category: "Necessary",
+    source: "Cloudflare",
+    name: "__cf_bm, cf_clearance, _cfuvid, or similar",
+    duration: "Session to 1 year, depending on the cookie",
+    purpose:
+      "Supports security, bot detection, traffic routing, and abuse prevention.",
+    storage: "Cookie on lobbystack.com or Cloudflare-managed domains",
+  },
+  {
+    category: "Analytics and performance",
+    source: "PostHog",
+    name: "posthog*, ph_*, and related PostHog identifiers",
+    duration: "Varies by identifier and browser settings",
+    purpose:
+      "Measures page views, CTA clicks, feature usage, errors, and site performance after you accept optional cookies.",
+    storage: "Cookie or local storage on lobbystack.com",
+  },
+  {
+    category: "Analytics and performance",
+    source: "PostHog",
+    name: "Session replay metadata",
+    duration: "Varies by session and browser settings",
+    purpose:
+      "Helps us understand usability issues after consent. Inputs are configured to be masked.",
+    storage: "Browser storage and PostHog service",
+  },
+]
+---
+
+<Layout
+  seo={{
+    title: "Cookie Policy - LobbyStack",
+    description:
+      "Cookie Policy for LobbyStack, including necessary cookies, analytics storage, browser controls, and cookie preferences.",
+    canonicalPath: "/cookie-policy/",
+    noindex: true,
+    jsonLd: [
+      organizationJsonLd(),
+      breadcrumbJsonLd([
+        { name: "Home", path: "/" },
+        { name: "Cookie Policy", path: "/cookie-policy/" },
+      ]),
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "@id": absoluteUrl("/cookie-policy/#webpage"),
+        name: "Cookie Policy - LobbyStack",
+        url: absoluteUrl("/cookie-policy/"),
+        description:
+          "Cookie Policy for LobbyStack, including necessary cookies, analytics storage, browser controls, and cookie preferences.",
+      },
+    ],
+  }}
+>
+  <Navbar />
+  <main class="bg-background text-foreground">
+    <section class="border-b border-border/60">
+      <div class="mx-auto max-w-4xl px-6 py-16 md:py-20">
+        <p class="text-sm font-medium text-muted-foreground">
+          Last updated: {updatedAt}
+        </p>
+        <h1 class="mt-4 text-4xl font-semibold tracking-tight md:text-5xl">
+          Cookie Policy
+        </h1>
+        <p
+          class="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg"
+        >
+          This Cookie Policy explains how Lobbystack Inc. ("LobbyStack," "we,"
+          "our," or "us") uses cookies and similar technologies when you visit
+          our website or interact with LobbyStack services.
+        </p>
+        <p class="mt-4 max-w-3xl text-sm leading-6 text-muted-foreground">
+          This page is provided for transparency and should be read together
+          with our <a class="underline" href="/privacy/">Privacy Policy</a>.
+        </p>
+      </div>
+    </section>
+
+    <section
+      class="mx-auto grid max-w-6xl gap-10 px-6 py-12 md:grid-cols-[220px_1fr] md:py-16"
+    >
+      <aside class="hidden md:block">
+        <nav class="sticky top-8 space-y-2 text-sm text-muted-foreground">
+          <a class="block hover:text-foreground" href="#overview">Overview</a>
+          <a class="block hover:text-foreground" href="#types">Types</a>
+          <a class="block hover:text-foreground" href="#cookies">Cookies</a>
+          <a class="block hover:text-foreground" href="#necessary"
+            >Necessary</a
+          >
+          <a class="block hover:text-foreground" href="#analytics"
+            >Analytics</a
+          >
+          <a class="block hover:text-foreground" href="#manage">Manage</a>
+          <a class="block hover:text-foreground" href="#changes">Changes</a>
+          <a class="block hover:text-foreground" href="#contact">Contact</a>
+        </nav>
+      </aside>
+
+      <article class="legal-copy max-w-none">
+        <section id="overview">
+          <h2>1. Overview</h2>
+          <p>
+            Cookies are small files or identifiers stored on your browser or
+            device. Similar technologies include local storage, pixels, web
+            beacons, SDK identifiers, and browser or device identifiers. We use
+            "cookies" in this policy to refer to these technologies together.
+          </p>
+          <p>
+            We use cookies to help this site function, understand service usage,
+            and support marketing efforts. Optional analytics and performance
+            cookies are used only after you accept them.
+          </p>
+        </section>
+
+        <section id="types">
+          <h2>2. Types of cookies and similar technologies</h2>
+          <h3>First-party technologies</h3>
+          <p>
+            First-party cookies and local storage are set by LobbyStack on our
+            own domains. They can remember your cookie choice, support basic
+            website functionality, and help operate features you choose to use.
+          </p>
+          <h3>Third-party technologies</h3>
+          <p>
+            Third-party technologies are provided by service providers that help
+            us operate, secure, analyze, or improve the website and service.
+            Some third-party services may process information according to their
+            own policies.
+          </p>
+        </section>
+
+        <section id="cookies">
+          <h2>3. Cookies and storage we use</h2>
+          <p>
+            The specific cookies and similar technologies we use may vary based
+            on your browser, region, privacy choices, and the pages or features
+            you use.
+          </p>
+          <div class="mt-6 overflow-x-auto">
+            <table>
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>Source</th>
+                  <th>Name or pattern</th>
+                  <th>Duration</th>
+                  <th>Purpose</th>
+                  <th>Domain or storage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  cookieRows.map((row) => (
+                    <tr>
+                      <td>{row.category}</td>
+                      <td>{row.source}</td>
+                      <td>{row.name}</td>
+                      <td>{row.duration}</td>
+                      <td>{row.purpose}</td>
+                      <td>{row.storage}</td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="necessary">
+          <h2>4. Necessary cookies</h2>
+          <p>
+            Necessary cookies and similar storage are required for basic site
+            functionality, security, abuse prevention, remembering your privacy
+            choice, and operating features you choose to use. They cannot be
+            turned off through LobbyStack's cookie banner.
+          </p>
+        </section>
+
+        <section id="analytics">
+          <h2>5. Analytics and performance cookies</h2>
+          <p>
+            If you select <strong>Accept all</strong>, we may use PostHog to
+            understand how visitors use the site, including page views,
+            interactions, CTA clicks, errors, feature usage, and performance
+            signals. We also configure session recording to mask inputs.
+          </p>
+          <p>
+            If you select <strong>Reject non-essential</strong>, we do not load
+            PostHog for landing-site analytics and we do not intentionally set
+            analytics cookies from the landing site.
+          </p>
+        </section>
+
+        <section id="manage">
+          <h2>6. Managing cookies</h2>
+          <p>
+            You can choose <strong>Accept all</strong> or
+            <strong>Reject non-essential</strong> in the cookie banner. You can
+            reopen the banner later using the
+            <strong>Cookie preferences</strong> control in the footer.
+          </p>
+          <p>
+            Your choice is specific to the browser and device you use. You can
+            also delete or block cookies and local storage through your browser
+            settings. Blocking all cookies may affect some website or service
+            functionality, but rejecting non-essential cookies does not block
+            access to the public website.
+          </p>
+        </section>
+
+        <section id="changes">
+          <h2>7. Changes to this policy</h2>
+          <p>
+            We may update this Cookie Policy from time to time as our website,
+            service providers, or cookie practices change. The date at the top
+            of this page shows when it was last updated.
+          </p>
+        </section>
+
+        <section id="contact">
+          <h2>8. Contact us</h2>
+          <p>
+            If you have questions about this Cookie Policy or our privacy
+            practices, contact
+            <a href="mailto:support@lobbystack.com">support@lobbystack.com</a>.
+          </p>
+        </section>
+      </article>
+    </section>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/landing/src/pages/fr/cookie-policy.astro
+++ b/apps/landing/src/pages/fr/cookie-policy.astro
@@ -1,0 +1,274 @@
+---
+import Layout from "@/layouts/main.astro"
+import { Navbar } from "@/components/Navbar"
+import { Footer } from "@/components/Footer"
+import { absoluteUrl, breadcrumbJsonLd, organizationJsonLd } from "@/lib/seo"
+
+const locale = "fr" as const
+const updatedAt = "12 juin 2026"
+const cookieRows = [
+  {
+    category: "Nécessaire",
+    source: "LobbyStack",
+    name: "lobbystack.cookieConsent.v1",
+    duration: "Jusqu'à suppression par l'utilisateur",
+    purpose:
+      "Enregistre si vous avez accepté ou refusé les cookies analytiques optionnels.",
+    storage: "Stockage local sur lobbystack.com",
+  },
+  {
+    category: "Nécessaire",
+    source: "LobbyStack",
+    name: "lobbystack.webVoiceVisitorId",
+    duration: "Jusqu'à suppression par l'utilisateur",
+    purpose:
+      "Aide à relier les sessions de démonstration vocale lorsque vous choisissez de démarrer un appel depuis le navigateur.",
+    storage: "Stockage local sur lobbystack.com",
+  },
+  {
+    category: "Nécessaire",
+    source: "Cloudflare",
+    name: "__cf_bm, cf_clearance, _cfuvid ou similaires",
+    duration: "Session à 1 an, selon le cookie",
+    purpose:
+      "Soutient la sécurité, la détection des robots, le routage du trafic et la prévention des abus.",
+    storage: "Cookie sur lobbystack.com ou domaines gérés par Cloudflare",
+  },
+  {
+    category: "Analytique et performance",
+    source: "PostHog",
+    name: "posthog*, ph_* et identifiants PostHog connexes",
+    duration: "Variable selon l'identifiant et les paramètres du navigateur",
+    purpose:
+      "Mesure les pages vues, clics CTA, usages, erreurs et performances après votre acceptation.",
+    storage: "Cookie ou stockage local sur lobbystack.com",
+  },
+  {
+    category: "Analytique et performance",
+    source: "PostHog",
+    name: "Métadonnées de relecture de session",
+    duration: "Variable selon la session et les paramètres du navigateur",
+    purpose:
+      "Nous aide à comprendre les problèmes d'utilisation après consentement. Les champs de saisie sont configurés pour être masqués.",
+    storage: "Stockage du navigateur et service PostHog",
+  },
+]
+---
+
+<Layout
+  seo={{
+    title: "Politique relative aux cookies - LobbyStack",
+    description:
+      "Politique relative aux cookies de LobbyStack, couvrant cookies nécessaires, stockage analytique, contrôles navigateur et préférences cookies.",
+    canonicalPath: "/fr/cookie-policy/",
+    locale,
+    noindex: true,
+    jsonLd: [
+      organizationJsonLd(),
+      breadcrumbJsonLd([
+        { name: "Accueil", path: "/fr/" },
+        { name: "Politique relative aux cookies", path: "/fr/cookie-policy/" },
+      ]),
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "@id": absoluteUrl("/fr/cookie-policy/#webpage"),
+        name: "Politique relative aux cookies - LobbyStack",
+        url: absoluteUrl("/fr/cookie-policy/"),
+        description:
+          "Politique relative aux cookies de LobbyStack, couvrant cookies nécessaires, stockage analytique, contrôles navigateur et préférences cookies.",
+      },
+    ],
+  }}
+>
+  <Navbar locale={locale} />
+  <main class="bg-background text-foreground">
+    <section class="border-b border-border/60">
+      <div class="mx-auto max-w-4xl px-6 py-16 md:py-20">
+        <p class="text-sm font-medium text-muted-foreground">
+          Dernière mise à jour : {updatedAt}
+        </p>
+        <h1 class="mt-4 text-4xl font-semibold tracking-tight md:text-5xl">
+          Politique relative aux cookies
+        </h1>
+        <p
+          class="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg"
+        >
+          Cette Politique explique comment Lobbystack Inc. ("LobbyStack",
+          "nous", "notre" ou "nos") utilise les cookies et technologies
+          similaires lorsque vous visitez notre site ou interagissez avec les
+          services LobbyStack.
+        </p>
+        <p class="mt-4 max-w-3xl text-sm leading-6 text-muted-foreground">
+          Cette page est fournie à des fins de transparence et doit être lue
+          avec notre
+          <a class="underline" href="/fr/privacy/">Politique de confidentialité</a>.
+        </p>
+      </div>
+    </section>
+
+    <section
+      class="mx-auto grid max-w-6xl gap-10 px-6 py-12 md:grid-cols-[220px_1fr] md:py-16"
+    >
+      <aside class="hidden md:block">
+        <nav class="sticky top-8 space-y-2 text-sm text-muted-foreground">
+          <a class="block hover:text-foreground" href="#overview">Aperçu</a>
+          <a class="block hover:text-foreground" href="#types">Types</a>
+          <a class="block hover:text-foreground" href="#cookies">Cookies</a>
+          <a class="block hover:text-foreground" href="#necessary"
+            >Nécessaires</a
+          >
+          <a class="block hover:text-foreground" href="#analytics"
+            >Analytique</a
+          >
+          <a class="block hover:text-foreground" href="#manage">Gérer</a>
+          <a class="block hover:text-foreground" href="#changes"
+            >Modifications</a
+          >
+          <a class="block hover:text-foreground" href="#contact">Contact</a>
+        </nav>
+      </aside>
+
+      <article class="legal-copy max-w-none">
+        <section id="overview">
+          <h2>1. Aperçu</h2>
+          <p>
+            Les cookies sont de petits fichiers ou identifiants stockés dans
+            votre navigateur ou sur votre appareil. Les technologies similaires
+            incluent le stockage local, les pixels, balises web, identifiants
+            SDK et identifiants de navigateur ou d'appareil. Dans cette
+            Politique, nous utilisons le terme "cookies" pour désigner ces
+            technologies ensemble.
+          </p>
+          <p>
+            Nous utilisons les cookies pour aider ce site à fonctionner,
+            comprendre l'utilisation du service et soutenir nos efforts
+            marketing. Les cookies analytiques et de performance optionnels ne
+            sont utilisés qu'après votre acceptation.
+          </p>
+        </section>
+
+        <section id="types">
+          <h2>2. Types de cookies et technologies similaires</h2>
+          <h3>Technologies internes</h3>
+          <p>
+            Les cookies et le stockage local internes sont définis par
+            LobbyStack sur nos propres domaines. Ils peuvent mémoriser votre
+            choix relatif aux cookies, soutenir les fonctions de base du site et
+            faire fonctionner les fonctionnalités que vous choisissez d'utiliser.
+          </p>
+          <h3>Technologies tierces</h3>
+          <p>
+            Les technologies tierces sont fournies par des prestataires qui nous
+            aident à exploiter, sécuriser, analyser ou améliorer le site et le
+            service. Certains services tiers peuvent traiter les informations
+            selon leurs propres politiques.
+          </p>
+        </section>
+
+        <section id="cookies">
+          <h2>3. Cookies et stockage que nous utilisons</h2>
+          <p>
+            Les cookies et technologies similaires utilisés peuvent varier selon
+            votre navigateur, votre région, vos choix de confidentialité et les
+            pages ou fonctionnalités utilisées.
+          </p>
+          <div class="mt-6 overflow-x-auto">
+            <table>
+              <thead>
+                <tr>
+                  <th>Catégorie</th>
+                  <th>Source</th>
+                  <th>Nom ou modèle</th>
+                  <th>Durée</th>
+                  <th>Objectif</th>
+                  <th>Domaine ou stockage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  cookieRows.map((row) => (
+                    <tr>
+                      <td>{row.category}</td>
+                      <td>{row.source}</td>
+                      <td>{row.name}</td>
+                      <td>{row.duration}</td>
+                      <td>{row.purpose}</td>
+                      <td>{row.storage}</td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="necessary">
+          <h2>4. Cookies nécessaires</h2>
+          <p>
+            Les cookies nécessaires et le stockage similaire sont requis pour
+            les fonctions de base du site, la sécurité, la prévention des abus,
+            la mémorisation de votre choix de confidentialité et le
+            fonctionnement des fonctionnalités que vous choisissez d'utiliser.
+            Ils ne peuvent pas être désactivés depuis la bannière cookies de
+            LobbyStack.
+          </p>
+        </section>
+
+        <section id="analytics">
+          <h2>5. Cookies analytiques et de performance</h2>
+          <p>
+            Si vous sélectionnez <strong>Tout accepter</strong>, nous pouvons
+            utiliser PostHog pour comprendre l'utilisation du site, notamment
+            pages vues, interactions, clics CTA, erreurs, usages de
+            fonctionnalités et signaux de performance. La relecture de session
+            est configurée pour masquer les champs de saisie.
+          </p>
+          <p>
+            Si vous sélectionnez <strong>Refuser le non essentiel</strong>, nous
+            ne chargeons pas PostHog pour l'analytique du site public et nous ne
+            définissons pas intentionnellement de cookies analytiques depuis le
+            site public.
+          </p>
+        </section>
+
+        <section id="manage">
+          <h2>6. Gérer les cookies</h2>
+          <p>
+            Vous pouvez choisir <strong>Tout accepter</strong> ou
+            <strong>Refuser le non essentiel</strong> dans la bannière cookies.
+            Vous pouvez rouvrir la bannière plus tard avec le contrôle
+            <strong>Préférences cookies</strong> dans le pied de page.
+          </p>
+          <p>
+            Votre choix est propre au navigateur et à l'appareil utilisés. Vous
+            pouvez aussi supprimer ou bloquer les cookies et le stockage local
+            dans les paramètres de votre navigateur. Bloquer tous les cookies
+            peut affecter certaines fonctionnalités du site ou du service, mais
+            refuser les cookies non essentiels ne bloque pas l'accès au site
+            public.
+          </p>
+        </section>
+
+        <section id="changes">
+          <h2>7. Modifications de cette politique</h2>
+          <p>
+            Nous pouvons mettre à jour cette Politique lorsque notre site, nos
+            prestataires ou nos pratiques cookies évoluent. La date en haut de
+            cette page indique la dernière mise à jour.
+          </p>
+        </section>
+
+        <section id="contact">
+          <h2>8. Nous contacter</h2>
+          <p>
+            Pour toute question sur cette Politique ou nos pratiques de
+            confidentialité, contactez
+            <a href="mailto:support@lobbystack.com">support@lobbystack.com</a>.
+          </p>
+        </section>
+      </article>
+    </section>
+  </main>
+  <Footer locale={locale} />
+</Layout>

--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -340,7 +340,9 @@ import { absoluteUrl, breadcrumbJsonLd, organizationJsonLd } from "@/lib/seo"
             preferences, understand product usage, improve performance, detect
             abuse, and measure marketing effectiveness. You can control some
             cookies through your browser settings, but disabling cookies may
-            affect service functionality.
+            affect service functionality. See our
+            <a href="/cookie-policy/">Cookie Policy</a> for more detail about
+            the cookies and similar technologies we use.
           </p>
         </section>
 

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -281,6 +281,23 @@
   @apply font-semibold text-foreground;
 }
 
+.legal-copy table {
+  @apply w-full min-w-[760px] border-separate border-spacing-0 overflow-hidden rounded-xl border border-border/70 text-left text-sm;
+}
+
+.legal-copy th,
+.legal-copy td {
+  @apply border-b border-border/60 px-4 py-3 align-top;
+}
+
+.legal-copy th {
+  @apply bg-muted/50 font-semibold text-foreground;
+}
+
+.legal-copy tbody tr:last-child td {
+  @apply border-b-0;
+}
+
 .blog-copy {
   @apply text-base leading-8 text-muted-foreground md:text-lg md:leading-9;
 }


### PR DESCRIPTION
## Summary
- Add a first-party cookie consent banner and persistence helpers for the landing experience
- Gate PostHog initialization behind consent and update middleware/layout wiring accordingly
- Add cookie policy and privacy content in English and French, with routing and i18n updates
- Refresh footer, legal page, and related UI pieces to surface the new policy
- Expand tests around cookie consent behavior and localization routing

## Testing
- Added and updated unit tests for cookie consent logic and i18n routing
- Not run (not requested)