### PR TITLE
Add country-aware phone onboarding and verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ LobbyStack can be adapted for many local business workflows:
 | SMS | Text conversations and booking outcomes connected to the same customer history. |
 | Dashboard | Calls, messages, contacts, appointments, recordings, transcripts, follow-ups, and analytics together. |
 | Usage and billing | Hosted plans, voice usage, alert SMS, outbound call attempts, storage, and metered add-ons. |
+| Bring your own API keys | Self-hosted deployments can use your own Convex, Twilio, OpenAI, calendar, email, analytics, and billing provider credentials. |
 
 ## Built With
 
@@ -114,7 +115,7 @@ LobbyStack is open source with a hosted cloud service.
 
 Use **LobbyStack Cloud** when you want the product managed for you. You still control the receptionist behavior, knowledge, services, rules, numbers, integrations, and team workflow from the app.
 
-Self-host when your team wants to run the stack on your own infrastructure with your own Convex, Twilio, OpenAI, calendar, analytics, billing, and email provider accounts.
+Self-host when your team wants to run the stack on your own infrastructure, bring your own API keys, and use your own Convex, Twilio, OpenAI, calendar, analytics, billing, and email provider accounts.
 
 Full product control in the hosted app. Infrastructure ownership when you self-host. Same open-source core either way.
 

--- a/apps/landing/src/components/LandingPageAdditions.tsx
+++ b/apps/landing/src/components/LandingPageAdditions.tsx
@@ -108,7 +108,7 @@ const homeSectionsCopy = {
     },
     pricing: {
       heading: "Start free. Upgrade when calls grow.",
-      body: "Try LobbyStack with starter usage, then move to predictable Pro pricing when you are ready for production call coverage.",
+      body: "Try LobbyStack with included usage, then move to Starter or Pro when you are ready for production call coverage.",
       badge: "Most Popular",
       viewDetails: "View pricing details",
       note: "No credit card required to start.",
@@ -117,13 +117,19 @@ const homeSectionsCopy = {
           name: "Free",
           price: "$0",
           description:
-            "Starter voice minutes, outbound call attempts, SMS alerts, appointment booking, summaries, and call history.",
+            "30 voice minutes, 10 alert SMS segments, 2 outbound call attempts, and all core receptionist features.",
+        },
+        {
+          name: "Starter",
+          price: "$30/mo",
+          description:
+            "150 voice minutes, 50 alert SMS segments, 20 outbound call attempts, and email support.",
         },
         {
           name: "Pro",
-          price: "$15/mo",
+          price: "$100/mo",
           description:
-            "Higher included limits, usage-based billing, and priority email support.",
+            "500 voice minutes, 200 alert SMS segments, 100 outbound call attempts, and priority email support.",
         },
         {
           name: "Enterprise",
@@ -246,7 +252,7 @@ const homeSectionsCopy = {
     pricing: {
       heading:
         "Commencez gratuitement. Passez au forfait supérieur quand les appels augmentent.",
-      body: "Essayez LobbyStack avec le volume de départ, puis passez à un forfait Pro prévisible quand vous êtes prêt à couvrir vos appels en production.",
+      body: "Essayez LobbyStack avec l’usage inclus, puis passez à Starter ou Pro quand vous êtes prêt à couvrir vos appels en production.",
       badge: "Le plus populaire",
       viewDetails: "Voir le détail des tarifs",
       note: "Aucune carte bancaire requise pour commencer.",
@@ -255,13 +261,19 @@ const homeSectionsCopy = {
           name: "Free",
           price: "$0",
           description:
-            "Minutes vocales de départ, appels sortants, alertes SMS, prise de rendez‑vous, résumés et historique d’appels.",
+            "30 minutes vocales, 10 segments SMS d’alerte, 2 appels sortants et toutes les fonctionnalités de réception.",
+        },
+        {
+          name: "Starter",
+          price: "$30/mois",
+          description:
+            "150 minutes vocales, 50 segments SMS d’alerte, 20 appels sortants et support par courriel.",
         },
         {
           name: "Pro",
-          price: "$15/mo",
+          price: "$100/mois",
           description:
-            "Limites incluses plus élevées, facturation à l’usage et support prioritaire par courriel.",
+            "500 minutes vocales, 200 segments SMS d’alerte, 100 appels sortants et support prioritaire par courriel.",
         },
         {
           name: "Enterprise",
@@ -509,9 +521,9 @@ function PricingPreviewSection({ locale = "en" }: LocalizedProps) {
           <p className="section-intro">{sectionCopy.body}</p>
         </div>
 
-        <div className="mt-16 grid gap-6 lg:grid-cols-3">
-          {sectionCopy.plans.map((plan, index) => {
-            const isPro = index === 1
+        <div className="mt-16 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          {sectionCopy.plans.map((plan) => {
+            const isPro = plan.name === "Pro"
             return (
               <article
                 key={plan.name}

--- a/apps/landing/src/components/calculator/MissedCallCalculator.tsx
+++ b/apps/landing/src/components/calculator/MissedCallCalculator.tsx
@@ -32,9 +32,7 @@ const copy = {
     trade: "Trade / Industry",
     selectTrade: "Select a trade",
     missedCalls: "Missed calls per week",
-    missedCallsHint: (max: number) => `Use 0 to ${max} missed calls per week.`,
     averageJobValue: "Average job value ($)",
-    averageJobValueHint: (value: string) => `Estimate up to ${value} per job.`,
     opportunityRate: "% of calls that are real jobs",
     bookingRate: "Booking rate if answered",
     monthlyRevenue: "Monthly Revenue at Risk",
@@ -61,11 +59,7 @@ const copy = {
     trade: "Métier / secteur",
     selectTrade: "Sélectionner un métier",
     missedCalls: "Appels manqués par semaine",
-    missedCallsHint: (max: number) =>
-      `Utilisez une valeur entre 0 et ${max} appels manqués par semaine.`,
     averageJobValue: "Valeur moyenne d’un travail ($)",
-    averageJobValueHint: (value: string) =>
-      `Estimez jusqu’à ${value} par travail.`,
     opportunityRate: "% d’appels qui sont de vraies occasions",
     bookingRate: "Taux de réservation quand l’appel est pris",
     monthlyRevenue: "Revenu mensuel à risque",
@@ -95,9 +89,7 @@ const copy = {
     trade: string
     selectTrade: string
     missedCalls: string
-    missedCallsHint: (max: number) => string
     averageJobValue: string
-    averageJobValueHint: (value: string) => string
     opportunityRate: string
     bookingRate: string
     monthlyRevenue: string
@@ -200,19 +192,12 @@ export function MissedCallCalculator({ locale = "en" }: { locale?: Locale }) {
                 inputMode="numeric"
                 min={0}
                 max={MAX_MISSED_CALLS_PER_WEEK}
-                aria-describedby="missed-calls-hint"
                 value={calls}
                 onChange={handleNumberChange(
                   setCalls,
                   MAX_MISSED_CALLS_PER_WEEK
                 )}
               />
-              <p
-                id="missed-calls-hint"
-                className="mt-2 text-xs text-muted-foreground"
-              >
-                {t.missedCallsHint(MAX_MISSED_CALLS_PER_WEEK)}
-              </p>
             </div>
             <div>
               <label
@@ -227,19 +212,12 @@ export function MissedCallCalculator({ locale = "en" }: { locale?: Locale }) {
                 inputMode="numeric"
                 min={0}
                 max={MAX_AVERAGE_JOB_VALUE}
-                aria-describedby="average-job-value-hint"
                 value={jobValue}
                 onChange={handleNumberChange(
                   setJobValue,
                   MAX_AVERAGE_JOB_VALUE
                 )}
               />
-              <p
-                id="average-job-value-hint"
-                className="mt-2 text-xs text-muted-foreground"
-              >
-                {t.averageJobValueHint(formatCurrency(MAX_AVERAGE_JOB_VALUE))}
-              </p>
             </div>
           </div>
 

--- a/apps/landing/src/components/calculator/MissedCallCalculator.tsx
+++ b/apps/landing/src/components/calculator/MissedCallCalculator.tsx
@@ -113,6 +113,10 @@ function clampNumber(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
 
+function getSliderValue(value: number | readonly number[]) {
+  return Array.isArray(value) ? value[0] : value
+}
+
 export function MissedCallCalculator({ locale = "en" }: { locale?: Locale }) {
   const t = copy[locale]
   const [trade, setTrade] = useState<keyof typeof TRADES>("Custom")
@@ -253,14 +257,12 @@ export function MissedCallCalculator({ locale = "en" }: { locale?: Locale }) {
                 </span>
               </div>
               <Slider
-                value={[oppRate]}
+                value={oppRate}
                 min={0}
                 max={100}
                 aria-labelledby="opportunity-rate-label"
                 onValueChange={(value) =>
-                  setOppRate(
-                    clampNumber(Array.isArray(value) ? value[0] : value, 0, 100)
-                  )
+                  setOppRate(clampNumber(getSliderValue(value), 0, 100))
                 }
               />
             </div>
@@ -275,14 +277,12 @@ export function MissedCallCalculator({ locale = "en" }: { locale?: Locale }) {
                 </span>
               </div>
               <Slider
-                value={[bookRate]}
+                value={bookRate}
                 min={0}
                 max={100}
                 aria-labelledby="booking-rate-label"
                 onValueChange={(value) =>
-                  setBookRate(
-                    clampNumber(Array.isArray(value) ? value[0] : value, 0, 100)
-                  )
+                  setBookRate(clampNumber(getSliderValue(value), 0, 100))
                 }
               />
             </div>

--- a/apps/landing/src/components/ui/slider.tsx
+++ b/apps/landing/src/components/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
+    : typeof value === "number"
+      ? [value]
     : Array.isArray(defaultValue)
       ? defaultValue
-      : [min, max]
+      : typeof defaultValue === "number"
+        ? [defaultValue]
+        : [min, max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/web/public/locales/en/onboarding.json
+++ b/apps/web/public/locales/en/onboarding.json
@@ -77,10 +77,8 @@
     "title": "Let's verify you're real",
     "description": "",
     "fields": {
-      "mobileNumber": "Mobile number"
-    },
-    "placeholders": {
-      "mobileNumber": "+1 555 123 4567"
+      "mobileNumber": "Mobile number",
+      "region": "Region"
     },
     "hint": "Use a personal mobile number that can receive SMS.",
     "sendCode": "Send code",

--- a/apps/web/public/locales/fr/onboarding.json
+++ b/apps/web/public/locales/fr/onboarding.json
@@ -77,10 +77,8 @@
     "title": "Vérifions votre identité",
     "description": "",
     "fields": {
-      "mobileNumber": "Numéro de mobile"
-    },
-    "placeholders": {
-      "mobileNumber": "+1 555 123 4567"
+      "mobileNumber": "Numéro de mobile",
+      "region": "Région"
     },
     "hint": "Utilisez un numéro de mobile personnel qui peut recevoir des SMS.",
     "sendCode": "Envoyer le code",

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -158,7 +158,7 @@ describe("PhoneInput", () => {
     expect(screen.getByTestId("phone-value").textContent).toBe("+61412345678");
   });
 
-  it("prevents pasting too many national digits", async () => {
+  it("clips pasted input to the selected country's national digit limit", async () => {
     const user = userEvent.setup();
 
     render(<PhoneInputHarness country="US" limitNationalDigits />);
@@ -167,8 +167,8 @@ describe("PhoneInput", () => {
     await user.click(input);
     await user.paste("213373425399");
 
-    expect((input as HTMLInputElement).value).toBe("");
-    expect(screen.getByTestId("phone-value").textContent).toBe("");
+    expect((input as HTMLInputElement).value).toBe("(213) 373-4253");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+12133734253");
   });
 
   it("allows deleting and retyping after extra digits hit the national limit", async () => {
@@ -186,6 +186,23 @@ describe("PhoneInput", () => {
     expect(input.value).toBe("(213) 373-42");
 
     await user.type(input, "99");
+
+    expect(input.value).toBe("(213) 373-4299");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+12133734299");
+  });
+
+  it("keeps US input editable across repeated delete and retype cycles", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="US" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    await user.type(input, "2133734253");
+
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      await user.keyboard("[Backspace][Backspace]");
+      await user.type(input, "99");
+    }
 
     expect(input.value).toBe("(213) 373-4299");
     expect(screen.getByTestId("phone-value").textContent).toBe("+12133734299");

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -6,10 +6,12 @@ import { describe, expect, it } from "vitest";
 import { PhoneInput } from "@/components/ui/phone-input";
 
 function PhoneInputHarness({
+  country,
   defaultCountry = "US",
   locale = "en-US",
 }: {
-  defaultCountry?: "US" | "CA" | "FR";
+  country?: "US" | "CA" | "FR" | "GB";
+  defaultCountry?: "US" | "CA" | "FR" | "GB";
   locale?: string;
 }) {
   const [value, setValue] = React.useState<string | undefined>();
@@ -22,6 +24,7 @@ function PhoneInputHarness({
         locale={locale}
         onChange={setValue}
         value={value}
+        {...(country !== undefined ? { country } : {})}
       />
       <output data-testid="phone-value">{value ?? ""}</output>
     </div>
@@ -46,6 +49,15 @@ describe("PhoneInput", () => {
     await user.type(screen.getByRole("textbox", { name: "Phone" }), "612345678");
 
     expect(screen.getByTestId("phone-value").textContent).toBe("+33612345678");
+  });
+
+  it("uses the configured fixed country for parsing", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="GB" defaultCountry="US" locale="en-US" />);
+    await user.type(screen.getByRole("textbox", { name: "Phone" }), "7911123456");
+
+    expect(screen.getByTestId("phone-value").textContent).toBe("+447911123456");
   });
 
   it("clears back to an empty value", async () => {

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -156,4 +156,22 @@ describe("PhoneInput", () => {
     expect((input as HTMLInputElement).value).toBe("");
     expect(screen.getByTestId("phone-value").textContent).toBe("");
   });
+
+  it("allows deleting and retyping after extra digits hit the national limit", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="US" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    await user.type(input, "213373425399");
+    expect(input.value).toBe("(213) 373-4253");
+
+    await user.keyboard("[Backspace][Backspace]");
+    expect(input.value).toBe("(213) 373-42");
+
+    await user.type(input, "99");
+
+    expect(input.value).toBe("(213) 373-4299");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+12133734299");
+  });
 });

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -142,8 +142,20 @@ describe("PhoneInput", () => {
 
     await user.type(input, "79111234567");
 
-    expect(input.value).toBe("7911123456");
+    expect(input.value).toBe("7911 123456");
     expect(screen.getByTestId("phone-value").textContent).toBe("+447911123456");
+  });
+
+  it("formats Australian input when the national trunk prefix is omitted", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="AU" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    await user.type(input, "4123456789");
+
+    expect(input.value).toBe("412 345 678");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+61412345678");
   });
 
   it("prevents pasting too many national digits", async () => {

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -171,6 +171,19 @@ describe("PhoneInput", () => {
     expect(screen.getByTestId("phone-value").textContent).toBe("+12133734253");
   });
 
+  it("accepts pasted North American numbers with a leading country code", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="US" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" });
+    await user.click(input);
+    await user.paste("1 (213) 373-4253");
+
+    expect((input as HTMLInputElement).value).toBe("(213) 373-4253");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+12133734253");
+  });
+
   it("allows deleting and retyping after extra digits hit the national limit", async () => {
     const user = userEvent.setup();
 

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -10,8 +10,8 @@ function PhoneInputHarness({
   defaultCountry = "US",
   locale = "en-US",
 }: {
-  country?: "US" | "CA" | "FR" | "GB";
-  defaultCountry?: "US" | "CA" | "FR" | "GB";
+  country?: "US" | "CA" | "FR" | "GB" | "AU";
+  defaultCountry?: "US" | "CA" | "FR" | "GB" | "AU";
   locale?: string;
 }) {
   const [value, setValue] = React.useState<string | undefined>();
@@ -85,5 +85,20 @@ describe("PhoneInput", () => {
 
     expect(input.value).toBe("(231) 23");
     expect(input.value).not.toBe("(231) 232-1");
+  });
+
+  it("allows deleting partial input with a fixed country", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="AU" defaultCountry="US" locale="en-US" />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    await user.type(input, "0412345");
+    const valueBeforeBackspace = input.value;
+
+    await user.keyboard("[Backspace]");
+
+    expect(input.value).not.toBe(valueBeforeBackspace);
+    expect(input.value.length).toBeLessThan(valueBeforeBackspace.length);
   });
 });

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -123,11 +123,12 @@ describe("PhoneInput", () => {
 
     render(<PhoneInputHarness country="AU" limitNationalDigits />);
 
-    await user.type(screen.getByRole("textbox", { name: "Phone" }), "04123456789");
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    expect(input.maxLength).toBe(-1);
 
-    expect((screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement).value).toBe(
-      "0412 345 678",
-    );
+    await user.type(input, "04123456789");
+
+    expect(input.value).toBe("0412 345 678");
     expect(screen.getByTestId("phone-value").textContent).toBe("+61412345678");
   });
 
@@ -136,11 +137,12 @@ describe("PhoneInput", () => {
 
     render(<PhoneInputHarness country="GB" limitNationalDigits />);
 
-    await user.type(screen.getByRole("textbox", { name: "Phone" }), "79111234567");
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    expect(input.maxLength).toBe(-1);
 
-    expect((screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement).value).toBe(
-      "7911123456",
-    );
+    await user.type(input, "79111234567");
+
+    expect(input.value).toBe("7911123456");
     expect(screen.getByTestId("phone-value").textContent).toBe("+447911123456");
   });
 
@@ -163,6 +165,8 @@ describe("PhoneInput", () => {
     render(<PhoneInputHarness country="US" limitNationalDigits />);
 
     const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    expect(input.maxLength).toBe(-1);
+
     await user.type(input, "213373425399");
     expect(input.value).toBe("(213) 373-4253");
 
@@ -173,5 +177,41 @@ describe("PhoneInput", () => {
 
     expect(input.value).toBe("(213) 373-4299");
     expect(screen.getByTestId("phone-value").textContent).toBe("+12133734299");
+  });
+
+  it("allows deleting and retyping after hitting the Australian national limit", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="AU" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    await user.type(input, "04123456789");
+    expect(input.value).toBe("0412 345 678");
+
+    await user.keyboard("[Backspace][Backspace]");
+    expect(input.value).toBe("0412 345 6");
+
+    await user.type(input, "99");
+
+    expect(input.value).toBe("0412 345 699");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+61412345699");
+  });
+
+  it("allows deleting and retyping after hitting the UK national limit", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="GB" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement;
+    await user.type(input, "071231234569");
+    expect(input.value).toBe("07123 123456");
+
+    await user.keyboard("[Backspace][Backspace]");
+    expect(input.value).toBe("07123 1234");
+
+    await user.type(input, "99");
+
+    expect(input.value).toBe("07123 123499");
+    expect(screen.getByTestId("phone-value").textContent).toBe("+447123123499");
   });
 });

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -8,10 +8,12 @@ import { PhoneInput } from "@/components/ui/phone-input";
 function PhoneInputHarness({
   country,
   defaultCountry = "US",
+  limitNationalDigits = false,
   locale = "en-US",
 }: {
   country?: "US" | "CA" | "FR" | "GB" | "AU";
   defaultCountry?: "US" | "CA" | "FR" | "GB" | "AU";
+  limitNationalDigits?: boolean;
   locale?: string;
 }) {
   const [value, setValue] = React.useState<string | undefined>();
@@ -21,6 +23,7 @@ function PhoneInputHarness({
       <PhoneInput
         aria-label="Phone"
         defaultCountry={defaultCountry}
+        limitNationalDigits={limitNationalDigits}
         locale={locale}
         onChange={setValue}
         value={value}
@@ -100,5 +103,57 @@ describe("PhoneInput", () => {
 
     expect(input.value).not.toBe(valueBeforeBackspace);
     expect(input.value.length).toBeLessThan(valueBeforeBackspace.length);
+  });
+
+  it("limits US input to ten national digits without counting formatting", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="US" limitNationalDigits />);
+
+    await user.type(screen.getByRole("textbox", { name: "Phone" }), "21337342539");
+
+    expect((screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement).value).toBe(
+      "(213) 373-4253",
+    );
+    expect(screen.getByTestId("phone-value").textContent).toBe("+12133734253");
+  });
+
+  it("limits Australian input to the mobile length with the national trunk prefix", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="AU" limitNationalDigits />);
+
+    await user.type(screen.getByRole("textbox", { name: "Phone" }), "04123456789");
+
+    expect((screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement).value).toBe(
+      "0412 345 678",
+    );
+    expect(screen.getByTestId("phone-value").textContent).toBe("+61412345678");
+  });
+
+  it("limits UK input to ten digits when the national trunk prefix is omitted", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="GB" limitNationalDigits />);
+
+    await user.type(screen.getByRole("textbox", { name: "Phone" }), "79111234567");
+
+    expect((screen.getByRole("textbox", { name: "Phone" }) as HTMLInputElement).value).toBe(
+      "7911123456",
+    );
+    expect(screen.getByTestId("phone-value").textContent).toBe("+447911123456");
+  });
+
+  it("prevents pasting too many national digits", async () => {
+    const user = userEvent.setup();
+
+    render(<PhoneInputHarness country="US" limitNationalDigits />);
+
+    const input = screen.getByRole("textbox", { name: "Phone" });
+    await user.click(input);
+    await user.paste("213373425399");
+
+    expect((input as HTMLInputElement).value).toBe("");
+    expect(screen.getByTestId("phone-value").textContent).toBe("");
   });
 });

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import PhoneNumberInput, { getCountryCallingCode } from "react-phone-number-input/input";
+import PhoneNumberInput from "react-phone-number-input/input";
 import type { Country } from "react-phone-number-input/input";
 
 import { inputClassName } from "@/components/ui/input";
@@ -45,22 +45,6 @@ function exceedsNationalDigitLimit(
   const limit = getPhoneNationalDigitLimit(country, nextDigits);
 
   return limit !== undefined && nextDigits.length > limit;
-}
-
-function getPhoneInputMaxLength(
-  country: Country | undefined,
-  placeholder: string,
-): number | undefined {
-  if (!country) {
-    return undefined;
-  }
-
-  const nationalLimit = getPhoneNationalDigitLimit(country);
-  if (nationalLimit === undefined) {
-    return undefined;
-  }
-
-  return Math.max(placeholder.length, `+${getCountryCallingCode(country)}`.length + nationalLimit);
 }
 
 const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextInputProps>(
@@ -113,11 +97,6 @@ export function PhoneInput({
   const resolvedPlaceholder = props.placeholder ?? getPhonePlaceholder(locale, {
     defaultCountry: resolvedDefaultCountry,
   });
-  const maxLength =
-    props.maxLength ??
-    (limitNationalDigits
-      ? getPhoneInputMaxLength(resolvedDefaultCountry as Country, resolvedPlaceholder)
-      : undefined);
   const inputComponent = React.useMemo(() => {
     if (!limitNationalDigits) {
       return PhoneNumberTextInput;
@@ -152,7 +131,6 @@ export function PhoneInput({
         placeholder={resolvedPlaceholder}
         smartCaret={false}
         type={props.type ?? "tel"}
-        {...(maxLength !== undefined ? { maxLength } : {})}
         {...(country !== undefined ? { country } : {})}
         {...(country === undefined ? { defaultCountry: resolvedDefaultCountry as Country } : {})}
         {...(value !== undefined ? { value } : {})}

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -60,7 +60,6 @@ export function PhoneInput({
       <PhoneNumberInput
         {...props}
         autoComplete={props.autoComplete ?? "tel"}
-        defaultCountry={resolvedDefaultCountry as Country}
         disabled={disabled}
         inputMode={props.inputMode ?? "tel"}
         inputComponent={PhoneNumberTextInput}
@@ -69,6 +68,7 @@ export function PhoneInput({
         placeholder={resolvedPlaceholder}
         type={props.type ?? "tel"}
         {...(country !== undefined ? { country } : {})}
+        {...(country === undefined ? { defaultCountry: resolvedDefaultCountry as Country } : {})}
         {...(value !== undefined ? { value } : {})}
       />
     </div>

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -4,7 +4,11 @@ import type { Country } from "react-phone-number-input/input";
 
 import { inputClassName } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { getDefaultPhoneCountry, getPhonePlaceholder } from "@/lib/phone";
+import {
+  getDefaultPhoneCountry,
+  getPhoneNationalDigitLimit,
+  getPhonePlaceholder,
+} from "@/lib/phone";
 
 type PhoneInputProps = Omit<
   React.ComponentProps<"input">,
@@ -14,23 +18,111 @@ type PhoneInputProps = Omit<
   country?: Country;
   defaultCountry?: Country;
   locale?: string | null;
+  limitNationalDigits?: boolean;
   onChange?: (value?: string) => void;
   onRawValueChange?: (value: string) => void;
   value?: string | undefined;
 };
 
 type PhoneNumberTextInputProps = React.ComponentProps<"input"> & {
+  nationalDigitLimitCountry?: Country;
   onRawValueChange?: (value: string) => void;
 };
 
+function getDigits(value: string): string {
+  return value.replace(/\D/g, "");
+}
+
+function shouldPreventNationalDigitInsertion(
+  input: HTMLInputElement,
+  insertedText: string,
+  country: Country | undefined,
+): boolean {
+  if (!country || insertedText.includes("+") || input.value.trim().startsWith("+")) {
+    return false;
+  }
+
+  const insertedDigits = getDigits(insertedText);
+  if (!insertedDigits) {
+    return false;
+  }
+
+  const selectionStart = input.selectionStart ?? input.value.length;
+  const selectionEnd = input.selectionEnd ?? selectionStart;
+  const nextValue = `${input.value.slice(0, selectionStart)}${insertedText}${input.value.slice(
+    selectionEnd,
+  )}`;
+  const nextDigits = getDigits(nextValue);
+  const limit = getPhoneNationalDigitLimit(country, nextDigits);
+
+  return limit !== undefined && nextDigits.length > limit;
+}
+
 const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextInputProps>(
-  ({ className, onChange, onRawValueChange, ...props }, ref) => (
+  (
+    {
+      className,
+      nationalDigitLimitCountry,
+      onBeforeInput,
+      onChange,
+      onKeyDown,
+      onPaste,
+      onRawValueChange,
+      ...props
+    },
+    ref,
+  ) => (
     <input
       ref={ref}
       className={cn(inputClassName, className)}
+      onBeforeInput={(event) => {
+        const inputEvent = event.nativeEvent as InputEvent;
+        if (
+          inputEvent.data &&
+          shouldPreventNationalDigitInsertion(
+            event.currentTarget,
+            inputEvent.data,
+            nationalDigitLimitCountry,
+          )
+        ) {
+          event.preventDefault();
+          return;
+        }
+
+        onBeforeInput?.(event);
+      }}
       onChange={(event) => {
         onRawValueChange?.(event.target.value);
         onChange?.(event);
+      }}
+      onKeyDown={(event) => {
+        if (
+          event.key.length === 1 &&
+          shouldPreventNationalDigitInsertion(
+            event.currentTarget,
+            event.key,
+            nationalDigitLimitCountry,
+          )
+        ) {
+          event.preventDefault();
+          return;
+        }
+
+        onKeyDown?.(event);
+      }}
+      onPaste={(event) => {
+        if (
+          shouldPreventNationalDigitInsertion(
+            event.currentTarget,
+            event.clipboardData.getData("text"),
+            nationalDigitLimitCountry,
+          )
+        ) {
+          event.preventDefault();
+          return;
+        }
+
+        onPaste?.(event);
       }}
       {...props}
     />
@@ -44,6 +136,7 @@ export function PhoneInput({
   country,
   defaultCountry,
   disabled,
+  limitNationalDigits,
   locale,
   onChange,
   onRawValueChange,
@@ -54,6 +147,26 @@ export function PhoneInput({
   const resolvedPlaceholder = props.placeholder ?? getPhonePlaceholder(locale, {
     defaultCountry: resolvedDefaultCountry,
   });
+  const inputComponent = React.useMemo(() => {
+    if (!limitNationalDigits) {
+      return PhoneNumberTextInput;
+    }
+
+    const nationalDigitLimitCountry = resolvedDefaultCountry as Country;
+    const LimitedPhoneNumberTextInput = React.forwardRef<
+      HTMLInputElement,
+      PhoneNumberTextInputProps
+    >((inputProps, ref) => (
+      <PhoneNumberTextInput
+        {...inputProps}
+        ref={ref}
+        nationalDigitLimitCountry={nationalDigitLimitCountry}
+      />
+    ));
+    LimitedPhoneNumberTextInput.displayName = "LimitedPhoneNumberTextInput";
+
+    return LimitedPhoneNumberTextInput;
+  }, [limitNationalDigits, resolvedDefaultCountry]);
 
   return (
     <div className={cn("w-full", containerClassName)}>
@@ -62,7 +175,7 @@ export function PhoneInput({
         autoComplete={props.autoComplete ?? "tel"}
         disabled={disabled}
         inputMode={props.inputMode ?? "tel"}
-        inputComponent={PhoneNumberTextInput}
+        inputComponent={inputComponent}
         onChange={(nextValue) => onChange?.(nextValue)}
         onRawValueChange={onRawValueChange}
         placeholder={resolvedPlaceholder}

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import PhoneNumberInput from "react-phone-number-input/input";
+import PhoneNumberInput, { getCountryCallingCode } from "react-phone-number-input/input";
 import type { Country } from "react-phone-number-input/input";
 
 import { inputClassName } from "@/components/ui/input";
@@ -33,29 +33,34 @@ function getDigits(value: string): string {
   return value.replace(/\D/g, "");
 }
 
-function shouldPreventNationalDigitInsertion(
-  input: HTMLInputElement,
-  insertedText: string,
+function exceedsNationalDigitLimit(
+  value: string,
   country: Country | undefined,
 ): boolean {
-  if (!country || insertedText.includes("+") || input.value.trim().startsWith("+")) {
+  if (!country || value.trim().startsWith("+")) {
     return false;
   }
 
-  const insertedDigits = getDigits(insertedText);
-  if (!insertedDigits) {
-    return false;
-  }
-
-  const selectionStart = input.selectionStart ?? input.value.length;
-  const selectionEnd = input.selectionEnd ?? selectionStart;
-  const nextValue = `${input.value.slice(0, selectionStart)}${insertedText}${input.value.slice(
-    selectionEnd,
-  )}`;
-  const nextDigits = getDigits(nextValue);
+  const nextDigits = getDigits(value);
   const limit = getPhoneNationalDigitLimit(country, nextDigits);
 
   return limit !== undefined && nextDigits.length > limit;
+}
+
+function getPhoneInputMaxLength(
+  country: Country | undefined,
+  placeholder: string,
+): number | undefined {
+  if (!country) {
+    return undefined;
+  }
+
+  const nationalLimit = getPhoneNationalDigitLimit(country);
+  if (nationalLimit === undefined) {
+    return undefined;
+  }
+
+  return Math.max(placeholder.length, `+${getCountryCallingCode(country)}`.length + nationalLimit);
 }
 
 const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextInputProps>(
@@ -63,11 +68,9 @@ const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextI
     {
       className,
       nationalDigitLimitCountry,
-      onBeforeInput,
       onChange,
-      onKeyDown,
-      onPaste,
       onRawValueChange,
+      value,
       ...props
     },
     ref,
@@ -75,55 +78,18 @@ const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextI
     <input
       ref={ref}
       className={cn(inputClassName, className)}
-      onBeforeInput={(event) => {
-        const inputEvent = event.nativeEvent as InputEvent;
-        if (
-          inputEvent.data &&
-          shouldPreventNationalDigitInsertion(
-            event.currentTarget,
-            inputEvent.data,
-            nationalDigitLimitCountry,
-          )
-        ) {
-          event.preventDefault();
+      onChange={(event) => {
+        if (exceedsNationalDigitLimit(event.target.value, nationalDigitLimitCountry)) {
+          const previousValue = typeof value === "string" ? value : "";
+          event.currentTarget.value = previousValue;
+          event.currentTarget.setSelectionRange(previousValue.length, previousValue.length);
           return;
         }
 
-        onBeforeInput?.(event);
-      }}
-      onChange={(event) => {
         onRawValueChange?.(event.target.value);
         onChange?.(event);
       }}
-      onKeyDown={(event) => {
-        if (
-          event.key.length === 1 &&
-          shouldPreventNationalDigitInsertion(
-            event.currentTarget,
-            event.key,
-            nationalDigitLimitCountry,
-          )
-        ) {
-          event.preventDefault();
-          return;
-        }
-
-        onKeyDown?.(event);
-      }}
-      onPaste={(event) => {
-        if (
-          shouldPreventNationalDigitInsertion(
-            event.currentTarget,
-            event.clipboardData.getData("text"),
-            nationalDigitLimitCountry,
-          )
-        ) {
-          event.preventDefault();
-          return;
-        }
-
-        onPaste?.(event);
-      }}
+      value={value}
       {...props}
     />
   ),
@@ -147,6 +113,11 @@ export function PhoneInput({
   const resolvedPlaceholder = props.placeholder ?? getPhonePlaceholder(locale, {
     defaultCountry: resolvedDefaultCountry,
   });
+  const maxLength =
+    props.maxLength ??
+    (limitNationalDigits
+      ? getPhoneInputMaxLength(resolvedDefaultCountry as Country, resolvedPlaceholder)
+      : undefined);
   const inputComponent = React.useMemo(() => {
     if (!limitNationalDigits) {
       return PhoneNumberTextInput;
@@ -180,6 +151,7 @@ export function PhoneInput({
         onRawValueChange={onRawValueChange}
         placeholder={resolvedPlaceholder}
         type={props.type ?? "tel"}
+        {...(maxLength !== undefined ? { maxLength } : {})}
         {...(country !== undefined ? { country } : {})}
         {...(country === undefined ? { defaultCountry: resolvedDefaultCountry as Country } : {})}
         {...(value !== undefined ? { value } : {})}

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -11,6 +11,7 @@ type PhoneInputProps = Omit<
   "defaultValue" | "onChange" | "value"
 > & {
   containerClassName?: string;
+  country?: Country;
   defaultCountry?: Country;
   locale?: string | null;
   onChange?: (value?: string) => void;
@@ -40,6 +41,7 @@ PhoneNumberTextInput.displayName = "PhoneNumberTextInput";
 
 export function PhoneInput({
   containerClassName,
+  country,
   defaultCountry,
   disabled,
   locale,
@@ -48,7 +50,7 @@ export function PhoneInput({
   value,
   ...props
 }: PhoneInputProps) {
-  const resolvedDefaultCountry = defaultCountry ?? getDefaultPhoneCountry(locale);
+  const resolvedDefaultCountry = country ?? defaultCountry ?? getDefaultPhoneCountry(locale);
   const resolvedPlaceholder = props.placeholder ?? getPhonePlaceholder(locale, {
     defaultCountry: resolvedDefaultCountry,
   });
@@ -66,6 +68,7 @@ export function PhoneInput({
         onRawValueChange={onRawValueChange}
         placeholder={resolvedPlaceholder}
         type={props.type ?? "tel"}
+        {...(country !== undefined ? { country } : {})}
         {...(value !== undefined ? { value } : {})}
       />
     </div>

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -7,26 +7,27 @@ import { cn } from "@/lib/utils";
 import {
   formatPhoneNationalInput,
   getDefaultPhoneCountry,
+  getPhoneNationalInputValue,
   getPhoneNationalDigitLimit,
   getPhonePlaceholder,
+  normalizePhoneNumber,
 } from "@/lib/phone";
 
 type PhoneInputProps = Omit<
   React.ComponentProps<"input">,
   "defaultValue" | "onChange" | "value"
 > & {
-  containerClassName?: string;
-  country?: Country;
-  defaultCountry?: Country;
-  locale?: string | null;
-  limitNationalDigits?: boolean;
-  onChange?: (value?: string) => void;
-  onRawValueChange?: (value: string) => void;
+  containerClassName?: string | undefined;
+  country?: Country | undefined;
+  defaultCountry?: Country | undefined;
+  locale?: string | null | undefined;
+  limitNationalDigits?: boolean | undefined;
+  onChange?: ((value?: string) => void) | undefined;
+  onRawValueChange?: ((value: string) => void) | undefined;
   value?: string | undefined;
 };
 
 type PhoneNumberTextInputProps = React.ComponentProps<"input"> & {
-  nationalDigitLimitCountry?: Country;
   onRawValueChange?: (value: string) => void;
 };
 
@@ -34,53 +35,24 @@ function getDigits(value: string): string {
   return value.replace(/\D/g, "");
 }
 
-function exceedsNationalDigitLimit(
-  value: string,
-  country: Country | undefined,
-): boolean {
-  if (!country || value.trim().startsWith("+")) {
-    return false;
-  }
-
-  const nextDigits = getDigits(value);
-  const limit = getPhoneNationalDigitLimit(country, nextDigits);
-
-  return limit !== undefined && nextDigits.length > limit;
-}
-
 const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextInputProps>(
   (
     {
       className,
-      nationalDigitLimitCountry,
       onChange,
       onRawValueChange,
-      value,
       ...props
     },
     ref,
   ) => {
-    const displayValue =
-      typeof value === "string" && nationalDigitLimitCountry
-        ? formatPhoneNationalInput(value, nationalDigitLimitCountry)
-        : value;
-
     return (
       <input
         ref={ref}
         className={cn(inputClassName, className)}
         onChange={(event) => {
-          if (exceedsNationalDigitLimit(event.target.value, nationalDigitLimitCountry)) {
-            const previousValue = typeof displayValue === "string" ? displayValue : "";
-            event.currentTarget.value = previousValue;
-            event.currentTarget.setSelectionRange(previousValue.length, previousValue.length);
-            return;
-          }
-
           onRawValueChange?.(event.target.value);
           onChange?.(event);
         }}
-        value={displayValue}
         {...props}
       />
     );
@@ -88,6 +60,88 @@ const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextI
 );
 
 PhoneNumberTextInput.displayName = "PhoneNumberTextInput";
+
+function NationalPhoneInput({
+  className,
+  containerClassName,
+  country,
+  disabled,
+  onChange,
+  onRawValueChange,
+  value,
+  ...props
+}: PhoneInputProps & { country: Country }) {
+  const [rawValue, setRawValue] = React.useState(() =>
+    getPhoneNationalInputValue(value, country),
+  );
+  const lastCountryRef = React.useRef(country);
+  const lastEmittedValueRef = React.useRef(value ?? "");
+
+  React.useEffect(() => {
+    const normalizedPropValue = value ?? "";
+
+    if (lastCountryRef.current !== country) {
+      lastCountryRef.current = country;
+      lastEmittedValueRef.current = normalizedPropValue;
+      setRawValue(getPhoneNationalInputValue(value, country));
+      return;
+    }
+
+    if (normalizedPropValue !== lastEmittedValueRef.current) {
+      lastEmittedValueRef.current = normalizedPropValue;
+      setRawValue(getPhoneNationalInputValue(value, country));
+    }
+  }, [country, value]);
+
+  const displayValue = formatPhoneNationalInput(rawValue, country);
+
+  function emitPhoneValue(nextRawValue: string): void {
+    const nextPhoneValue =
+      normalizePhoneNumber(nextRawValue, { defaultCountry: country }) ?? "";
+    lastEmittedValueRef.current = nextPhoneValue;
+    onChange?.(nextPhoneValue || undefined);
+  }
+
+  return (
+    <div className={cn("w-full", containerClassName)}>
+      <input
+        {...props}
+        autoComplete={props.autoComplete ?? "tel"}
+        className={cn(inputClassName, className)}
+        disabled={disabled}
+        inputMode={props.inputMode ?? "tel"}
+        onChange={(event) => {
+          const nextValue = event.target.value;
+          onRawValueChange?.(nextValue);
+
+          if (nextValue.trim().startsWith("+")) {
+            const nextPhoneValue =
+              normalizePhoneNumber(nextValue, { defaultCountry: country }) ?? "";
+            const nextRawValue = getPhoneNationalInputValue(
+              nextPhoneValue || nextValue,
+              country,
+            );
+
+            lastEmittedValueRef.current = nextPhoneValue;
+            setRawValue(nextRawValue);
+            onChange?.(nextPhoneValue || undefined);
+            return;
+          }
+
+          const nextDigits = getDigits(nextValue);
+          const limit = getPhoneNationalDigitLimit(country, nextDigits);
+          const nextRawValue =
+            limit !== undefined ? nextDigits.slice(0, limit) : nextDigits;
+
+          setRawValue(nextRawValue);
+          emitPhoneValue(nextRawValue);
+        }}
+        type={props.type ?? "tel"}
+        value={displayValue}
+      />
+    </div>
+  );
+}
 
 export function PhoneInput({
   containerClassName,
@@ -105,26 +159,21 @@ export function PhoneInput({
   const resolvedPlaceholder = props.placeholder ?? getPhonePlaceholder(locale, {
     defaultCountry: resolvedDefaultCountry,
   });
-  const inputComponent = React.useMemo(() => {
-    if (!limitNationalDigits) {
-      return PhoneNumberTextInput;
-    }
 
-    const nationalDigitLimitCountry = resolvedDefaultCountry as Country;
-    const LimitedPhoneNumberTextInput = React.forwardRef<
-      HTMLInputElement,
-      PhoneNumberTextInputProps
-    >((inputProps, ref) => (
-      <PhoneNumberTextInput
-        {...inputProps}
-        ref={ref}
-        nationalDigitLimitCountry={nationalDigitLimitCountry}
+  if (limitNationalDigits) {
+    return (
+      <NationalPhoneInput
+        {...props}
+        containerClassName={containerClassName}
+        country={resolvedDefaultCountry as Country}
+        disabled={disabled}
+        onChange={onChange}
+        onRawValueChange={onRawValueChange}
+        placeholder={resolvedPlaceholder}
+        value={value}
       />
-    ));
-    LimitedPhoneNumberTextInput.displayName = "LimitedPhoneNumberTextInput";
-
-    return LimitedPhoneNumberTextInput;
-  }, [limitNationalDigits, resolvedDefaultCountry]);
+    );
+  }
 
   return (
     <div className={cn("w-full", containerClassName)}>
@@ -133,7 +182,7 @@ export function PhoneInput({
         autoComplete={props.autoComplete ?? "tel"}
         disabled={disabled}
         inputMode={props.inputMode ?? "tel"}
-        inputComponent={inputComponent}
+        inputComponent={PhoneNumberTextInput}
         onChange={(nextValue) => onChange?.(nextValue)}
         onRawValueChange={onRawValueChange}
         placeholder={resolvedPlaceholder}

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -150,6 +150,7 @@ export function PhoneInput({
         onChange={(nextValue) => onChange?.(nextValue)}
         onRawValueChange={onRawValueChange}
         placeholder={resolvedPlaceholder}
+        smartCaret={false}
         type={props.type ?? "tel"}
         {...(maxLength !== undefined ? { maxLength } : {})}
         {...(country !== undefined ? { country } : {})}

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import {
   formatPhoneNationalInput,
   getDefaultPhoneCountry,
+  getPhoneNationalDigits,
   getPhoneNationalInputValue,
   getPhoneNationalDigitLimit,
   getPhonePlaceholder,
@@ -30,10 +31,6 @@ type PhoneInputProps = Omit<
 type PhoneNumberTextInputProps = React.ComponentProps<"input"> & {
   onRawValueChange?: (value: string) => void;
 };
-
-function getDigits(value: string): string {
-  return value.replace(/\D/g, "");
-}
 
 const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextInputProps>(
   (
@@ -128,7 +125,7 @@ function NationalPhoneInput({
             return;
           }
 
-          const nextDigits = getDigits(nextValue);
+          const nextDigits = getPhoneNationalDigits(nextValue, country);
           const limit = getPhoneNationalDigitLimit(country, nextDigits);
           const nextRawValue =
             limit !== undefined ? nextDigits.slice(0, limit) : nextDigits;

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -5,6 +5,7 @@ import type { Country } from "react-phone-number-input/input";
 import { inputClassName } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import {
+  formatPhoneNationalInput,
   getDefaultPhoneCountry,
   getPhoneNationalDigitLimit,
   getPhonePlaceholder,
@@ -58,25 +59,32 @@ const PhoneNumberTextInput = React.forwardRef<HTMLInputElement, PhoneNumberTextI
       ...props
     },
     ref,
-  ) => (
-    <input
-      ref={ref}
-      className={cn(inputClassName, className)}
-      onChange={(event) => {
-        if (exceedsNationalDigitLimit(event.target.value, nationalDigitLimitCountry)) {
-          const previousValue = typeof value === "string" ? value : "";
-          event.currentTarget.value = previousValue;
-          event.currentTarget.setSelectionRange(previousValue.length, previousValue.length);
-          return;
-        }
+  ) => {
+    const displayValue =
+      typeof value === "string" && nationalDigitLimitCountry
+        ? formatPhoneNationalInput(value, nationalDigitLimitCountry)
+        : value;
 
-        onRawValueChange?.(event.target.value);
-        onChange?.(event);
-      }}
-      value={value}
-      {...props}
-    />
-  ),
+    return (
+      <input
+        ref={ref}
+        className={cn(inputClassName, className)}
+        onChange={(event) => {
+          if (exceedsNationalDigitLimit(event.target.value, nationalDigitLimitCountry)) {
+            const previousValue = typeof displayValue === "string" ? displayValue : "";
+            event.currentTarget.value = previousValue;
+            event.currentTarget.setSelectionRange(previousValue.length, previousValue.length);
+            return;
+          }
+
+          onRawValueChange?.(event.target.value);
+          onChange?.(event);
+        }}
+        value={displayValue}
+        {...props}
+      />
+    );
+  },
 );
 
 PhoneNumberTextInput.displayName = "PhoneNumberTextInput";

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OnboardingNumberPage } from "./OnboardingNumberPage";
@@ -8,6 +9,7 @@ const getInitialNumberSuggestionMock = vi.fn();
 const searchAvailableNumbersMock = vi.fn();
 const claimOnboardingNumberMock = vi.fn();
 const skipOnboardingNumberMock = vi.fn();
+const tMock = vi.hoisted(() => (key: string) => key);
 let primaryPhoneNumberMock: unknown = null;
 let observedActionCall = 0;
 
@@ -32,7 +34,7 @@ vi.mock("@/lib/analytics", () => ({
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: tMock,
   }),
 }));
 
@@ -111,5 +113,50 @@ describe("OnboardingNumberPage", () => {
     expect(screen.getByText("number.selectedTitle")).toBeTruthy();
     expect(screen.getByText("(581) 555-0102")).toBeTruthy();
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("lets users search UK business-number inventory", async () => {
+    const user = userEvent.setup();
+    getInitialNumberSuggestionMock.mockResolvedValue({
+      market: { countryCode: "US" },
+      suggestion: null,
+      alternatives: [],
+    });
+    searchAvailableNumbersMock.mockResolvedValue({
+      market: { countryCode: "GB" },
+      selectionContext: { mode: "suggested", countryCode: "GB" },
+      numbers: [],
+    });
+
+    render(
+      <OnboardingNumberPage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getInitialNumberSuggestionMock).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "number.countryLabel" }));
+    await user.click(await screen.findByText("UK"));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("number.areaCodeLabel") as HTMLInputElement).maxLength).toBe(
+        5,
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: "number.search" }));
+
+    await waitFor(() => {
+      expect(searchAvailableNumbersMock).toHaveBeenCalledWith({
+        businessId: "business-1",
+        mode: "suggested",
+        countryCode: "GB",
+        limit: 10,
+      });
+    });
   });
 });

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.test.tsx
@@ -142,11 +142,7 @@ describe("OnboardingNumberPage", () => {
     await user.click(screen.getByRole("combobox", { name: "number.countryLabel" }));
     await user.click(await screen.findByText("UK"));
 
-    await waitFor(() => {
-      expect((screen.getByLabelText("number.areaCodeLabel") as HTMLInputElement).maxLength).toBe(
-        5,
-      );
-    });
+    expect(screen.queryByLabelText("number.areaCodeLabel")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "number.search" }));
 
@@ -186,6 +182,9 @@ describe("OnboardingNumberPage", () => {
 
     await user.click(screen.getByRole("combobox", { name: "number.countryLabel" }));
     await user.click(await screen.findByText("AU"));
+
+    expect(screen.queryByLabelText("number.areaCodeLabel")).toBeNull();
+
     await user.click(screen.getByRole("button", { name: "number.search" }));
 
     await waitFor(() => {

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.test.tsx
@@ -159,4 +159,42 @@ describe("OnboardingNumberPage", () => {
       });
     });
   });
+
+  it("lets users search Australian business-number inventory", async () => {
+    const user = userEvent.setup();
+    getInitialNumberSuggestionMock.mockResolvedValue({
+      market: { countryCode: "US" },
+      suggestion: null,
+      alternatives: [],
+    });
+    searchAvailableNumbersMock.mockResolvedValue({
+      market: { countryCode: "AU" },
+      selectionContext: { mode: "suggested", countryCode: "AU" },
+      numbers: [],
+    });
+
+    render(
+      <OnboardingNumberPage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getInitialNumberSuggestionMock).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "number.countryLabel" }));
+    await user.click(await screen.findByText("AU"));
+    await user.click(screen.getByRole("button", { name: "number.search" }));
+
+    await waitFor(() => {
+      expect(searchAvailableNumbersMock).toHaveBeenCalledWith({
+        businessId: "business-1",
+        mode: "suggested",
+        countryCode: "AU",
+        limit: 10,
+      });
+    });
+  });
 });

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
@@ -23,6 +23,10 @@ import { OnboardingShell } from "@/features/onboarding/components/OnboardingShel
 import { getSafeOnboardingErrorMessage } from "@/features/onboarding/onboardingErrors";
 import { captureAnalyticsEvent } from "@/lib/analytics";
 import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
+import {
+  normalizeOnboardingPhoneCountry,
+  type SupportedOnboardingPhoneCountry,
+} from "@/lib/phone";
 
 type OnboardingNumberPageProps = {
   businessId: Id<"businesses">;
@@ -84,9 +88,14 @@ type PrimaryPhoneNumber = {
   status: string;
 };
 
-const COUNTRY_OPTIONS: Array<{ code: string; label: string; flag: string }> = [
+const COUNTRY_OPTIONS: Array<{
+  code: SupportedOnboardingPhoneCountry;
+  label: string;
+  flag: string;
+}> = [
   { code: "US", label: "US", flag: "🇺🇸" },
   { code: "CA", label: "CA", flag: "🇨🇦" },
+  { code: "GB", label: "UK", flag: "🇬🇧" },
 ];
 
 function formatPhoneNumber(e164: string): string {
@@ -146,7 +155,7 @@ export function OnboardingNumberPage({
     businessId,
   }) as PrimaryPhoneNumber | null | undefined;
 
-  const [country, setCountry] = useState<string>("US");
+  const [country, setCountry] = useState<SupportedOnboardingPhoneCountry>("US");
   const [areaCode, setAreaCode] = useState<string>("");
   const [numbers, setNumbers] = useState<Array<AvailableNumberSummary>>([]);
   const [selectedE164, setSelectedE164] = useState<string | null>(null);
@@ -158,7 +167,16 @@ export function OnboardingNumberPage({
   const [isSkipping, setIsSkipping] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const isSearching = searchSource !== null;
+  const areaCodeMaxLength = country === "GB" ? 5 : 3;
   const shouldLoadInventory = primaryPhoneNumber === null && !isComplete;
+
+  function handleCountryChange(value: string | null): void {
+    const nextCountry = normalizeOnboardingPhoneCountry(value);
+    setCountry(nextCountry);
+    setAreaCode((currentAreaCode) =>
+      currentAreaCode.slice(0, nextCountry === "GB" ? 5 : 3),
+    );
+  }
 
   // Initial load: get the suggested market + a starter list of numbers.
   useEffect(() => {
@@ -182,7 +200,7 @@ export function OnboardingNumberPage({
         })) as InitialSuggestionResult;
         if (cancelled) return;
 
-        setCountry(result.market.countryCode || "US");
+        setCountry(normalizeOnboardingPhoneCountry(result.market.countryCode));
         setAreaCode(result.market.areaCode ?? "");
         const initialList = [
           ...(result.suggestion ? [result.suggestion] : []),
@@ -237,7 +255,7 @@ export function OnboardingNumberPage({
       const result = (await searchAvailableNumbers({
         businessId,
         mode: trimmedAreaCode ? "area_code" : "suggested",
-        countryCode: country === "CA" ? "CA" : "US",
+        countryCode: country,
         ...(trimmedAreaCode ? { areaCode: trimmedAreaCode } : {}),
         limit,
       })) as SearchResult;
@@ -406,7 +424,7 @@ export function OnboardingNumberPage({
             <label className="text-sm font-medium" htmlFor="number-country">
               {t("number.countryLabel")}
             </label>
-            <Select onValueChange={(value) => setCountry(value ?? "US")} value={country}>
+            <Select onValueChange={handleCountryChange} value={country}>
               <SelectTrigger id="number-country">
                 <SelectValue />
               </SelectTrigger>
@@ -430,7 +448,7 @@ export function OnboardingNumberPage({
             <Input
               id="number-area-code"
               inputMode="numeric"
-              maxLength={3}
+              maxLength={areaCodeMaxLength}
               onChange={(event) => setAreaCode(event.target.value.replace(/[^\d]/g, ""))}
               placeholder={t("number.areaCodePlaceholder")}
               value={areaCode}

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
@@ -25,6 +25,7 @@ import { captureAnalyticsEvent } from "@/lib/analytics";
 import { useObservedAction, useObservedMutation } from "@/lib/observed-convex";
 import {
   normalizeOnboardingPhoneCountry,
+  supportsOnboardingAreaCodeSearch,
   type SupportedOnboardingPhoneCountry,
 } from "@/lib/phone";
 
@@ -168,15 +169,15 @@ export function OnboardingNumberPage({
   const [isSkipping, setIsSkipping] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const isSearching = searchSource !== null;
-  const areaCodeMaxLength = country === "GB" || country === "AU" ? 5 : 3;
+  const supportsAreaCodeSearch = supportsOnboardingAreaCodeSearch(country);
   const shouldLoadInventory = primaryPhoneNumber === null && !isComplete;
 
   function handleCountryChange(value: string | null): void {
     const nextCountry = normalizeOnboardingPhoneCountry(value);
     setCountry(nextCountry);
-    setAreaCode((currentAreaCode) =>
-      currentAreaCode.slice(0, nextCountry === "GB" || nextCountry === "AU" ? 5 : 3),
-    );
+    if (!supportsOnboardingAreaCodeSearch(nextCountry)) {
+      setAreaCode("");
+    }
   }
 
   // Initial load: get the suggested market + a starter list of numbers.
@@ -201,8 +202,13 @@ export function OnboardingNumberPage({
         })) as InitialSuggestionResult;
         if (cancelled) return;
 
-        setCountry(normalizeOnboardingPhoneCountry(result.market.countryCode));
-        setAreaCode(result.market.areaCode ?? "");
+        const initialCountry = normalizeOnboardingPhoneCountry(result.market.countryCode);
+        setCountry(initialCountry);
+        setAreaCode(
+          supportsOnboardingAreaCodeSearch(initialCountry)
+            ? (result.market.areaCode ?? "")
+            : "",
+        );
         const initialList = [
           ...(result.suggestion ? [result.suggestion] : []),
           ...result.alternatives,
@@ -251,7 +257,7 @@ export function OnboardingNumberPage({
     setSearchSource(source);
     setError(null);
     try {
-      const trimmedAreaCode = areaCode.trim();
+      const trimmedAreaCode = supportsAreaCodeSearch ? areaCode.trim() : "";
       const limit = source === "loadMore" ? Math.min(numbers.length + 10, 20) : 10;
       const result = (await searchAvailableNumbers({
         businessId,
@@ -420,7 +426,13 @@ export function OnboardingNumberPage({
       }
     >
       <div className="flex flex-col gap-6">
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[140px_1fr_160px_auto] sm:items-end">
+        <div
+          className={
+            supportsAreaCodeSearch
+              ? "grid grid-cols-1 gap-3 sm:grid-cols-[140px_1fr_160px_auto] sm:items-end"
+              : "grid grid-cols-1 gap-3 sm:grid-cols-[140px_auto] sm:items-end"
+          }
+        >
           <div className="flex flex-col gap-2">
             <label className="text-sm font-medium" htmlFor="number-country">
               {t("number.countryLabel")}
@@ -441,20 +453,24 @@ export function OnboardingNumberPage({
               </SelectContent>
             </Select>
           </div>
-          <div aria-hidden="true" className="hidden sm:block" />
-          <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium" htmlFor="number-area-code">
-              {t("number.areaCodeLabel")}
-            </label>
-            <Input
-              id="number-area-code"
-              inputMode="numeric"
-              maxLength={areaCodeMaxLength}
-              onChange={(event) => setAreaCode(event.target.value.replace(/[^\d]/g, ""))}
-              placeholder={t("number.areaCodePlaceholder")}
-              value={areaCode}
-            />
-          </div>
+          {supportsAreaCodeSearch ? (
+            <>
+              <div aria-hidden="true" className="hidden sm:block" />
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-medium" htmlFor="number-area-code">
+                  {t("number.areaCodeLabel")}
+                </label>
+                <Input
+                  id="number-area-code"
+                  inputMode="numeric"
+                  maxLength={3}
+                  onChange={(event) => setAreaCode(event.target.value.replace(/[^\d]/g, ""))}
+                  placeholder={t("number.areaCodePlaceholder")}
+                  value={areaCode}
+                />
+              </div>
+            </>
+          ) : null}
           <Button
             className="h-11 w-full sm:w-auto"
             disabled={isSearching || isLoading}

--- a/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingNumberPage.tsx
@@ -96,6 +96,7 @@ const COUNTRY_OPTIONS: Array<{
   { code: "US", label: "US", flag: "🇺🇸" },
   { code: "CA", label: "CA", flag: "🇨🇦" },
   { code: "GB", label: "UK", flag: "🇬🇧" },
+  { code: "AU", label: "AU", flag: "🇦🇺" },
 ];
 
 function formatPhoneNumber(e164: string): string {
@@ -167,14 +168,14 @@ export function OnboardingNumberPage({
   const [isSkipping, setIsSkipping] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const isSearching = searchSource !== null;
-  const areaCodeMaxLength = country === "GB" ? 5 : 3;
+  const areaCodeMaxLength = country === "GB" || country === "AU" ? 5 : 3;
   const shouldLoadInventory = primaryPhoneNumber === null && !isComplete;
 
   function handleCountryChange(value: string | null): void {
     const nextCountry = normalizeOnboardingPhoneCountry(value);
     setCountry(nextCountry);
     setAreaCode((currentAreaCode) =>
-      currentAreaCode.slice(0, nextCountry === "GB" ? 5 : 3),
+      currentAreaCode.slice(0, nextCountry === "GB" || nextCountry === "AU" ? 5 : 3),
     );
   }
 

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -188,6 +188,38 @@ describe("OnboardingVerifyPhonePage", () => {
     });
   });
 
+  it("infers the prefix country when an international phone number is pasted", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    const phoneInput = screen.getByLabelText(
+      "verifyPhone.fields.mobileNumber",
+    ) as HTMLInputElement;
+    await user.click(phoneInput);
+    await user.paste("+447400123456");
+
+    await waitFor(() => {
+      expect(
+        container.querySelector("[data-phone-country-calling-code]")?.textContent,
+      ).toBe("+44");
+    });
+    expect(phoneInput.value).toBe("7400 123456");
+
+    await user.click(screen.getByRole("button", { name: "verifyPhone.sendCode" }));
+
+    await waitFor(() => {
+      expect(startPhoneVerificationMock).toHaveBeenCalledWith({
+        businessId: "business-1",
+        phoneE164: "+447400123456",
+      });
+    });
+  });
+
   it("submits an Australian number as E.164 after changing the prefix country", async () => {
     const user = userEvent.setup();
     render(

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingVerifyPhonePage } from "./OnboardingVerifyPhonePage";
+
+const startPhoneVerificationMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("@/lib/observed-convex", () => ({
+  useObservedAction: () => startPhoneVerificationMock,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  captureAnalyticsEvent: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    i18n: {
+      language: "en-US",
+      resolvedLanguage: "en-US",
+    },
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/features/onboarding/components/OnboardingShell", () => ({
+  OnboardingShell: ({
+    children,
+    title,
+  }: {
+    children: ReactNode;
+    title: string;
+  }) => (
+    <main>
+      <h1>{title}</h1>
+      {children}
+    </main>
+  ),
+}));
+
+describe("OnboardingVerifyPhonePage", () => {
+  beforeEach(() => {
+    startPhoneVerificationMock.mockReset();
+    navigateMock.mockReset();
+    startPhoneVerificationMock.mockResolvedValue({
+      countryCode: "US",
+      phoneE164: "+12133734253",
+      status: "pending",
+    });
+  });
+
+  it("renders the calling code outside the phone input", () => {
+    const { container } = render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    const phoneInput = screen.getByLabelText(
+      "verifyPhone.fields.mobileNumber",
+    ) as HTMLInputElement;
+    const prefix = container.querySelector('[data-slot="phone-country-prefix"]');
+
+    expect(screen.getByRole("combobox", { name: "verifyPhone.fields.region" })).toBeTruthy();
+    expect(prefix?.textContent).toBe("+1");
+    expect(phoneInput.placeholder).toBe("(555) 123-4567");
+    expect(phoneInput.placeholder).not.toContain("+1");
+    expect(phoneInput.value).not.toContain("+1");
+  });
+
+  it("submits the E.164 phone number after national-format entry", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await user.type(
+      screen.getByLabelText("verifyPhone.fields.mobileNumber"),
+      "2133734253",
+    );
+    await user.click(screen.getByRole("button", { name: "verifyPhone.sendCode" }));
+
+    await waitFor(() => {
+      expect(startPhoneVerificationMock).toHaveBeenCalledWith({
+        businessId: "business-1",
+        phoneE164: "+12133734253",
+      });
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/onboarding/verify-phone/code");
+  });
+});

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -44,6 +44,20 @@ vi.mock("@/features/onboarding/components/OnboardingShell", () => ({
     </main>
   ),
 }));
+
+async function selectRegion(
+  user: ReturnType<typeof userEvent.setup>,
+  regionName: string,
+): Promise<void> {
+  await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
+  const optionText = await screen.findByText(regionName);
+  const option = optionText.closest("[role='option']");
+
+  expect(option).toBeTruthy();
+  await userEvent
+    .setup({ pointerEventsCheck: PointerEventsCheckLevel.Never })
+    .click(option ?? optionText);
+}
 
 describe("OnboardingVerifyPhonePage", () => {
   beforeEach(() => {
@@ -117,11 +131,7 @@ describe("OnboardingVerifyPhonePage", () => {
       />,
     );
 
-    const regionPicker = screen.getByRole("combobox", {
-      name: "verifyPhone.fields.region",
-    });
-    await user.click(regionPicker);
-    await user.click(await screen.findByText("United Kingdom"));
+    await selectRegion(user, "United Kingdom");
 
     expect(
       container.querySelector("[data-phone-country-calling-code]")?.textContent,
@@ -159,8 +169,7 @@ describe("OnboardingVerifyPhonePage", () => {
       />,
     );
 
-    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
-    await user.click(await screen.findByText("United Kingdom"));
+    await selectRegion(user, "United Kingdom");
     await user.type(
       screen.getByLabelText("verifyPhone.fields.mobileNumber"),
       "7911123456",
@@ -184,8 +193,7 @@ describe("OnboardingVerifyPhonePage", () => {
       />,
     );
 
-    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
-    await user.click(await screen.findByText("Australia"));
+    await selectRegion(user, "Australia");
     await user.type(
       screen.getByLabelText("verifyPhone.fields.mobileNumber"),
       "0412345678",
@@ -209,8 +217,7 @@ describe("OnboardingVerifyPhonePage", () => {
       />,
     );
 
-    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
-    await user.click(await screen.findByText("Australia"));
+    await selectRegion(user, "Australia");
 
     const phoneInput = screen.getByLabelText(
       "verifyPhone.fields.mobileNumber",
@@ -222,6 +229,25 @@ describe("OnboardingVerifyPhonePage", () => {
 
     expect(phoneInput.value).not.toBe(valueBeforeBackspace);
     expect(phoneInput.value.length).toBeLessThan(valueBeforeBackspace.length);
+  });
+
+  it("limits onboarding phone input to the selected country's national length", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await selectRegion(user, "Australia");
+
+    const phoneInput = screen.getByLabelText(
+      "verifyPhone.fields.mobileNumber",
+    ) as HTMLInputElement;
+    await user.type(phoneInput, "04123456789");
+
+    expect(phoneInput.value).toBe("0412 345 678");
   });
 
   it("clears stale phone input when the prefix country changes", async () => {
@@ -239,11 +265,13 @@ describe("OnboardingVerifyPhonePage", () => {
     await user.type(phoneInput, "2133734253");
     expect(phoneInput.value).not.toBe("");
 
-    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
-    const australiaOption = (await screen.findByText("Australia")).closest("[role='option']");
-    expect(australiaOption).toBeTruthy();
-    await user.click(australiaOption as HTMLElement);
+    await selectRegion(user, "Australia");
 
-    expect(phoneInput.value).toBe("");
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("verifyPhone.fields.mobileNumber") as HTMLInputElement)
+          .value,
+      ).toBe("");
+    });
   });
 });

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -174,6 +174,10 @@ describe("OnboardingVerifyPhonePage", () => {
       screen.getByLabelText("verifyPhone.fields.mobileNumber"),
       "7911123456",
     );
+    expect(
+      (screen.getByLabelText("verifyPhone.fields.mobileNumber") as HTMLInputElement)
+        .value,
+    ).toBe("7911 123456");
     await user.click(screen.getByRole("button", { name: "verifyPhone.sendCode" }));
 
     await waitFor(() => {
@@ -198,6 +202,10 @@ describe("OnboardingVerifyPhonePage", () => {
       screen.getByLabelText("verifyPhone.fields.mobileNumber"),
       "0412345678",
     );
+    expect(
+      (screen.getByLabelText("verifyPhone.fields.mobileNumber") as HTMLInputElement)
+        .value,
+    ).toBe("0412 345 678");
     await user.click(screen.getByRole("button", { name: "verifyPhone.sendCode" }));
 
     await waitFor(() => {

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -74,6 +74,7 @@ describe("OnboardingVerifyPhonePage", () => {
       name: "verifyPhone.fields.region",
     });
     expect(regionPicker).toBe(prefix);
+    expect(prefix?.className).toContain("data-[size=default]:h-11");
     expect(callingCode?.textContent).toBe("+1");
     expect(prefix?.querySelector("svg")).toBeTruthy();
     expect(phoneInput.placeholder).toBe("(555) 123-4567");

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -75,6 +75,7 @@ describe("OnboardingVerifyPhonePage", () => {
     });
     expect(regionPicker).toBe(prefix);
     expect(prefix?.className).toContain("data-[size=default]:h-11");
+    expect(prefix?.className).not.toContain("border-r-0");
     expect(callingCode?.textContent).toBe("+1");
     expect(prefix?.querySelector("svg")).toBeTruthy();
     expect(phoneInput.placeholder).toBe("(555) 123-4567");

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -67,13 +67,19 @@ describe("OnboardingVerifyPhonePage", () => {
     const phoneInput = screen.getByLabelText(
       "verifyPhone.fields.mobileNumber",
     ) as HTMLInputElement;
-    const prefix = container.querySelector('[data-slot="phone-country-prefix"]');
+    const prefix = container.querySelector("[data-phone-country-prefix]");
+    const callingCode = container.querySelector("[data-phone-country-calling-code]");
 
-    expect(screen.getByRole("combobox", { name: "verifyPhone.fields.region" })).toBeTruthy();
-    expect(prefix?.textContent).toBe("+1");
+    const regionPicker = screen.getByRole("combobox", {
+      name: "verifyPhone.fields.region",
+    });
+    expect(regionPicker).toBe(prefix);
+    expect(callingCode?.textContent).toBe("+1");
+    expect(prefix?.querySelector("svg")).toBeTruthy();
     expect(phoneInput.placeholder).toBe("(555) 123-4567");
     expect(phoneInput.placeholder).not.toContain("+1");
     expect(phoneInput.value).not.toContain("+1");
+    expect(screen.queryByText("US")).toBeNull();
   });
 
   it("submits the E.164 phone number after national-format entry", async () => {
@@ -98,5 +104,29 @@ describe("OnboardingVerifyPhonePage", () => {
       });
     });
     expect(navigateMock).toHaveBeenCalledWith("/onboarding/verify-phone/code");
+  });
+
+  it("changes country from the calling-code prefix picker", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    const regionPicker = screen.getByRole("combobox", {
+      name: "verifyPhone.fields.region",
+    });
+    await user.click(regionPicker);
+    await user.click(await screen.findByText("United Kingdom"));
+
+    expect(
+      container.querySelector("[data-phone-country-calling-code]")?.textContent,
+    ).toBe("+44");
+    expect(
+      (screen.getByLabelText("verifyPhone.fields.mobileNumber") as HTMLInputElement)
+        .placeholder,
+    ).toBe("07123 456789");
   });
 });

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -199,4 +199,51 @@ describe("OnboardingVerifyPhonePage", () => {
       });
     });
   });
+
+  it("keeps fixed-country partial input editable", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
+    await user.click(await screen.findByText("Australia"));
+
+    const phoneInput = screen.getByLabelText(
+      "verifyPhone.fields.mobileNumber",
+    ) as HTMLInputElement;
+    await user.type(phoneInput, "0412345");
+    const valueBeforeBackspace = phoneInput.value;
+
+    await user.keyboard("[Backspace]");
+
+    expect(phoneInput.value).not.toBe(valueBeforeBackspace);
+    expect(phoneInput.value.length).toBeLessThan(valueBeforeBackspace.length);
+  });
+
+  it("clears stale phone input when the prefix country changes", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    const phoneInput = screen.getByLabelText(
+      "verifyPhone.fields.mobileNumber",
+    ) as HTMLInputElement;
+    await user.type(phoneInput, "2133734253");
+    expect(phoneInput.value).not.toBe("");
+
+    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
+    const australiaOption = (await screen.findByText("Australia")).closest("[role='option']");
+    expect(australiaOption).toBeTruthy();
+    await user.click(australiaOption as HTMLElement);
+
+    expect(phoneInput.value).toBe("");
+  });
 });

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -131,4 +131,46 @@ describe("OnboardingVerifyPhonePage", () => {
         .placeholder,
     ).toBe("07123 456789");
   });
+
+  it("only offers supported onboarding regions", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
+
+    expect(await screen.findByText("United States")).toBeTruthy();
+    expect(screen.getByText("Canada")).toBeTruthy();
+    expect(screen.getByText("United Kingdom")).toBeTruthy();
+    expect(screen.queryByText("France")).toBeNull();
+  });
+
+  it("submits a UK number as E.164 after changing the prefix country", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
+    await user.click(await screen.findByText("United Kingdom"));
+    await user.type(
+      screen.getByLabelText("verifyPhone.fields.mobileNumber"),
+      "7911123456",
+    );
+    await user.click(screen.getByRole("button", { name: "verifyPhone.sendCode" }));
+
+    await waitFor(() => {
+      expect(startPhoneVerificationMock).toHaveBeenCalledWith({
+        businessId: "business-1",
+        phoneE164: "+447911123456",
+      });
+    });
+  });
 });

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -146,6 +146,7 @@ describe("OnboardingVerifyPhonePage", () => {
     expect(await screen.findByText("United States")).toBeTruthy();
     expect(screen.getByText("Canada")).toBeTruthy();
     expect(screen.getByText("United Kingdom")).toBeTruthy();
+    expect(screen.getByText("Australia")).toBeTruthy();
     expect(screen.queryByText("France")).toBeNull();
   });
 
@@ -170,6 +171,31 @@ describe("OnboardingVerifyPhonePage", () => {
       expect(startPhoneVerificationMock).toHaveBeenCalledWith({
         businessId: "business-1",
         phoneE164: "+447911123456",
+      });
+    });
+  });
+
+  it("submits an Australian number as E.164 after changing the prefix country", async () => {
+    const user = userEvent.setup();
+    render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        onSignOut={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "verifyPhone.fields.region" }));
+    await user.click(await screen.findByText("Australia"));
+    await user.type(
+      screen.getByLabelText("verifyPhone.fields.mobileNumber"),
+      "0412345678",
+    );
+    await user.click(screen.getByRole("button", { name: "verifyPhone.sendCode" }));
+
+    await waitFor(() => {
+      expect(startPhoneVerificationMock).toHaveBeenCalledWith({
+        businessId: "business-1",
+        phoneE164: "+61412345678",
       });
     });
   });

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.test.tsx
@@ -290,6 +290,25 @@ describe("OnboardingVerifyPhonePage", () => {
     expect(phoneInput.value).toBe("0412 345 678");
   });
 
+  it("clears unsupported legacy saved phones on load", () => {
+    const { container } = render(
+      <OnboardingVerifyPhonePage
+        businessId={"business-1" as never}
+        currentUserPhone="+33612345678"
+        onSignOut={() => {}}
+      />,
+    );
+
+    const phoneInput = screen.getByLabelText(
+      "verifyPhone.fields.mobileNumber",
+    ) as HTMLInputElement;
+
+    expect(
+      container.querySelector("[data-phone-country-calling-code]")?.textContent,
+    ).toBe("+1");
+    expect(phoneInput.value).toBe("");
+  });
+
   it("clears stale phone input when the prefix country changes", async () => {
     const user = userEvent.setup();
     render(

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -176,6 +176,7 @@ export function OnboardingVerifyPhonePage({
                 containerClassName="min-w-0 flex-1"
                 country={selectedCountry}
                 id="onboarding-phone"
+                limitNationalDigits
                 onChange={handlePhoneChange}
                 onRawValueChange={handleRawPhoneChange}
                 value={phone}

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -139,7 +139,7 @@ export function OnboardingVerifyPhonePage({
               <Select onValueChange={handleCountryChange} value={selectedCountry}>
                 <SelectTrigger
                   aria-label={t("verifyPhone.fields.region")}
-                  className="h-11 w-20 shrink-0 rounded-l-4xl rounded-r-none border-r-0 px-4 font-medium text-muted-foreground data-[size=default]:h-11"
+                  className="h-11 w-20 shrink-0 rounded-l-4xl rounded-r-none px-4 font-medium text-muted-foreground data-[size=default]:h-11"
                   data-phone-country-prefix
                 >
                   <span data-phone-country-calling-code>

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { LoaderCircle } from "lucide-react";
+import type { Country } from "react-phone-number-input/input";
 
 import { api } from "../../../../../convex/_generated/api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
@@ -15,10 +16,23 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { PhoneInput } from "@/components/ui/phone-input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { OnboardingShell } from "@/features/onboarding/components/OnboardingShell";
 import { getSafeOnboardingErrorMessage } from "@/features/onboarding/onboardingErrors";
 import { captureAnalyticsEvent } from "@/lib/analytics";
 import { useObservedAction } from "@/lib/observed-convex";
+import {
+  getDefaultPhoneCountry,
+  getPhoneCountryOptions,
+  inferPhoneCountry,
+} from "@/lib/phone";
 
 type OnboardingVerifyPhonePageProps = {
   businessId: Id<"businesses">;
@@ -33,14 +47,51 @@ export function OnboardingVerifyPhonePage({
   onSignOut,
   progressNavigableUntil,
 }: OnboardingVerifyPhonePageProps) {
-  const { t } = useTranslation("onboarding");
+  const { t, i18n } = useTranslation("onboarding");
+  const locale = i18n.resolvedLanguage ?? i18n.language;
+  const defaultCountry = getDefaultPhoneCountry(locale) as Country;
   const navigate = useNavigate();
   const startPhoneVerification = useObservedAction(
     api.onboarding.phoneVerification.startPhoneVerification,
   );
+  const countryOptions = useMemo(() => getPhoneCountryOptions(locale), [locale]);
+  const [selectedCountry, setSelectedCountry] = useState<Country>(
+    () => (inferPhoneCountry(currentUserPhone, defaultCountry) ?? defaultCountry) as Country,
+  );
   const [phone, setPhone] = useState<string>(currentUserPhone ?? "");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const selectedCountryOption =
+    countryOptions.find((option) => option.code === selectedCountry) ??
+    countryOptions.find((option) => option.code === defaultCountry) ??
+    countryOptions[0];
+
+  function handleCountryChange(value: string | null): void {
+    if (!value) {
+      return;
+    }
+    setSelectedCountry(value as Country);
+  }
+
+  function handlePhoneChange(value?: string): void {
+    const nextPhone = value ?? "";
+    setPhone(nextPhone);
+    const inferredCountry = inferPhoneCountry(nextPhone, selectedCountry);
+    if (inferredCountry) {
+      setSelectedCountry(inferredCountry as Country);
+    }
+  }
+
+  function handleRawPhoneChange(rawValue: string): void {
+    if (!rawValue.trim().startsWith("+")) {
+      return;
+    }
+
+    const inferredCountry = inferPhoneCountry(rawValue, selectedCountry);
+    if (inferredCountry) {
+      setSelectedCountry(inferredCountry as Country);
+    }
+  }
 
   async function handleSubmit(): Promise<void> {
     const trimmed = phone.trim();
@@ -85,14 +136,44 @@ export function OnboardingVerifyPhonePage({
             <FieldLabel htmlFor="onboarding-phone">
               {t("verifyPhone.fields.mobileNumber")}
             </FieldLabel>
-            <PhoneInput
-              autoFocus
-              className="h-11"
-              id="onboarding-phone"
-              onChange={(value) => setPhone(value ?? "")}
-              placeholder={t("verifyPhone.placeholders.mobileNumber")}
-              value={phone}
-            />
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,11rem)_minmax(0,1fr)]">
+              <Select onValueChange={handleCountryChange} value={selectedCountry}>
+                <SelectTrigger
+                  aria-label={t("verifyPhone.fields.region")}
+                  className="h-11 w-full"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {countryOptions.map((option) => (
+                      <SelectItem key={option.code} value={option.code}>
+                        <span>{option.label}</span>
+                        <span className="text-muted-foreground">{option.callingCode}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <div className="flex min-w-0">
+                <span
+                  className="flex h-11 shrink-0 items-center rounded-l-4xl rounded-r-none border border-input bg-input/30 px-4 text-sm font-medium text-muted-foreground"
+                  data-slot="phone-country-prefix"
+                >
+                  {selectedCountryOption?.callingCode ?? ""}
+                </span>
+                <PhoneInput
+                  autoFocus
+                  className="h-11 rounded-l-none border-l-0"
+                  containerClassName="min-w-0 flex-1"
+                  country={selectedCountry}
+                  id="onboarding-phone"
+                  onChange={handlePhoneChange}
+                  onRawValueChange={handleRawPhoneChange}
+                  value={phone}
+                />
+              </div>
+            </div>
             <FieldDescription>{t("verifyPhone.hint")}</FieldDescription>
           </Field>
 

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -22,7 +22,6 @@ import {
   SelectGroup,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import { OnboardingShell } from "@/features/onboarding/components/OnboardingShell";
 import { getSafeOnboardingErrorMessage } from "@/features/onboarding/onboardingErrors";
@@ -136,15 +135,18 @@ export function OnboardingVerifyPhonePage({
             <FieldLabel htmlFor="onboarding-phone">
               {t("verifyPhone.fields.mobileNumber")}
             </FieldLabel>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,11rem)_minmax(0,1fr)]">
+            <div className="flex min-w-0">
               <Select onValueChange={handleCountryChange} value={selectedCountry}>
                 <SelectTrigger
                   aria-label={t("verifyPhone.fields.region")}
-                  className="h-11 w-full"
+                  className="h-11 shrink-0 rounded-l-4xl rounded-r-none border-r-0 px-4 font-medium text-muted-foreground"
+                  data-phone-country-prefix
                 >
-                  <SelectValue />
+                  <span data-phone-country-calling-code>
+                    {selectedCountryOption?.callingCode ?? ""}
+                  </span>
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className="min-w-72">
                   <SelectGroup>
                     {countryOptions.map((option) => (
                       <SelectItem key={option.code} value={option.code}>
@@ -155,24 +157,16 @@ export function OnboardingVerifyPhonePage({
                   </SelectGroup>
                 </SelectContent>
               </Select>
-              <div className="flex min-w-0">
-                <span
-                  className="flex h-11 shrink-0 items-center rounded-l-4xl rounded-r-none border border-input bg-input/30 px-4 text-sm font-medium text-muted-foreground"
-                  data-slot="phone-country-prefix"
-                >
-                  {selectedCountryOption?.callingCode ?? ""}
-                </span>
-                <PhoneInput
-                  autoFocus
-                  className="h-11 rounded-l-none border-l-0"
-                  containerClassName="min-w-0 flex-1"
-                  country={selectedCountry}
-                  id="onboarding-phone"
-                  onChange={handlePhoneChange}
-                  onRawValueChange={handleRawPhoneChange}
-                  value={phone}
-                />
-              </div>
+              <PhoneInput
+                autoFocus
+                className="h-11 rounded-l-none border-l-0"
+                containerClassName="min-w-0 flex-1"
+                country={selectedCountry}
+                id="onboarding-phone"
+                onChange={handlePhoneChange}
+                onRawValueChange={handleRawPhoneChange}
+                value={phone}
+              />
             </div>
             <FieldDescription>{t("verifyPhone.hint")}</FieldDescription>
           </Field>

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -29,8 +29,10 @@ import { captureAnalyticsEvent } from "@/lib/analytics";
 import { useObservedAction } from "@/lib/observed-convex";
 import {
   getDefaultPhoneCountry,
-  getPhoneCountryOptions,
+  getSupportedOnboardingPhoneCountryOptions,
   inferPhoneCountry,
+  isSupportedOnboardingPhoneCountry,
+  normalizeOnboardingPhoneCountry,
 } from "@/lib/phone";
 
 type OnboardingVerifyPhonePageProps = {
@@ -48,14 +50,21 @@ export function OnboardingVerifyPhonePage({
 }: OnboardingVerifyPhonePageProps) {
   const { t, i18n } = useTranslation("onboarding");
   const locale = i18n.resolvedLanguage ?? i18n.language;
-  const defaultCountry = getDefaultPhoneCountry(locale) as Country;
+  const defaultCountry = normalizeOnboardingPhoneCountry(getDefaultPhoneCountry(locale));
   const navigate = useNavigate();
   const startPhoneVerification = useObservedAction(
     api.onboarding.phoneVerification.startPhoneVerification,
   );
-  const countryOptions = useMemo(() => getPhoneCountryOptions(locale), [locale]);
+  const countryOptions = useMemo(
+    () => getSupportedOnboardingPhoneCountryOptions(locale),
+    [locale],
+  );
   const [selectedCountry, setSelectedCountry] = useState<Country>(
-    () => (inferPhoneCountry(currentUserPhone, defaultCountry) ?? defaultCountry) as Country,
+    () =>
+      normalizeOnboardingPhoneCountry(
+        inferPhoneCountry(currentUserPhone, defaultCountry),
+        defaultCountry,
+      ) as Country,
   );
   const [phone, setPhone] = useState<string>(currentUserPhone ?? "");
   const [error, setError] = useState<string | null>(null);
@@ -69,14 +78,14 @@ export function OnboardingVerifyPhonePage({
     if (!value) {
       return;
     }
-    setSelectedCountry(value as Country);
+    setSelectedCountry(normalizeOnboardingPhoneCountry(value, defaultCountry) as Country);
   }
 
   function handlePhoneChange(value?: string): void {
     const nextPhone = value ?? "";
     setPhone(nextPhone);
     const inferredCountry = inferPhoneCountry(nextPhone, selectedCountry);
-    if (inferredCountry) {
+    if (isSupportedOnboardingPhoneCountry(inferredCountry)) {
       setSelectedCountry(inferredCountry as Country);
     }
   }
@@ -87,7 +96,7 @@ export function OnboardingVerifyPhonePage({
     }
 
     const inferredCountry = inferPhoneCountry(rawValue, selectedCountry);
-    if (inferredCountry) {
+    if (isSupportedOnboardingPhoneCountry(inferredCountry)) {
       setSelectedCountry(inferredCountry as Country);
     }
   }

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -59,14 +59,20 @@ export function OnboardingVerifyPhonePage({
     () => getSupportedOnboardingPhoneCountryOptions(locale),
     [locale],
   );
+  const initialVerifyPhone = (() => {
+    const inferredCountry = inferPhoneCountry(currentUserPhone, defaultCountry);
+    return {
+      country: normalizeOnboardingPhoneCountry(inferredCountry, defaultCountry) as Country,
+      phone:
+        currentUserPhone && isSupportedOnboardingPhoneCountry(inferredCountry)
+          ? currentUserPhone
+          : "",
+    };
+  })();
   const [selectedCountry, setSelectedCountry] = useState<Country>(
-    () =>
-      normalizeOnboardingPhoneCountry(
-        inferPhoneCountry(currentUserPhone, defaultCountry),
-        defaultCountry,
-      ) as Country,
+    initialVerifyPhone.country,
   );
-  const [phone, setPhone] = useState<string>(currentUserPhone ?? "");
+  const [phone, setPhone] = useState<string>(initialVerifyPhone.phone);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const selectedCountryOption =

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -139,7 +139,7 @@ export function OnboardingVerifyPhonePage({
               <Select onValueChange={handleCountryChange} value={selectedCountry}>
                 <SelectTrigger
                   aria-label={t("verifyPhone.fields.region")}
-                  className="h-11 shrink-0 rounded-l-4xl rounded-r-none border-r-0 px-4 font-medium text-muted-foreground"
+                  className="h-11 w-20 shrink-0 rounded-l-4xl rounded-r-none border-r-0 px-4 font-medium text-muted-foreground data-[size=default]:h-11"
                   data-phone-country-prefix
                 >
                   <span data-phone-country-calling-code>

--- a/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingVerifyPhonePage.tsx
@@ -78,16 +78,17 @@ export function OnboardingVerifyPhonePage({
     if (!value) {
       return;
     }
-    setSelectedCountry(normalizeOnboardingPhoneCountry(value, defaultCountry) as Country);
+    const nextCountry = normalizeOnboardingPhoneCountry(value, defaultCountry);
+    if (nextCountry === selectedCountry) {
+      return;
+    }
+
+    setSelectedCountry(nextCountry as Country);
+    setPhone("");
   }
 
   function handlePhoneChange(value?: string): void {
-    const nextPhone = value ?? "";
-    setPhone(nextPhone);
-    const inferredCountry = inferPhoneCountry(nextPhone, selectedCountry);
-    if (isSupportedOnboardingPhoneCountry(inferredCountry)) {
-      setSelectedCountry(inferredCountry as Country);
-    }
+    setPhone(value ?? "");
   }
 
   function handleRawPhoneChange(rawValue: string): void {
@@ -96,7 +97,10 @@ export function OnboardingVerifyPhonePage({
     }
 
     const inferredCountry = inferPhoneCountry(rawValue, selectedCountry);
-    if (isSupportedOnboardingPhoneCountry(inferredCountry)) {
+    if (
+      isSupportedOnboardingPhoneCountry(inferredCountry) &&
+      inferredCountry !== selectedCountry
+    ) {
       setSelectedCountry(inferredCountry as Country);
     }
   }

--- a/apps/web/src/features/onboarding/components/OnboardingHeader.tsx
+++ b/apps/web/src/features/onboarding/components/OnboardingHeader.tsx
@@ -1,15 +1,19 @@
-/**
- * Top of every onboarding/auth screen: a centred LobbyStack wordmark.
- */
 export function OnboardingHeader() {
   return (
-    <div className="flex w-full items-center justify-center">
+    <div
+      aria-label="LobbyStack"
+      className="flex w-full items-center justify-center gap-2.5"
+    >
       <img
-        alt="LobbyStack"
-        className="h-7 w-auto select-none"
+        alt=""
+        aria-hidden="true"
+        className="size-6 select-none dark:invert"
         draggable={false}
-        src="/brand/logo-wordmark.svg"
+        src="/brand/logo-icon.svg"
       />
+      <span className="font-heading text-xl font-semibold leading-none text-foreground">
+        LobbyStack
+      </span>
     </div>
   );
 }

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -4,6 +4,7 @@ import {
   formatPhoneNationalInput,
   formatPhoneNumberDisplay,
   getDefaultPhoneCountry,
+  getPhoneNationalInputValue,
   getPhoneNationalDigitLimit,
   getPhonePlaceholder,
   getSupportedOnboardingPhoneCountryOptions,
@@ -72,6 +73,12 @@ describe("phone helpers", () => {
     expect(formatPhoneNationalInput("0412345678", "AU")).toBe("0412 345 678");
     expect(formatPhoneNationalInput("412345678", "AU")).toBe("412 345 678");
     expect(formatPhoneNationalInput("(213) 373-4253", "US")).toBe("(213) 373-4253");
+  });
+
+  it("derives national input text from E.164 values", () => {
+    expect(getPhoneNationalInputValue("+12133734253", "US")).toBe("2133734253");
+    expect(getPhoneNationalInputValue("+447911123456", "GB")).toBe("7911123456");
+    expect(getPhoneNationalInputValue("+61412345678", "AU")).toBe("412345678");
   });
 
   it("limits onboarding country options to supported markets", () => {

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -4,6 +4,7 @@ import {
   formatPhoneNumberDisplay,
   getDefaultPhoneCountry,
   getPhonePlaceholder,
+  getSupportedOnboardingPhoneCountryOptions,
   normalizePhoneNumber,
 } from "@/lib/phone";
 
@@ -12,6 +13,7 @@ describe("phone helpers", () => {
     expect(getDefaultPhoneCountry("en-CA")).toBe("CA");
     expect(getDefaultPhoneCountry("fr-CA")).toBe("CA");
     expect(getDefaultPhoneCountry("en-US")).toBe("US");
+    expect(getDefaultPhoneCountry("en-GB")).toBe("GB");
     expect(getDefaultPhoneCountry("en")).toBe("US");
     expect(getDefaultPhoneCountry("fr")).toBe("FR");
   });
@@ -48,5 +50,11 @@ describe("phone helpers", () => {
 
   it("falls back to the raw value when parsing fails", () => {
     expect(formatPhoneNumberDisplay("not a phone", "en-US")).toBe("not a phone");
+  });
+
+  it("limits onboarding country options to supported markets", () => {
+    expect(
+      getSupportedOnboardingPhoneCountryOptions("en-US").map((option) => option.code),
+    ).toEqual(["US", "CA", "GB"]);
   });
 });

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatPhoneNationalInput,
   formatPhoneNumberDisplay,
   getDefaultPhoneCountry,
   getPhoneNationalDigitLimit,
@@ -63,6 +64,14 @@ describe("phone helpers", () => {
     expect(getPhoneNationalDigitLimit("AU", "0412345678")).toBe(10);
     expect(getPhoneNationalDigitLimit("AU", "412345678")).toBe(9);
     expect(getPhoneNationalDigitLimit("FR", "0612345678")).toBeUndefined();
+  });
+
+  it("formats supported onboarding national input as it is typed", () => {
+    expect(formatPhoneNationalInput("07123456789", "GB")).toBe("07123 456789");
+    expect(formatPhoneNationalInput("7123456789", "GB")).toBe("7123 456789");
+    expect(formatPhoneNationalInput("0412345678", "AU")).toBe("0412 345 678");
+    expect(formatPhoneNationalInput("412345678", "AU")).toBe("412 345 678");
+    expect(formatPhoneNationalInput("(213) 373-4253", "US")).toBe("(213) 373-4253");
   });
 
   it("limits onboarding country options to supported markets", () => {

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -14,6 +14,7 @@ describe("phone helpers", () => {
     expect(getDefaultPhoneCountry("fr-CA")).toBe("CA");
     expect(getDefaultPhoneCountry("en-US")).toBe("US");
     expect(getDefaultPhoneCountry("en-GB")).toBe("GB");
+    expect(getDefaultPhoneCountry("en-AU")).toBe("AU");
     expect(getDefaultPhoneCountry("en")).toBe("US");
     expect(getDefaultPhoneCountry("fr")).toBe("FR");
   });
@@ -46,6 +47,7 @@ describe("phone helpers", () => {
     expect(getPhonePlaceholder("fr-CA")).toBe("(555) 123-4567");
     expect(getPhonePlaceholder("fr-FR", { defaultCountry: "FR" })).toBe("06 12 34 56 78");
     expect(getPhonePlaceholder("en-US", { defaultCountry: "GB" })).toBe("07123 456789");
+    expect(getPhonePlaceholder("en-US", { defaultCountry: "AU" })).toBe("0412 345 678");
   });
 
   it("falls back to the raw value when parsing fails", () => {
@@ -55,6 +57,6 @@ describe("phone helpers", () => {
   it("limits onboarding country options to supported markets", () => {
     expect(
       getSupportedOnboardingPhoneCountryOptions("en-US").map((option) => option.code),
-    ).toEqual(["US", "CA", "GB"]);
+    ).toEqual(["US", "CA", "GB", "AU"]);
   });
 });

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatPhoneNumberDisplay,
   getDefaultPhoneCountry,
+  getPhoneNationalDigitLimit,
   getPhonePlaceholder,
   getSupportedOnboardingPhoneCountryOptions,
   normalizePhoneNumber,
@@ -52,6 +53,16 @@ describe("phone helpers", () => {
 
   it("falls back to the raw value when parsing fails", () => {
     expect(formatPhoneNumberDisplay("not a phone", "en-US")).toBe("not a phone");
+  });
+
+  it("returns national digit limits for supported onboarding countries", () => {
+    expect(getPhoneNationalDigitLimit("US", "2133734253")).toBe(10);
+    expect(getPhoneNationalDigitLimit("CA", "5145550123")).toBe(10);
+    expect(getPhoneNationalDigitLimit("GB", "07123123456")).toBe(11);
+    expect(getPhoneNationalDigitLimit("GB", "7123123456")).toBe(10);
+    expect(getPhoneNationalDigitLimit("AU", "0412345678")).toBe(10);
+    expect(getPhoneNationalDigitLimit("AU", "412345678")).toBe(9);
+    expect(getPhoneNationalDigitLimit("FR", "0612345678")).toBeUndefined();
   });
 
   it("limits onboarding country options to supported markets", () => {

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -4,6 +4,7 @@ import {
   formatPhoneNationalInput,
   formatPhoneNumberDisplay,
   getDefaultPhoneCountry,
+  getPhoneNationalDigits,
   getPhoneNationalInputValue,
   getPhoneNationalDigitLimit,
   getPhonePlaceholder,
@@ -67,7 +68,14 @@ describe("phone helpers", () => {
     expect(getPhoneNationalDigitLimit("FR", "0612345678")).toBeUndefined();
   });
 
+  it("removes a pasted North American calling code from national digits", () => {
+    expect(getPhoneNationalDigits("1 (213) 373-4253", "US")).toBe("2133734253");
+    expect(getPhoneNationalDigits("1 514 555 0123", "CA")).toBe("5145550123");
+    expect(getPhoneNationalDigits("0412 345 678", "AU")).toBe("0412345678");
+  });
+
   it("formats supported onboarding national input as it is typed", () => {
+    expect(formatPhoneNationalInput("12133734253", "US")).toBe("(213) 373-4253");
     expect(formatPhoneNationalInput("07123456789", "GB")).toBe("07123 456789");
     expect(formatPhoneNationalInput("7123456789", "GB")).toBe("7123 456789");
     expect(formatPhoneNationalInput("0412345678", "AU")).toBe("0412 345 678");

--- a/apps/web/src/lib/phone.test.ts
+++ b/apps/web/src/lib/phone.test.ts
@@ -43,6 +43,7 @@ describe("phone helpers", () => {
     expect(getPhonePlaceholder("en-US")).toBe("(555) 123-4567");
     expect(getPhonePlaceholder("fr-CA")).toBe("(555) 123-4567");
     expect(getPhonePlaceholder("fr-FR", { defaultCountry: "FR" })).toBe("06 12 34 56 78");
+    expect(getPhonePlaceholder("en-US", { defaultCountry: "GB" })).toBe("07123 456789");
   });
 
   it("falls back to the raw value when parsing fails", () => {

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -112,6 +112,8 @@ export function getPhonePlaceholder(
       return "(555) 123-4567";
     case "FR":
       return "06 12 34 56 78";
+    case "GB":
+      return "07123 456789";
     default:
       return "555 123 4567";
   }

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -28,6 +28,27 @@ function normalizePhoneText(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
 
+function formatDigitGroups(digits: string, groupSizes: Array<number>): string {
+  const groups: Array<string> = [];
+  let offset = 0;
+
+  for (const groupSize of groupSizes) {
+    const group = digits.slice(offset, offset + groupSize);
+    if (!group) {
+      break;
+    }
+
+    groups.push(group);
+    offset += groupSize;
+  }
+
+  if (offset < digits.length) {
+    groups.push(digits.slice(offset));
+  }
+
+  return groups.join(" ");
+}
+
 export function getDefaultPhoneCountry(locale?: string | null): CountryCode {
   const normalized = normalizePhoneText(locale).toLowerCase();
 
@@ -150,6 +171,34 @@ export function getPhoneNationalDigitLimit(
       return nationalDigits.startsWith("0") ? 10 : 9;
     default:
       return undefined;
+  }
+}
+
+export function formatPhoneNationalInput(
+  value: string | null | undefined,
+  country: CountryCode | null | undefined,
+): string {
+  const normalizedValue = normalizePhoneText(value);
+  if (!normalizedValue || normalizedValue.startsWith("+")) {
+    return normalizedValue;
+  }
+
+  const nationalDigits = normalizedValue.replace(/\D/g, "");
+  if (!nationalDigits) {
+    return "";
+  }
+
+  switch (country) {
+    case "AU":
+      return nationalDigits.startsWith("0")
+        ? formatDigitGroups(nationalDigits.slice(0, 10), [4, 3, 3])
+        : formatDigitGroups(nationalDigits.slice(0, 9), [3, 3, 3]);
+    case "GB":
+      return nationalDigits.startsWith("0")
+        ? formatDigitGroups(nationalDigits.slice(0, 11), [5, 6])
+        : formatDigitGroups(nationalDigits.slice(0, 10), [4, 6]);
+    default:
+      return normalizedValue;
   }
 }
 

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -293,6 +293,13 @@ export function normalizeOnboardingPhoneCountry(
   return isSupportedOnboardingPhoneCountry(normalized) ? normalized : fallback;
 }
 
+export function supportsOnboardingAreaCodeSearch(
+  value: string | null | undefined,
+): value is "US" | "CA" {
+  const normalized = normalizePhoneText(value).toUpperCase();
+  return normalized === "US" || normalized === "CA";
+}
+
 export type PhoneCountryOption = {
   callingCode: string;
   code: CountryCode;

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -10,7 +10,7 @@ import enLabels from "react-phone-number-input/locale/en";
 import frLabels from "react-phone-number-input/locale/fr";
 
 const DEFAULT_PHONE_COUNTRY = "US" satisfies CountryCode;
-const SUPPORTED_ONBOARDING_PHONE_COUNTRIES = ["US", "CA", "GB"] as const;
+const SUPPORTED_ONBOARDING_PHONE_COUNTRIES = ["US", "CA", "GB", "AU"] as const;
 
 export type SupportedOnboardingPhoneCountry =
   (typeof SUPPORTED_ONBOARDING_PHONE_COUNTRIES)[number];
@@ -41,6 +41,10 @@ export function getDefaultPhoneCountry(locale?: string | null): CountryCode {
 
   if (normalized.startsWith("en-gb") || normalized.startsWith("en-uk")) {
     return "GB";
+  }
+
+  if (normalized.startsWith("en-au")) {
+    return "AU";
   }
 
   if (normalized === "en" || normalized.startsWith("en-us")) {
@@ -125,6 +129,8 @@ export function getPhonePlaceholder(
       return "06 12 34 56 78";
     case "GB":
       return "07123 456789";
+    case "AU":
+      return "0412 345 678";
     default:
       return "555 123 4567";
   }

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -49,6 +49,23 @@ function formatDigitGroups(digits: string, groupSizes: Array<number>): string {
   return groups.join(" ");
 }
 
+function formatNorthAmericanPhoneInput(digits: string): string {
+  const nationalDigits = digits.slice(0, 10);
+
+  if (nationalDigits.length <= 3) {
+    return nationalDigits.length > 0 ? `(${nationalDigits}` : "";
+  }
+
+  if (nationalDigits.length <= 6) {
+    return `(${nationalDigits.slice(0, 3)}) ${nationalDigits.slice(3)}`;
+  }
+
+  return `(${nationalDigits.slice(0, 3)}) ${nationalDigits.slice(
+    3,
+    6,
+  )}-${nationalDigits.slice(6)}`;
+}
+
 export function getDefaultPhoneCountry(locale?: string | null): CountryCode {
   const normalized = normalizePhoneText(locale).toLowerCase();
 
@@ -189,6 +206,9 @@ export function formatPhoneNationalInput(
   }
 
   switch (country) {
+    case "CA":
+    case "US":
+      return formatNorthAmericanPhoneInput(nationalDigits);
     case "AU":
       return nationalDigits.startsWith("0")
         ? formatDigitGroups(nationalDigits.slice(0, 10), [4, 3, 3])
@@ -200,6 +220,23 @@ export function formatPhoneNationalInput(
     default:
       return normalizedValue;
   }
+}
+
+export function getPhoneNationalInputValue(
+  value: string | null | undefined,
+  country: CountryCode | null | undefined,
+): string {
+  const normalizedValue = normalizePhoneText(value);
+  if (!normalizedValue) {
+    return "";
+  }
+
+  if (normalizedValue.startsWith("+")) {
+    const parsed = parsePhoneNumberFromString(normalizedValue, country ?? undefined);
+    return parsed?.nationalNumber ?? normalizedValue;
+  }
+
+  return normalizedValue;
 }
 
 export function inferPhoneCountry(

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -9,13 +9,20 @@ import type { Labels } from "react-phone-number-input";
 import enLabels from "react-phone-number-input/locale/en";
 import frLabels from "react-phone-number-input/locale/fr";
 
-const DEFAULT_PHONE_COUNTRY: CountryCode = "US";
+const DEFAULT_PHONE_COUNTRY = "US" satisfies CountryCode;
+const SUPPORTED_ONBOARDING_PHONE_COUNTRIES = ["US", "CA", "GB"] as const;
+
+export type SupportedOnboardingPhoneCountry =
+  (typeof SUPPORTED_ONBOARDING_PHONE_COUNTRIES)[number];
 
 const PHONE_LABELS_BY_LOCALE: Record<"en" | "fr", Labels> = {
   en: enLabels,
   fr: frLabels,
 };
 const NORTH_AMERICAN_PHONE_COUNTRIES = new Set<CountryCode>(["US", "CA"]);
+const SUPPORTED_ONBOARDING_PHONE_COUNTRY_SET = new Set<string>(
+  SUPPORTED_ONBOARDING_PHONE_COUNTRIES,
+);
 
 function normalizePhoneText(value: string | null | undefined): string {
   return value?.trim() ?? "";
@@ -30,6 +37,10 @@ export function getDefaultPhoneCountry(locale?: string | null): CountryCode {
 
   if (normalized.startsWith("en-ca") || normalized.startsWith("fr-ca")) {
     return "CA";
+  }
+
+  if (normalized.startsWith("en-gb") || normalized.startsWith("en-uk")) {
+    return "GB";
   }
 
   if (normalized === "en" || normalized.startsWith("en-us")) {
@@ -135,6 +146,21 @@ export function inferPhoneCountry(
   );
 }
 
+export function isSupportedOnboardingPhoneCountry(
+  value: string | null | undefined,
+): value is SupportedOnboardingPhoneCountry {
+  const normalized = normalizePhoneText(value).toUpperCase();
+  return SUPPORTED_ONBOARDING_PHONE_COUNTRY_SET.has(normalized);
+}
+
+export function normalizeOnboardingPhoneCountry(
+  value: string | null | undefined,
+  fallback: SupportedOnboardingPhoneCountry = DEFAULT_PHONE_COUNTRY,
+): SupportedOnboardingPhoneCountry {
+  const normalized = normalizePhoneText(value).toUpperCase();
+  return isSupportedOnboardingPhoneCountry(normalized) ? normalized : fallback;
+}
+
 export type PhoneCountryOption = {
   callingCode: string;
   code: CountryCode;
@@ -152,4 +178,17 @@ export function getPhoneCountryOptions(locale?: string | null): Array<PhoneCount
       callingCode: `+${getCountryCallingCode(country)}`,
     }))
     .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function getSupportedOnboardingPhoneCountryOptions(
+  locale?: string | null,
+): Array<PhoneCountryOption & { code: SupportedOnboardingPhoneCountry }> {
+  const optionByCode = new Map(
+    getPhoneCountryOptions(locale).map((option) => [option.code, option]),
+  );
+
+  return SUPPORTED_ONBOARDING_PHONE_COUNTRIES.flatMap((country) => {
+    const option = optionByCode.get(country);
+    return option ? [{ ...option, code: country }] : [];
+  });
 }

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -136,6 +136,23 @@ export function getPhonePlaceholder(
   }
 }
 
+export function getPhoneNationalDigitLimit(
+  country: CountryCode | null | undefined,
+  nationalDigits = "",
+): number | undefined {
+  switch (country) {
+    case "CA":
+    case "US":
+      return 10;
+    case "GB":
+      return nationalDigits.startsWith("0") ? 11 : 10;
+    case "AU":
+      return nationalDigits.startsWith("0") ? 10 : 9;
+    default:
+      return undefined;
+  }
+}
+
 export function inferPhoneCountry(
   value: string | null | undefined,
   defaultCountry?: CountryCode | null,

--- a/apps/web/src/lib/phone.ts
+++ b/apps/web/src/lib/phone.ts
@@ -50,7 +50,7 @@ function formatDigitGroups(digits: string, groupSizes: Array<number>): string {
 }
 
 function formatNorthAmericanPhoneInput(digits: string): string {
-  const nationalDigits = digits.slice(0, 10);
+  const nationalDigits = stripNorthAmericanCallingCode(digits).slice(0, 10);
 
   if (nationalDigits.length <= 3) {
     return nationalDigits.length > 0 ? `(${nationalDigits}` : "";
@@ -64,6 +64,14 @@ function formatNorthAmericanPhoneInput(digits: string): string {
     3,
     6,
   )}-${nationalDigits.slice(6)}`;
+}
+
+function stripNorthAmericanCallingCode(digits: string): string {
+  if (digits.length > 10 && digits.startsWith("1")) {
+    return digits.slice(1);
+  }
+
+  return digits;
 }
 
 export function getDefaultPhoneCountry(locale?: string | null): CountryCode {
@@ -191,6 +199,21 @@ export function getPhoneNationalDigitLimit(
   }
 }
 
+export function getPhoneNationalDigits(
+  value: string | null | undefined,
+  country: CountryCode | null | undefined,
+): string {
+  const digits = normalizePhoneText(value).replace(/\D/g, "");
+
+  switch (country) {
+    case "CA":
+    case "US":
+      return stripNorthAmericanCallingCode(digits);
+    default:
+      return digits;
+  }
+}
+
 export function formatPhoneNationalInput(
   value: string | null | undefined,
   country: CountryCode | null | undefined,
@@ -200,7 +223,7 @@ export function formatPhoneNationalInput(
     return normalizedValue;
   }
 
-  const nationalDigits = normalizedValue.replace(/\D/g, "");
+  const nationalDigits = getPhoneNationalDigits(normalizedValue, country);
   if (!nationalDigits) {
     return "";
   }

--- a/convex/onboarding/phoneNumbers.ts
+++ b/convex/onboarding/phoneNumbers.ts
@@ -54,6 +54,7 @@ type TwilioLookupResult = {
 };
 
 type SupportedPhoneNumberCountryCode = "US" | "CA" | "GB" | "AU";
+type TwilioAreaCodeSearchCountryCode = "US" | "CA";
 
 type PurchasedIncomingNumber = {
   sid: string;
@@ -294,6 +295,13 @@ function normalizeSupportedCountryCode(
   return normalized === "US" || normalized === "CA" || normalized === "GB" || normalized === "AU"
     ? normalized
     : null;
+}
+
+function supportsTwilioAreaCodeSearch(
+  countryCode: string,
+): countryCode is TwilioAreaCodeSearchCountryCode {
+  const normalized = countryCode.trim().toUpperCase();
+  return normalized === "US" || normalized === "CA";
 }
 
 function dedupeNumbers(numbers: Array<AvailableNumberSummary>): Array<AvailableNumberSummary> {
@@ -630,6 +638,14 @@ function buildNormalizedSelectionContext(input: {
   }
 
   if (requestedSelectionContext.mode === "area_code") {
+    if (!supportsTwilioAreaCodeSearch(countryCode)) {
+      return buildSuggestedSelectionContext({
+        countryCode,
+        confidence: fallbackContext.confidence,
+        source: fallbackContext.source,
+      });
+    }
+
     return buildAreaCodeSelectionContext({
       countryCode,
       areaCode: requestedAreaCode || "",
@@ -790,10 +806,15 @@ export const searchAvailableNumbers = action({
       userId,
     });
     const { market, context } = await resolveVerifiedSuggestionContext(ctx, args.businessId, userId);
-    const searchContext: NumberSuggestionContext = {
-      ...context,
-      ...(args.countryCode ? { countryCode: args.countryCode } : {}),
-    };
+    const searchCountryCode = args.countryCode ?? context.countryCode;
+    const searchContext: NumberSuggestionContext =
+      searchCountryCode === context.countryCode
+        ? context
+        : {
+            countryCode: searchCountryCode,
+            confidence: context.confidence,
+            source: context.source,
+          };
     const limit = normalizeInventorySearchLimit(args.limit);
     const selectionContext = buildNormalizedSelectionContext({
       requestedSelectionContext: {

--- a/convex/onboarding/phoneNumbers.ts
+++ b/convex/onboarding/phoneNumbers.ts
@@ -53,6 +53,8 @@ type TwilioLookupResult = {
   valid: boolean;
 };
 
+type SupportedPhoneNumberCountryCode = "US" | "CA" | "GB";
+
 type PurchasedIncomingNumber = {
   sid: string;
   smsUrl?: string | null;
@@ -285,9 +287,13 @@ function verifyNumberClaimToken(input: {
   return payload;
 }
 
-function normalizeSupportedCountryCode(value: string | undefined): "US" | "CA" | null {
+function normalizeSupportedCountryCode(
+  value: string | undefined,
+): SupportedPhoneNumberCountryCode | null {
   const normalized = value?.trim().toUpperCase();
-  return normalized === "US" || normalized === "CA" ? normalized : null;
+  return normalized === "US" || normalized === "CA" || normalized === "GB"
+    ? normalized
+    : null;
 }
 
 function dedupeNumbers(numbers: Array<AvailableNumberSummary>): Array<AvailableNumberSummary> {
@@ -769,7 +775,7 @@ export const searchAvailableNumbers = action({
   args: {
     businessId: v.id("businesses"),
     mode: searchModeValidator,
-    countryCode: v.optional(v.union(v.literal("US"), v.literal("CA"))),
+    countryCode: v.optional(v.union(v.literal("US"), v.literal("CA"), v.literal("GB"))),
     city: v.optional(v.string()),
     areaCode: v.optional(v.string()),
     limit: v.optional(v.number()),

--- a/convex/onboarding/phoneNumbers.ts
+++ b/convex/onboarding/phoneNumbers.ts
@@ -53,7 +53,7 @@ type TwilioLookupResult = {
   valid: boolean;
 };
 
-type SupportedPhoneNumberCountryCode = "US" | "CA" | "GB";
+type SupportedPhoneNumberCountryCode = "US" | "CA" | "GB" | "AU";
 
 type PurchasedIncomingNumber = {
   sid: string;
@@ -291,7 +291,7 @@ function normalizeSupportedCountryCode(
   value: string | undefined,
 ): SupportedPhoneNumberCountryCode | null {
   const normalized = value?.trim().toUpperCase();
-  return normalized === "US" || normalized === "CA" || normalized === "GB"
+  return normalized === "US" || normalized === "CA" || normalized === "GB" || normalized === "AU"
     ? normalized
     : null;
 }
@@ -775,7 +775,9 @@ export const searchAvailableNumbers = action({
   args: {
     businessId: v.id("businesses"),
     mode: searchModeValidator,
-    countryCode: v.optional(v.union(v.literal("US"), v.literal("CA"), v.literal("GB"))),
+    countryCode: v.optional(
+      v.union(v.literal("US"), v.literal("CA"), v.literal("GB"), v.literal("AU")),
+    ),
     city: v.optional(v.string()),
     areaCode: v.optional(v.string()),
     limit: v.optional(v.number()),

--- a/convex/onboarding/phoneVerification.ts
+++ b/convex/onboarding/phoneVerification.ts
@@ -234,6 +234,7 @@ export const reuseVerifiedPhoneForOnboarding = action({
     if (!latestApprovedAttempt || latestApprovedAttempt.phoneE164 !== user.phone) {
       throw new Error("Verify your mobile number before continuing.");
     }
+    assertSupportedVerificationCountry(latestApprovedAttempt.countryCode);
 
     await ctx.runMutation(internal.onboarding.phoneVerificationState.saveVerificationAttempt, {
       businessId: args.businessId,
@@ -283,6 +284,7 @@ export const resendPhoneVerification = action({
     if (!attempt) {
       throw new Error("Start verification again before requesting a new code.");
     }
+    assertSupportedVerificationCountry(attempt.countryCode);
 
     const now = Date.now();
     if (now - attempt.updatedAt < VERIFICATION_RESEND_COOLDOWN_MS) {
@@ -351,6 +353,7 @@ export const checkPhoneVerification = action({
     if (!attempt || attempt.phoneE164 !== args.phoneE164) {
       throw new Error("Start verification again before entering a code.");
     }
+    assertSupportedVerificationCountry(attempt.countryCode);
 
     if (attempt.status === "approved") {
       return {

--- a/convex/onboarding/phoneVerification.ts
+++ b/convex/onboarding/phoneVerification.ts
@@ -47,10 +47,17 @@ type CheckPhoneVerificationResult =
     };
 
 const VERIFICATION_RESEND_COOLDOWN_MS = 30_000;
+const SUPPORTED_VERIFICATION_COUNTRIES = new Set(["US", "CA", "GB"]);
 
 function normalizeLineType(lineType: string | null | undefined): string | undefined {
   const normalized = lineType?.trim().toLowerCase();
   return normalized ? normalized : undefined;
+}
+
+function assertSupportedVerificationCountry(countryCode: string): void {
+  if (!SUPPORTED_VERIFICATION_COUNTRIES.has(countryCode.trim().toUpperCase())) {
+    throw new Error("We currently support US, Canadian, and UK mobile numbers.");
+  }
 }
 
 function buildVerificationErrorMessage(error: unknown): string {
@@ -140,6 +147,7 @@ export const startPhoneVerification = action({
       if (!lookup.valid) {
         throw new Error("Enter a valid mobile number in international format.");
       }
+      assertSupportedVerificationCountry(lookup.countryCode);
 
       const lineType = normalizeLineType(lookup.lineTypeIntelligence?.type);
       if (lineType && lineType !== "mobile") {

--- a/convex/onboarding/phoneVerification.ts
+++ b/convex/onboarding/phoneVerification.ts
@@ -47,7 +47,7 @@ type CheckPhoneVerificationResult =
     };
 
 const VERIFICATION_RESEND_COOLDOWN_MS = 30_000;
-const SUPPORTED_VERIFICATION_COUNTRIES = new Set(["US", "CA", "GB"]);
+const SUPPORTED_VERIFICATION_COUNTRIES = new Set(["US", "CA", "GB", "AU"]);
 
 function normalizeLineType(lineType: string | null | undefined): string | undefined {
   const normalized = lineType?.trim().toLowerCase();
@@ -56,7 +56,7 @@ function normalizeLineType(lineType: string | null | undefined): string | undefi
 
 function assertSupportedVerificationCountry(countryCode: string): void {
   if (!SUPPORTED_VERIFICATION_COUNTRIES.has(countryCode.trim().toUpperCase())) {
-    throw new Error("We currently support US, Canadian, and UK mobile numbers.");
+    throw new Error("We currently support US, Canadian, UK, and Australian mobile numbers.");
   }
 }
 

--- a/convex/tests/onboardingPhoneNumbers.test.ts
+++ b/convex/tests/onboardingPhoneNumbers.test.ts
@@ -637,6 +637,54 @@ describe("onboarding phone-number actions", () => {
     });
   });
 
+  it("searches Australian local inventory when AU is selected", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    await seedVerifiedPhone({
+      t,
+      businessId,
+      userId,
+      phoneE164: "+61412345678",
+      countryCode: "AU",
+    });
+    const authed = t.withIdentity({ subject });
+
+    listLocalNumbersMock.mockResolvedValue([
+      {
+        phoneNumber: "+61280123456",
+        locality: "Sydney",
+        region: "NSW",
+        isoCountry: "AU",
+        capabilities: { sms: true, voice: true },
+      },
+    ]);
+
+    const result = await authed.action(api.onboarding.phoneNumbers.searchAvailableNumbers, {
+      businessId,
+      mode: "suggested",
+      countryCode: "AU",
+      limit: 5,
+    });
+
+    expect(listLocalNumbersMock).toHaveBeenCalledWith({
+      countryCode: "AU",
+      args: {
+        limit: 5,
+        smsEnabled: true,
+        voiceEnabled: true,
+      },
+    });
+    expect(result.selectionContext).toEqual({
+      mode: "suggested",
+      countryCode: "AU",
+    });
+    expect(result.numbers[0]).toMatchObject({
+      e164: "+61280123456",
+      countryCode: "AU",
+      kind: "local",
+    });
+  });
+
   it("only returns inventory with both voice and SMS capabilities", async () => {
     const t = createConvexHarness();
     const { businessId, subject, userId } = await seedBusinessOwner(t);

--- a/convex/tests/onboardingPhoneNumbers.test.ts
+++ b/convex/tests/onboardingPhoneNumbers.test.ts
@@ -637,6 +637,59 @@ describe("onboarding phone-number actions", () => {
     });
   });
 
+  it("falls back to country-wide UK inventory for area-code searches", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    await seedVerifiedPhone({
+      t,
+      businessId,
+      userId,
+      phoneE164: "+447911123456",
+      countryCode: "GB",
+    });
+    const authed = t.withIdentity({ subject });
+
+    listLocalNumbersMock.mockResolvedValue([
+      {
+        phoneNumber: "+442071838750",
+        locality: "London",
+        region: "London",
+        isoCountry: "GB",
+        capabilities: { sms: true, voice: true },
+      },
+    ]);
+
+    const result = await authed.action(api.onboarding.phoneNumbers.searchAvailableNumbers, {
+      businessId,
+      mode: "area_code",
+      countryCode: "GB",
+      areaCode: "020",
+      limit: 5,
+    });
+
+    expect(listLocalNumbersMock).toHaveBeenCalledWith({
+      countryCode: "GB",
+      args: {
+        limit: 5,
+        smsEnabled: true,
+        voiceEnabled: true,
+      },
+    });
+    expect(result.selectionContext).toEqual({
+      mode: "suggested",
+      countryCode: "GB",
+    });
+    expect(result.numbers[0]).toMatchObject({
+      e164: "+442071838750",
+      countryCode: "GB",
+      kind: "local",
+      selectionContext: {
+        mode: "suggested",
+        countryCode: "GB",
+      },
+    });
+  });
+
   it("searches Australian local inventory when AU is selected", async () => {
     const t = createConvexHarness();
     const { businessId, subject, userId } = await seedBusinessOwner(t);
@@ -682,6 +735,56 @@ describe("onboarding phone-number actions", () => {
       e164: "+61280123456",
       countryCode: "AU",
       kind: "local",
+    });
+  });
+
+  it("does not reuse verified NANP area hints when switching to Australia", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    await seedVerifiedPhone({
+      t,
+      businessId,
+      userId,
+      phoneE164: "+15815550100",
+      countryCode: "CA",
+    });
+    const authed = t.withIdentity({ subject });
+
+    listLocalNumbersMock.mockResolvedValue([
+      {
+        phoneNumber: "+61280123456",
+        locality: "Sydney",
+        region: "NSW",
+        isoCountry: "AU",
+        capabilities: { sms: true, voice: true },
+      },
+    ]);
+
+    const result = await authed.action(api.onboarding.phoneNumbers.searchAvailableNumbers, {
+      businessId,
+      mode: "suggested",
+      countryCode: "AU",
+      limit: 5,
+    });
+
+    expect(listLocalNumbersMock).toHaveBeenCalledWith({
+      countryCode: "AU",
+      args: {
+        limit: 5,
+        smsEnabled: true,
+        voiceEnabled: true,
+      },
+    });
+    expect(result.selectionContext).toEqual({
+      mode: "suggested",
+      countryCode: "AU",
+    });
+    expect(result.numbers[0]).toMatchObject({
+      e164: "+61280123456",
+      selectionContext: {
+        mode: "suggested",
+        countryCode: "AU",
+      },
     });
   });
 

--- a/convex/tests/onboardingPhoneNumbers.test.ts
+++ b/convex/tests/onboardingPhoneNumbers.test.ts
@@ -589,6 +589,54 @@ describe("onboarding phone-number actions", () => {
     expect(typeof result.numbers[0]?.claimToken).toBe("string");
   });
 
+  it("searches UK local inventory when GB is selected", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    await seedVerifiedPhone({
+      t,
+      businessId,
+      userId,
+      phoneE164: "+447911123456",
+      countryCode: "GB",
+    });
+    const authed = t.withIdentity({ subject });
+
+    listLocalNumbersMock.mockResolvedValue([
+      {
+        phoneNumber: "+442071838750",
+        locality: "London",
+        region: "London",
+        isoCountry: "GB",
+        capabilities: { sms: true, voice: true },
+      },
+    ]);
+
+    const result = await authed.action(api.onboarding.phoneNumbers.searchAvailableNumbers, {
+      businessId,
+      mode: "suggested",
+      countryCode: "GB",
+      limit: 5,
+    });
+
+    expect(listLocalNumbersMock).toHaveBeenCalledWith({
+      countryCode: "GB",
+      args: {
+        limit: 5,
+        smsEnabled: true,
+        voiceEnabled: true,
+      },
+    });
+    expect(result.selectionContext).toEqual({
+      mode: "suggested",
+      countryCode: "GB",
+    });
+    expect(result.numbers[0]).toMatchObject({
+      e164: "+442071838750",
+      countryCode: "GB",
+      kind: "local",
+    });
+  });
+
   it("only returns inventory with both voice and SMS capabilities", async () => {
     const t = createConvexHarness();
     const { businessId, subject, userId } = await seedBusinessOwner(t);

--- a/convex/tests/onboardingPhoneVerification.test.ts
+++ b/convex/tests/onboardingPhoneVerification.test.ts
@@ -274,6 +274,34 @@ describe("onboarding phone verification actions", () => {
     });
   });
 
+  it("allows Australian mobile phone verification", async () => {
+    lookupFetchMock.mockImplementation(async ({ phoneNumber }: { phoneNumber: string }) => ({
+      phoneNumber: phoneNumber.trim(),
+      countryCode: "AU",
+      valid: true,
+      lineTypeIntelligence: {
+        type: "mobile",
+      },
+    }));
+    const t = createConvexHarness();
+    const { businessId, subject } = await seedBusinessOwner(t);
+    const authed = t.withIdentity({ subject });
+
+    const result = await authed.action(api.onboarding.phoneVerification.startPhoneVerification, {
+      businessId,
+      phoneE164: "+61412345678",
+    });
+
+    expect(verificationCreateMock).toHaveBeenCalledWith({
+      to: "+61412345678",
+      channel: "sms",
+    });
+    expect(result).toMatchObject({
+      phoneE164: "+61412345678",
+      countryCode: "AU",
+    });
+  });
+
   it("rejects unsupported verification countries", async () => {
     lookupFetchMock.mockImplementation(async ({ phoneNumber }: { phoneNumber: string }) => ({
       phoneNumber: phoneNumber.trim(),
@@ -292,7 +320,9 @@ describe("onboarding phone verification actions", () => {
         businessId,
         phoneE164: "+33612345678",
       }),
-    ).rejects.toThrow("We currently support US, Canadian, and UK mobile numbers.");
+    ).rejects.toThrow(
+      "We currently support US, Canadian, UK, and Australian mobile numbers.",
+    );
     expect(verificationCreateMock).not.toHaveBeenCalled();
   });
 

--- a/convex/tests/onboardingPhoneVerification.test.ts
+++ b/convex/tests/onboardingPhoneVerification.test.ts
@@ -56,6 +56,8 @@ const convexModules = modules;
 const originalTwilioAccountSid = process.env.TWILIO_ACCOUNT_SID;
 const originalTwilioAuthToken = process.env.TWILIO_AUTH_TOKEN;
 const originalTwilioVerifyServiceSid = process.env.TWILIO_VERIFY_SERVICE_SID;
+const UNSUPPORTED_VERIFICATION_COUNTRY_MESSAGE =
+  "We currently support US, Canadian, UK, and Australian mobile numbers.";
 
 function createConvexHarness() {
   const t = convexTest(schema, convexModules);
@@ -173,6 +175,34 @@ async function listVerificationAttempts(
       .query("onboarding_phone_verifications")
       .withIndex("by_business_id_and_user_id", (q) => q.eq("businessId", businessId))
       .collect();
+  });
+}
+
+async function seedLegacyVerificationAttempt(input: {
+  t: ConvexHarness;
+  businessId: Id<"businesses">;
+  userId: Id<"users">;
+  phoneE164: string;
+  countryCode: string;
+  status?: string;
+  verificationSid?: string;
+}) {
+  const timestamp = 1_700_000_000_000;
+
+  return await input.t.run(async (ctx) => {
+    return await ctx.db.insert("onboarding_phone_verifications", {
+      businessId: input.businessId,
+      userId: input.userId,
+      phoneE164: input.phoneE164,
+      countryCode: input.countryCode,
+      verificationSid: input.verificationSid ?? "VE-legacy",
+      status: input.status ?? "pending",
+      startedAt: timestamp,
+      updatedAt: timestamp,
+      expiresAt: timestamp + 10 * 60 * 1000,
+      ...(input.status === "approved" ? { approvedAt: timestamp } : {}),
+      attemptCount: input.status === "approved" ? 1 : 0,
+    });
   });
 }
 
@@ -320,10 +350,105 @@ describe("onboarding phone verification actions", () => {
         businessId,
         phoneE164: "+33612345678",
       }),
-    ).rejects.toThrow(
-      "We currently support US, Canadian, UK, and Australian mobile numbers.",
-    );
+    ).rejects.toThrow(UNSUPPORTED_VERIFICATION_COUNTRY_MESSAGE);
     expect(verificationCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects reused verified phones from unsupported countries", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    const priorBusinessId = await seedAdditionalBusinessForUser({
+      t,
+      userId,
+      slug: "prior-unsupported-phone-business",
+    });
+    const authed = t.withIdentity({ subject });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, {
+        phone: "+33612345678",
+        phoneVerificationTime: 1_700_000_000_000,
+      });
+    });
+    await seedLegacyVerificationAttempt({
+      t,
+      businessId: priorBusinessId,
+      userId,
+      phoneE164: "+33612345678",
+      countryCode: "FR",
+      status: "approved",
+      verificationSid: "VE-prior-unsupported-approved",
+    });
+
+    await expect(
+      authed.action(api.onboarding.phoneVerification.reuseVerifiedPhoneForOnboarding, {
+        businessId,
+      }),
+    ).rejects.toThrow(UNSUPPORTED_VERIFICATION_COUNTRY_MESSAGE);
+
+    const business = await t.query(internal.businesses.admin.getBusinessById, {
+      businessId,
+    });
+    expect(business?.onboardingStage).toBe("verify_phone");
+    await expect(listVerificationAttempts(t, businessId)).resolves.toHaveLength(0);
+  });
+
+  it("rejects resends for unsupported legacy verification attempts", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    const authed = t.withIdentity({ subject });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(businessId, {
+        onboardingStage: "verify_phone_code",
+      });
+    });
+    await seedLegacyVerificationAttempt({
+      t,
+      businessId,
+      userId,
+      phoneE164: "+33612345678",
+      countryCode: "FR",
+      verificationSid: "VE-legacy-unsupported-pending",
+    });
+
+    await expect(
+      authed.action(api.onboarding.phoneVerification.resendPhoneVerification, {
+        businessId,
+      }),
+    ).rejects.toThrow(UNSUPPORTED_VERIFICATION_COUNTRY_MESSAGE);
+
+    expect(verificationCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects code checks for unsupported legacy verification attempts", async () => {
+    const t = createConvexHarness();
+    const { businessId, subject, userId } = await seedBusinessOwner(t);
+    const authed = t.withIdentity({ subject });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(businessId, {
+        onboardingStage: "verify_phone_code",
+      });
+    });
+    await seedLegacyVerificationAttempt({
+      t,
+      businessId,
+      userId,
+      phoneE164: "+33612345678",
+      countryCode: "FR",
+      verificationSid: "VE-legacy-unsupported-code-check",
+    });
+
+    await expect(
+      authed.action(api.onboarding.phoneVerification.checkPhoneVerification, {
+        businessId,
+        phoneE164: "+33612345678",
+        code: "123456",
+      }),
+    ).rejects.toThrow(UNSUPPORTED_VERIFICATION_COUNTRY_MESSAGE);
+
+    expect(verificationCheckCreateMock).not.toHaveBeenCalled();
   });
 
   it("throttles rapid resend attempts for the same verified phone", async () => {

--- a/convex/tests/onboardingPhoneVerification.test.ts
+++ b/convex/tests/onboardingPhoneVerification.test.ts
@@ -246,6 +246,56 @@ describe("onboarding phone verification actions", () => {
     });
   });
 
+  it("allows UK mobile phone verification", async () => {
+    lookupFetchMock.mockImplementation(async ({ phoneNumber }: { phoneNumber: string }) => ({
+      phoneNumber: phoneNumber.trim(),
+      countryCode: "GB",
+      valid: true,
+      lineTypeIntelligence: {
+        type: "mobile",
+      },
+    }));
+    const t = createConvexHarness();
+    const { businessId, subject } = await seedBusinessOwner(t);
+    const authed = t.withIdentity({ subject });
+
+    const result = await authed.action(api.onboarding.phoneVerification.startPhoneVerification, {
+      businessId,
+      phoneE164: "+447911123456",
+    });
+
+    expect(verificationCreateMock).toHaveBeenCalledWith({
+      to: "+447911123456",
+      channel: "sms",
+    });
+    expect(result).toMatchObject({
+      phoneE164: "+447911123456",
+      countryCode: "GB",
+    });
+  });
+
+  it("rejects unsupported verification countries", async () => {
+    lookupFetchMock.mockImplementation(async ({ phoneNumber }: { phoneNumber: string }) => ({
+      phoneNumber: phoneNumber.trim(),
+      countryCode: "FR",
+      valid: true,
+      lineTypeIntelligence: {
+        type: "mobile",
+      },
+    }));
+    const t = createConvexHarness();
+    const { businessId, subject } = await seedBusinessOwner(t);
+    const authed = t.withIdentity({ subject });
+
+    await expect(
+      authed.action(api.onboarding.phoneVerification.startPhoneVerification, {
+        businessId,
+        phoneE164: "+33612345678",
+      }),
+    ).rejects.toThrow("We currently support US, Canadian, and UK mobile numbers.");
+    expect(verificationCreateMock).not.toHaveBeenCalled();
+  });
+
   it("throttles rapid resend attempts for the same verified phone", async () => {
     const t = createConvexHarness();
     const { businessId, subject } = await seedBusinessOwner(t);


### PR DESCRIPTION
## Summary
- Add country prefix support to onboarding phone collection and verification
- Update phone input, onboarding pages, and locale copy to reflect country-aware formatting
- Strengthen backend phone normalization and verification coverage with new tests
- Refresh landing page calculator and supporting UI slider styles for the updated flow

## Testing
- Added and updated unit tests for phone parsing, phone input behavior, onboarding pages, and Convex phone verification flows
- Verified locale updates for English and French onboarding copy
- Not run (not requested)