### PR TITLE
Allow dashboard origin for production web calls

### DIFF
--- a/fly.voice-gateway.production.toml
+++ b/fly.voice-gateway.production.toml
@@ -11,6 +11,7 @@ primary_region = "iad"
   DEPLOYMENT_MODE = "cloud"
   PORT = "3001"
   VOICE_GATEWAY_TRUST_PROXY = "true"
+  WEB_CALL_ALLOWED_ORIGINS = "https://app.lobbystack.com,https://lobbystack.com,https://www.lobbystack.com"
 
 [http_service]
   internal_port = 3001

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -36,7 +36,10 @@ describe("loadVoiceGatewayEnv", () => {
     });
 
     expect(env.WEB_CALL_ALLOWED_ORIGINS).toBe(
-      "https://lobbystack.com,https://www.lobbystack.com",
+      "https://app.lobbystack.com,https://lobbystack.com,https://www.lobbystack.com",
+    );
+    expect(env.WEB_CALL_ALLOWED_ORIGINS).toContain(
+      "https://app.lobbystack.com",
     );
     expect(env.WEB_CALL_ALLOWED_ORIGINS).toContain("https://lobbystack.com");
     expect(env.WEB_CALL_ALLOWED_ORIGINS).toContain(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -119,7 +119,9 @@ const voiceGatewayEnvSchema = z.object({
   OPENAI_TRANSCRIPTION_OUTPUT_TOKEN_PRICE_USD: z.coerce.number().optional(),
   WEB_CALL_ALLOWED_ORIGINS: z
     .string()
-    .default("https://lobbystack.com,https://www.lobbystack.com"),
+    .default(
+      "https://app.lobbystack.com,https://lobbystack.com,https://www.lobbystack.com",
+    ),
   WEB_CALL_MAX_DURATION_MS: z.coerce
     .number()
     .int()


### PR DESCRIPTION
## Summary
- Add `https://app.lobbystack.com` to the default web-call allowed origins.
- Set the same origin list in the production voice gateway Fly config.
- Update the config test to cover the dashboard origin.

## Verification
- `../../node_modules/.bin/vitest run src/index.test.ts` from `packages/config`
- `git diff --check`
- Production preflight now returns `200` for `Origin: https://app.lobbystack.com` against `https://voice.lobbystack.com/web-call/sessions`.

## Production note
The production Fly secret `WEB_CALL_ALLOWED_ORIGINS` was updated immediately to restore dashboard test calls before this PR lands.