### PR TITLE
Remove daily recap feature

### DIFF
--- a/apps/landing/src/components/features/FeatureWall.tsx
+++ b/apps/landing/src/components/features/FeatureWall.tsx
@@ -22,7 +22,6 @@ import {
   FileText,
   ScrollText,
   Mail,
-  BarChart3,
   BookOpen,
   Layers,
   CircleSlash,
@@ -203,13 +202,6 @@ const mediumCards: FeatureCard[] = [
     description:
       "Send booking updates, quote requests, urgent alerts, missed-transfer summaries, and high-value lead notices to the right person.",
     icon: Mail,
-    size: "medium",
-  },
-  {
-    title: "Daily recap",
-    description:
-      "Send a daily summary of bookings, quote requests, missed calls, spam blocked, and follow-ups.",
-    icon: BarChart3,
     size: "medium",
   },
   {
@@ -449,13 +441,6 @@ const mediumCardsFr: FeatureCard[] = [
     description:
       "Envoyez rendez‑vous, demandes de devis, alertes urgentes, transferts manqués et prospects importants à la bonne personne.",
     icon: Mail,
-    size: "medium",
-  },
-  {
-    title: "Récapitulatif quotidien",
-    description:
-      "Recevez chaque jour un résumé des rendez‑vous, demandes de devis, appels manqués, appels filtrés et suivis.",
-    icon: BarChart3,
     size: "medium",
   },
   {

--- a/apps/web/public/locales/en/settings.json
+++ b/apps/web/public/locales/en/settings.json
@@ -722,7 +722,7 @@
       "title": "Channels",
       "email": {
         "title": "Email",
-        "description": "Receive alerts and daily summaries by email."
+        "description": "Receive alerts by email."
       },
       "sms": {
         "title": "SMS",
@@ -763,17 +763,6 @@
     },
     "systemIssues": {
       "title": "System issues"
-    },
-    "digest": {
-      "title": "Digest",
-      "dailySummary": {
-        "title": "Daily summary",
-        "description": "Receive a single daily email summarizing call activity and new messages."
-      },
-      "sendTime": {
-        "title": "Send time",
-        "description": "The time of day your daily summary will be sent."
-      }
     },
     "smsConsent": {
       "title": "Enable SMS alerts",

--- a/apps/web/public/locales/fr/settings.json
+++ b/apps/web/public/locales/fr/settings.json
@@ -721,7 +721,7 @@
       "title": "Canaux",
       "email": {
         "title": "Courriel",
-        "description": "Recevez les alertes et les résumés quotidiens par courriel."
+        "description": "Recevez les alertes par courriel."
       },
       "sms": {
         "title": "SMS",
@@ -762,17 +762,6 @@
     },
     "systemIssues": {
       "title": "Problèmes système"
-    },
-    "digest": {
-      "title": "Résumé",
-      "dailySummary": {
-        "title": "Résumé quotidien",
-        "description": "Recevez un seul courriel quotidien résumant l'activité des appels et les nouveaux messages."
-      },
-      "sendTime": {
-        "title": "Heure d'envoi",
-        "description": "L'heure à laquelle votre résumé quotidien sera envoyé."
-      }
     },
     "smsConsent": {
       "title": "Activer les alertes SMS",

--- a/apps/web/src/features/settings/SettingsNotificationsPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsNotificationsPage.test.tsx
@@ -49,8 +49,6 @@ function buildPreferences(overrides: Record<string, unknown> = {}) {
       transferFailed: { email: true, sms: false },
       aiReplyFailed: { email: true, sms: false },
     },
-    dailySummaryEnabled: true,
-    dailySummarySendTime: "08:00",
     email: "operator@example.com",
     phone: "+15145550123",
     phoneVerified: true,
@@ -99,7 +97,7 @@ describe("SettingsNotificationsPage", () => {
     expect(screen.queryByText("settings:notifications.sources.browser.title")).toBeNull();
   });
 
-  it("persists channel toggles and digest send time changes", async () => {
+  it("persists channel toggles", async () => {
     const user = userEvent.setup();
     renderNotificationsPage();
 
@@ -114,20 +112,6 @@ describe("SettingsNotificationsPage", () => {
         expect.objectContaining({
           businessId,
           emailEnabled: false,
-        }),
-      );
-    });
-
-    await user.selectOptions(
-      screen.getByLabelText("settings:notifications.digest.sendTime.title"),
-      "17:00",
-    );
-
-    await waitFor(() => {
-      expect(updateNotificationPreferencesMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          businessId,
-          dailySummarySendTime: "17:00",
         }),
       );
     });

--- a/apps/web/src/features/settings/SettingsNotificationsPage.tsx
+++ b/apps/web/src/features/settings/SettingsNotificationsPage.tsx
@@ -23,10 +23,6 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 import { useObservedMutation } from "@/lib/observed-convex";
-import {
-  NativeSelect,
-  NativeSelectOption,
-} from "@/components/ui/native-select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Surface } from "@/components/ui/surface";
 import { Switch } from "@/components/ui/switch";
@@ -62,8 +58,6 @@ type NotificationPreferencesState = {
   emailEnabled: boolean;
   smsEnabled: boolean;
   eventPreferences: NotificationEventPreferences;
-  dailySummaryEnabled: boolean;
-  dailySummarySendTime: string;
   smsConsentGranted: boolean;
   smsConsentDisclosureVersion: string;
   smsConsentDisclosureText: string;
@@ -88,8 +82,6 @@ function toPreferenceState(input: NotificationPreferencesState): NotificationPre
     emailEnabled: input.emailEnabled,
     smsEnabled: input.smsEnabled,
     eventPreferences: input.eventPreferences,
-    dailySummaryEnabled: input.dailySummaryEnabled,
-    dailySummarySendTime: input.dailySummarySendTime,
     smsConsentGranted: input.smsConsentGranted,
     smsConsentDisclosureVersion: input.smsConsentDisclosureVersion,
     smsConsentDisclosureText: input.smsConsentDisclosureText,
@@ -231,26 +223,6 @@ export function SettingsNotificationsPage({
           [channel]: checked,
         },
       },
-    });
-  }
-
-  function handleDailySummaryChange(checked: boolean): void {
-    if (!draft) {
-      return;
-    }
-    persistPreferences({
-      ...draft,
-      dailySummaryEnabled: checked,
-    });
-  }
-
-  function handleSendTimeChange(sendTime: string): void {
-    if (!draft) {
-      return;
-    }
-    persistPreferences({
-      ...draft,
-      dailySummarySendTime: sendTime,
     });
   }
 
@@ -423,59 +395,6 @@ export function SettingsNotificationsPage({
               {renderConfigHeader()}
               <TableBody>{renderConfigRows(systemIssueEvents)}</TableBody>
             </Table>
-          </Surface>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <div>
-            <h3 className="text-sm font-medium text-foreground">
-              {t("settings:notifications.digest.title")}
-            </h3>
-          </div>
-          <Surface className="flex flex-col">
-            <Item
-              className="rounded-none border-x-0 border-t-0 border-b border-border last:border-b-0"
-              variant="default"
-            >
-              <ItemContent>
-                <ItemTitle>{t("settings:notifications.digest.dailySummary.title")}</ItemTitle>
-                <ItemDescription>
-                  {t("settings:notifications.digest.dailySummary.description")}
-                </ItemDescription>
-              </ItemContent>
-              <ItemActions>
-                <Switch
-                  aria-label={t("settings:notifications.digest.dailySummary.title")}
-                  checked={draft.dailySummaryEnabled}
-                  onCheckedChange={handleDailySummaryChange}
-                />
-              </ItemActions>
-            </Item>
-
-            <Item
-              className="rounded-none border-x-0 border-t-0 border-b border-border last:border-b-0"
-              variant="default"
-            >
-              <ItemContent>
-                <ItemTitle>{t("settings:notifications.digest.sendTime.title")}</ItemTitle>
-                <ItemDescription>
-                  {t("settings:notifications.digest.sendTime.description")}
-                </ItemDescription>
-              </ItemContent>
-              <ItemActions>
-                <NativeSelect
-                  aria-label={t("settings:notifications.digest.sendTime.title")}
-                  className="w-full sm:w-28"
-                  onChange={(event) => handleSendTimeChange(event.target.value)}
-                  value={draft.dailySummarySendTime}
-                >
-                  <NativeSelectOption value="08:00">8:00 AM</NativeSelectOption>
-                  <NativeSelectOption value="09:00">9:00 AM</NativeSelectOption>
-                  <NativeSelectOption value="17:00">5:00 PM</NativeSelectOption>
-                  <NativeSelectOption value="18:00">6:00 PM</NativeSelectOption>
-                </NativeSelect>
-              </ItemActions>
-            </Item>
           </Surface>
         </div>
       </div>

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -11,23 +11,10 @@ export const dispatchDueNotifications = internalAction({
   },
 });
 
-export const dispatchDueDailyDigests = internalAction({
-  args: {},
-  handler: async (ctx): Promise<{ attempted: number; sent: number }> => {
-    return await ctx.runAction(internal.operatorNotifications.dispatchDueDailyDigests, {});
-  },
-});
-
 crons.interval(
   "dispatch due notifications",
   { minutes: 15 },
   internal.crons.dispatchDueNotifications,
-  {},
-);
-crons.interval(
-  "dispatch due operator daily digests",
-  { minutes: 15 },
-  internal.crons.dispatchDueDailyDigests,
   {},
 );
 crons.interval(

--- a/convex/lib/operatorNotificationPreferences.ts
+++ b/convex/lib/operatorNotificationPreferences.ts
@@ -54,8 +54,6 @@ export type OperatorNotificationEventPreferences = Record<
   Record<OperatorNotificationChannel, boolean>
 >;
 
-export const DEFAULT_DAILY_SUMMARY_SEND_TIME = "08:00";
-
 export function buildDefaultOperatorNotificationEventPreferences():
   OperatorNotificationEventPreferences {
   return {
@@ -66,14 +64,6 @@ export function buildDefaultOperatorNotificationEventPreferences():
     transferFailed: { email: true, sms: false },
     aiReplyFailed: { email: true, sms: false },
   };
-}
-
-export function normalizeDailySummarySendTime(value: string): string {
-  const normalized = value.trim();
-  if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(normalized)) {
-    throw new Error("Daily summary send time must use HH:mm format.");
-  }
-  return normalized;
 }
 
 export function hasEnabledSmsEventPreference(

--- a/convex/operatorNotifications.ts
+++ b/convex/operatorNotifications.ts
@@ -1,5 +1,3 @@
-import {
-  DateTime } from "luxon";
 import { observedInternalAction as internalAction, observedInternalMutation as internalMutation } from "./telemetry/observedFunctions";
 import { v } from "convex/values";
 
@@ -13,12 +11,12 @@ import {
 } from "./_generated/server";
 import { sendTransactionalEmail } from "./lib/providers/email";
 import {
-  DEFAULT_DAILY_SUMMARY_SEND_TIME,
   buildDefaultOperatorNotificationEventPreferences,
   operatorNotificationChannelValidator,
   operatorNotificationEventKindValidator,
   type OperatorNotificationChannel,
   type OperatorNotificationEventKey,
+  type OperatorNotificationEventKind,
   type OperatorNotificationEventPreferences,
 } from "./lib/operatorNotificationPreferences";
 import {
@@ -36,8 +34,6 @@ type EffectivePreferences = {
   smsEnabled: boolean;
   smsConsentGranted: boolean;
   eventPreferences: OperatorNotificationEventPreferences;
-  dailySummaryEnabled: boolean;
-  dailySummarySendTime: string;
 };
 
 type NotificationRecipient = {
@@ -47,24 +43,6 @@ type NotificationRecipient = {
   emailEnabled: boolean;
   smsEnabled: boolean;
   eventPreferences: OperatorNotificationEventPreferences;
-};
-
-type DigestTarget = {
-  businessId: Id<"businesses">;
-  businessName: string;
-  timezone: string;
-  userId: Id<"users">;
-  email: string;
-  dailySummarySendTime: string;
-  isActiveBusinessForUser: boolean;
-};
-
-type DigestSummary = {
-  callsHandled: number;
-  appointmentsBooked: number;
-  voiceMessagesCaptured: number;
-  pausedSmsRepliesWaiting: number;
-  systemIssuesOpened: number;
 };
 
 function buildTwilioSmsStatusCallbackUrl(): string {
@@ -90,9 +68,6 @@ function getEffectivePreferences(
     ),
     eventPreferences:
       preferences?.eventPreferences ?? buildDefaultOperatorNotificationEventPreferences(),
-    dailySummaryEnabled: preferences?.dailySummaryEnabled ?? true,
-    dailySummarySendTime:
-      preferences?.dailySummarySendTime ?? DEFAULT_DAILY_SUMMARY_SEND_TIME,
   };
 }
 
@@ -160,70 +135,15 @@ function estimateSmsSegments(body: string): number {
 }
 
 function getSensitiveDeliveryContentExpiresAt(
-  eventKind: "dailyDigest" | "test" | OperatorNotificationEventKey,
+  eventKind: OperatorNotificationEventKind,
 ): string | undefined {
   return eventKind === "voiceMessage" || eventKind === "pausedSms"
     ? getMessageContentExpiresAt()
     : undefined;
 }
 
-function parseSendTime(sendTime: string): { hour: number; minute: number } {
-  const [hourRaw, minuteRaw] = sendTime.split(":");
-  const hour = Number(hourRaw);
-  const minute = Number(minuteRaw);
-  if (
-    !Number.isInteger(hour) ||
-    !Number.isInteger(minute) ||
-    hour < 0 ||
-    hour > 23 ||
-    minute < 0 ||
-    minute > 59
-  ) {
-    return { hour: 8, minute: 0 };
-  }
-  return { hour, minute };
-}
-
-function sendTimeSortValue(sendTime: string): number {
-  const { hour, minute } = parseSendTime(sendTime);
-  return hour * 60 + minute;
-}
-
-function normalizeDigestEmail(email: string): string {
-  return email.trim().toLowerCase();
-}
-
-function hashDigestRecipientEmail(email: string): string {
-  let hash = 0x811c9dc5;
-  for (const char of normalizeDigestEmail(email)) {
-    hash ^= char.charCodeAt(0);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
-}
-
-function shouldPreferDigestTarget(candidate: DigestTarget, existing: DigestTarget): boolean {
-  if (candidate.isActiveBusinessForUser !== existing.isActiveBusinessForUser) {
-    return candidate.isActiveBusinessForUser;
-  }
-  return (
-    sendTimeSortValue(candidate.dailySummarySendTime) <
-    sendTimeSortValue(existing.dailySummarySendTime)
-  );
-}
-
 function deliveryErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function mergeDocsById<T extends { _id: string }>(collections: Array<Array<T>>): Array<T> {
-  const byId = new Map<string, T>();
-  for (const collection of collections) {
-    for (const doc of collection) {
-      byId.set(doc._id, doc);
-    }
-  }
-  return Array.from(byId.values());
 }
 
 function hasAlertSmsSender(input: {
@@ -376,24 +296,6 @@ export const getDirectRecipient = internalQuery({
   },
 });
 
-export const hasDeliveryForEvent = internalQuery({
-  args: {
-    userId: v.id("users"),
-    channel: operatorNotificationChannelValidator,
-    eventKey: v.string(),
-  },
-  handler: async (ctx, args): Promise<boolean> => {
-    const delivery = await ctx.db
-      .query("operator_notification_deliveries")
-      .withIndex("by_user_id_and_channel_and_event_key", (q) =>
-        q.eq("userId", args.userId).eq("channel", args.channel).eq("eventKey", args.eventKey),
-      )
-      .unique();
-
-    return delivery !== null;
-  },
-});
-
 export const reserveDelivery = internalMutation({
   args: {
     businessId: v.id("businesses"),
@@ -404,8 +306,6 @@ export const reserveDelivery = internalMutation({
     subject: v.string(),
     body: v.string(),
     scheduledFor: v.optional(v.string()),
-    digestForDate: v.optional(v.string()),
-    recipientEmail: v.optional(v.string()),
     contentExpiresAt: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -419,42 +319,6 @@ export const reserveDelivery = internalMutation({
       return { deliveryId: existing._id, created: false };
     }
 
-    if (args.eventKind === "dailyDigest") {
-      if (args.digestForDate) {
-        const existingDigestDeliveries = await ctx.db
-          .query("operator_notification_deliveries")
-          .withIndex(
-            "by_business_id_and_event_kind_and_channel_and_digest_for_date",
-            (q) =>
-              q
-                .eq("businessId", args.businessId)
-                .eq("eventKind", "dailyDigest")
-                .eq("channel", args.channel)
-                .eq("digestForDate", args.digestForDate),
-          )
-          .collect();
-        const existingDigest = existingDigestDeliveries.find(
-          (delivery) => delivery.eventKey === args.eventKey,
-        );
-        if (existingDigest) {
-          return { deliveryId: existingDigest._id, created: false };
-        }
-
-        if (args.channel === "email" && args.recipientEmail) {
-          const recipientEmail = normalizeDigestEmail(args.recipientEmail);
-          for (const delivery of existingDigestDeliveries) {
-            const existingRecipient = await ctx.db.get(delivery.userId);
-            if (
-              existingRecipient?.email &&
-              normalizeDigestEmail(existingRecipient.email) === recipientEmail
-            ) {
-              return { deliveryId: delivery._id, created: false };
-            }
-          }
-        }
-      }
-    }
-
     const deliveryId = await ctx.db.insert("operator_notification_deliveries", {
       businessId: args.businessId,
       userId: args.userId,
@@ -465,7 +329,6 @@ export const reserveDelivery = internalMutation({
       subject: args.subject,
       body: args.body,
       ...(args.scheduledFor !== undefined ? { scheduledFor: args.scheduledFor } : {}),
-      ...(args.digestForDate !== undefined ? { digestForDate: args.digestForDate } : {}),
       ...(args.contentExpiresAt !== undefined
         ? {
             contentRetentionStatus: "active" as const,
@@ -710,12 +573,11 @@ async function deliverChannel(
     userId: Id<"users">;
     channel: OperatorNotificationChannel;
     to: string;
-    eventKind: "dailyDigest" | "test" | OperatorNotificationEventKey;
+    eventKind: OperatorNotificationEventKind;
     eventKey: string;
     subject: string;
     body: string;
     scheduledFor?: string;
-    digestForDate?: string;
     contentExpiresAt?: string;
   },
 ): Promise<{ attempted: boolean; sent: boolean; error?: string }> {
@@ -729,12 +591,8 @@ async function deliverChannel(
       subject: input.subject,
       body: input.body,
       ...(input.scheduledFor !== undefined ? { scheduledFor: input.scheduledFor } : {}),
-      ...(input.digestForDate !== undefined ? { digestForDate: input.digestForDate } : {}),
       ...(input.contentExpiresAt !== undefined
         ? { contentExpiresAt: input.contentExpiresAt }
-        : {}),
-      ...(input.eventKind === "dailyDigest" && input.channel === "email"
-        ? { recipientEmail: input.to }
         : {}),
     });
 
@@ -854,7 +712,6 @@ export const dispatchDirectNotification = internalAction({
     eventKey: v.string(),
     subject: v.string(),
     body: v.string(),
-    digestForDate: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ sent: boolean; error?: string }> => {
     const recipient: NotificationRecipient | null = await ctx.runQuery(
@@ -887,7 +744,6 @@ export const dispatchDirectNotification = internalAction({
       eventKey: args.eventKey,
       subject: args.subject,
       body: args.body,
-      ...(args.digestForDate !== undefined ? { digestForDate: args.digestForDate } : {}),
     });
 
     return {
@@ -897,321 +753,3 @@ export const dispatchDirectNotification = internalAction({
   },
 });
 
-export const listDailyDigestTargets = internalQuery({
-  args: {},
-  handler: async (ctx): Promise<Array<DigestTarget>> => {
-    const businesses = await ctx.db.query("businesses").collect();
-    const targetsByRecipient = new Map<string, DigestTarget>();
-
-    for (const business of businesses) {
-      const memberships = await ctx.db
-        .query("business_memberships")
-        .withIndex("by_business_id", (q) => q.eq("businessId", business._id))
-        .collect();
-      for (const membership of memberships) {
-        if (membership.status !== "active") {
-          continue;
-        }
-
-        const user = await ctx.db.get(membership.userId);
-        if (!user?.email) {
-          continue;
-        }
-
-        const preferences = await ctx.db
-          .query("operator_notification_preferences")
-          .withIndex("by_business_id_and_user_id", (q) =>
-            q.eq("businessId", business._id).eq("userId", user._id),
-          )
-          .unique();
-        const effective = getEffectivePreferences(preferences);
-        if (!effective.dailySummaryEnabled || !effective.emailEnabled) {
-          continue;
-        }
-
-        const target = {
-          businessId: business._id,
-          businessName: business.name,
-          timezone: business.timezone,
-          userId: user._id,
-          email: user.email,
-          dailySummarySendTime: effective.dailySummarySendTime,
-          isActiveBusinessForUser: user.activeBusinessId === business._id,
-        };
-        const recipientKey = [
-          normalizeDigestEmail(user.email),
-          String(business._id),
-        ].join(":");
-        const existing = targetsByRecipient.get(recipientKey);
-        if (!existing || shouldPreferDigestTarget(target, existing)) {
-          targetsByRecipient.set(recipientKey, target);
-        }
-      }
-    }
-
-    return Array.from(targetsByRecipient.values());
-  },
-});
-
-export const getDailyDigestSummary = internalQuery({
-  args: {
-    businessId: v.id("businesses"),
-    startIso: v.string(),
-    endIso: v.string(),
-  },
-  handler: async (ctx, args): Promise<DigestSummary> => {
-    const startMs = Date.parse(args.startIso);
-    const endMs = Date.parse(args.endIso);
-    const [
-      calls,
-      appointments,
-      voiceItems,
-      calendarIssues,
-      messagesCreatedInWindow,
-      messagesUpdatedInWindow,
-      notificationsScheduledInWindow,
-      notificationsUpdatedInWindow,
-      notificationsCreatedInWindow,
-    ] =
-      await Promise.all([
-        ctx.db
-          .query("calls")
-          .withIndex("by_business_id_and_started_at", (q) =>
-            q.eq("businessId", args.businessId).gte("startedAt", args.startIso).lt("startedAt", args.endIso),
-          )
-          .collect(),
-        ctx.db
-          .query("appointments")
-          .withIndex("by_business_id", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .gte("_creationTime", startMs)
-              .lt("_creationTime", endMs),
-          )
-          .collect(),
-        ctx.db
-          .query("inbox_items")
-          .withIndex("by_business_id_and_kind", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .eq("kind", "voice_message")
-              .gte("_creationTime", startMs)
-              .lt("_creationTime", endMs),
-          )
-          .collect(),
-        ctx.db
-          .query("inbox_items")
-          .withIndex("by_business_id_and_kind", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .eq("kind", "calendar_sync_issue")
-              .gte("_creationTime", startMs)
-              .lt("_creationTime", endMs),
-          )
-          .collect(),
-        ctx.db
-          .query("messages")
-          .withIndex("by_business_id", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .gte("_creationTime", startMs)
-              .lt("_creationTime", endMs),
-          )
-          .collect(),
-        ctx.db
-          .query("messages")
-          .withIndex("by_business_id_and_provider_updated_at", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .gte("providerUpdatedAt", args.startIso)
-              .lt("providerUpdatedAt", args.endIso),
-          )
-          .collect(),
-        ctx.db
-          .query("notifications")
-          .withIndex("by_business_id_and_scheduled_for", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .gte("scheduledFor", args.startIso)
-              .lt("scheduledFor", args.endIso),
-          )
-          .collect(),
-        ctx.db
-          .query("notifications")
-          .withIndex("by_business_id_and_provider_updated_at", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .gte("providerUpdatedAt", args.startIso)
-              .lt("providerUpdatedAt", args.endIso),
-          )
-          .collect(),
-        ctx.db
-          .query("notifications")
-          .withIndex("by_business_id", (q) =>
-            q
-              .eq("businessId", args.businessId)
-              .gte("_creationTime", startMs)
-              .lt("_creationTime", endMs),
-          )
-          .collect(),
-      ]);
-
-    const messages = mergeDocsById([messagesCreatedInWindow, messagesUpdatedInWindow]);
-    const notifications = mergeDocsById([
-      notificationsScheduledInWindow,
-      notificationsUpdatedInWindow,
-      notificationsCreatedInWindow,
-    ]);
-    const inWindowMs = (value: number) => value >= startMs && value < endMs;
-    const inWindowIso = (value: string | undefined) =>
-      value !== undefined && inWindowMs(Date.parse(value));
-    const pausedSmsMessages = messages.filter(
-      (message) =>
-        message.direction === "inbound" &&
-        message.channel === "sms" &&
-        inWindowMs(message._creationTime),
-    );
-    let pausedSmsRepliesWaiting = 0;
-    for (const message of pausedSmsMessages) {
-      const conversation = await ctx.db.get(message.conversationId);
-      if (conversation?.automationState === "human_handoff") {
-        pausedSmsRepliesWaiting += 1;
-      }
-    }
-
-    const failedAiMessages = messages.filter(
-      (message) =>
-        message.aiGenerated &&
-        message.channel === "sms" &&
-        (message.status === "failed" || message.status === "undelivered") &&
-        (inWindowIso(message.providerUpdatedAt) || inWindowMs(message._creationTime)),
-    ).length;
-    const failedCustomerNotifications = notifications.filter(
-      (notification) =>
-        (notification.status === "failed" || notification.status === "undelivered") &&
-        (inWindowIso(notification.providerUpdatedAt) ||
-          inWindowIso(notification.scheduledFor) ||
-          inWindowMs(notification._creationTime)),
-    ).length;
-    const failedTransfers = calls.filter(
-      (call) =>
-        call.transferState === "failed" &&
-        (inWindowIso(call.endedAt) || inWindowIso(call.startedAt) || inWindowMs(call._creationTime)),
-    ).length;
-
-    return {
-      callsHandled: calls.filter((call) => call.status !== "in_progress" && call.status !== "open").length,
-      appointmentsBooked: appointments.filter((appointment) =>
-        inWindowMs(appointment._creationTime),
-      ).length,
-      voiceMessagesCaptured: voiceItems.filter((item) => inWindowMs(item._creationTime)).length,
-      pausedSmsRepliesWaiting,
-      systemIssuesOpened:
-        calendarIssues.filter((item) => inWindowMs(item._creationTime)).length +
-        failedAiMessages +
-        failedCustomerNotifications +
-        failedTransfers,
-    };
-  },
-});
-
-function buildDigestBody(input: {
-  businessName: string;
-  localDate: string;
-  summary: DigestSummary;
-}): string {
-  return [
-    `Daily summary for ${input.businessName}`,
-    `Date: ${input.localDate}`,
-    "",
-    `Calls handled: ${input.summary.callsHandled}`,
-    `Appointments booked: ${input.summary.appointmentsBooked}`,
-    `Voice messages captured: ${input.summary.voiceMessagesCaptured}`,
-    `Paused SMS replies waiting: ${input.summary.pausedSmsRepliesWaiting}`,
-    `System issues opened: ${input.summary.systemIssuesOpened}`,
-  ].join("\n");
-}
-
-export const dispatchDueDailyDigests = internalAction({
-  args: {},
-  handler: async (ctx): Promise<{ attempted: number; sent: number }> => {
-    const targets: Array<DigestTarget> = await ctx.runQuery(
-      internal.operatorNotifications.listDailyDigestTargets,
-      {},
-    );
-    const now = DateTime.utc();
-    let attempted = 0;
-    let sent = 0;
-    const summaryCache = new Map<string, DigestSummary>();
-
-    for (const target of targets) {
-      const localNow = now.setZone(target.timezone);
-      if (!localNow.isValid) {
-        continue;
-      }
-
-      const { hour, minute } = parseSendTime(target.dailySummarySendTime);
-      const sendAt = localNow.startOf("day").set({ hour, minute });
-      if (localNow < sendAt) {
-        continue;
-      }
-
-      const digestDay = localNow.minus({ days: 1 }).startOf("day");
-      const digestForDate = digestDay.toISODate();
-      if (!digestForDate) {
-        continue;
-      }
-      const startIso = digestDay.toUTC().toISO();
-      const endIso = digestDay.plus({ days: 1 }).toUTC().toISO();
-      if (!startIso || !endIso) {
-        continue;
-      }
-
-      const eventKey = [
-        "dailyDigest",
-        String(target.businessId),
-        hashDigestRecipientEmail(target.email),
-        digestForDate,
-      ].join(":");
-      const alreadyReserved: boolean = await ctx.runQuery(
-        internal.operatorNotifications.hasDeliveryForEvent,
-        { userId: target.userId, channel: "email", eventKey },
-      );
-      if (alreadyReserved) {
-        continue;
-      }
-
-      const summaryCacheKey = `${String(target.businessId)}:${startIso}:${endIso}`;
-      let summary = summaryCache.get(summaryCacheKey);
-      if (!summary) {
-        summary = await ctx.runQuery(internal.operatorNotifications.getDailyDigestSummary, {
-          businessId: target.businessId,
-          startIso,
-          endIso,
-        });
-        summaryCache.set(summaryCacheKey, summary);
-      }
-      const subject = `Daily summary for ${target.businessName}`;
-      const body = buildDigestBody({
-        businessName: target.businessName,
-        localDate: digestForDate,
-        summary,
-      });
-      const result = await deliverChannel(ctx, {
-        businessId: target.businessId,
-        userId: target.userId,
-        channel: "email",
-        to: target.email,
-        eventKind: "dailyDigest",
-        eventKey,
-        subject,
-        body,
-        digestForDate,
-      });
-      attempted += result.attempted ? 1 : 0;
-      sent += result.sent ? 1 : 0;
-    }
-
-    return { attempted, sent };
-  },
-});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -973,8 +973,8 @@ export default defineSchema({
     emailEnabled: v.boolean(),
     smsEnabled: v.boolean(),
     eventPreferences: operatorNotificationEventPreferencesValidator,
-    dailySummaryEnabled: v.boolean(),
-    dailySummarySendTime: v.string(),
+    dailySummaryEnabled: v.optional(v.boolean()),
+    dailySummarySendTime: v.optional(v.string()),
     smsConsentGrantedAt: v.optional(v.string()),
     smsConsentRevokedAt: v.optional(v.string()),
     smsConsentSource: v.optional(v.string()),
@@ -982,11 +982,7 @@ export default defineSchema({
     updatedAt: v.string(),
   })
     .index("by_business_id_and_user_id", ["businessId", "userId"])
-    .index("by_user_id_and_business_id", ["userId", "businessId"])
-    .index("by_daily_summary_enabled_and_daily_summary_send_time", [
-      "dailySummaryEnabled",
-      "dailySummarySendTime",
-    ]),
+    .index("by_user_id_and_business_id", ["userId", "businessId"]),
 
   operator_notification_deliveries: defineTable({
     businessId: v.id("businesses"),
@@ -1021,12 +1017,6 @@ export default defineSchema({
       "businessId",
       "eventKind",
       "eventKey",
-    ])
-    .index("by_business_id_and_event_kind_and_channel_and_digest_for_date", [
-      "businessId",
-      "eventKind",
-      "channel",
-      "digestForDate",
     ])
     .index("by_content_retention_status_and_content_expires_at", [
       "contentRetentionStatus",

--- a/convex/tests/operatorNotifications.test.ts
+++ b/convex/tests/operatorNotifications.test.ts
@@ -1,13 +1,11 @@
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { convexTest, type TestConvex } from "convex-test";
-import { DateTime } from "luxon";
 import { describe, expect, it, vi } from "vitest";
 
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import schema from "../schema";
 import { modules } from "../test.setup";
-import { buildDefaultOperatorNotificationEventPreferences } from "../lib/operatorNotificationPreferences";
 import { TEST_OPERATOR_NOTIFICATION_RATE_LIMIT_MESSAGE } from "../users/preferences";
 
 const convexModules = modules;
@@ -83,8 +81,6 @@ describe("operator notification preferences", () => {
 
     expect(preferences.emailEnabled).toBe(true);
     expect(preferences.smsEnabled).toBe(false);
-    expect(preferences.dailySummaryEnabled).toBe(true);
-    expect(preferences.dailySummarySendTime).toBe("08:00");
     expect(preferences.eventPreferences.voiceMessage).toEqual({
       email: true,
       sms: false,
@@ -111,8 +107,6 @@ describe("operator notification preferences", () => {
       emailEnabled: false,
       smsEnabled: false,
       eventPreferences: current.eventPreferences,
-      dailySummaryEnabled: false,
-      dailySummarySendTime: "17:00",
     });
 
     await t.run(async (ctx) => {
@@ -130,7 +124,6 @@ describe("operator notification preferences", () => {
         .unique();
 
       expect(firstPreference?.emailEnabled).toBe(false);
-      expect(firstPreference?.dailySummarySendTime).toBe("17:00");
       expect(secondPreference).toBeNull();
     });
   });
@@ -152,8 +145,6 @@ describe("operator notification preferences", () => {
         emailEnabled: true,
         smsEnabled: true,
         eventPreferences: current.eventPreferences,
-        dailySummaryEnabled: true,
-        dailySummarySendTime: "08:00",
       }),
     ).rejects.toThrow(/verified phone number/i);
 
@@ -193,8 +184,6 @@ describe("operator notification preferences", () => {
         emailEnabled: true,
         smsEnabled: true,
         eventPreferences: current.eventPreferences,
-        dailySummaryEnabled: true,
-        dailySummarySendTime: "08:00",
       }),
     ).rejects.toThrow(/consent/i);
   });
@@ -271,8 +260,6 @@ describe("operator notification preferences", () => {
         emailEnabled: true,
         smsEnabled: true,
         eventPreferences: current.eventPreferences,
-        dailySummaryEnabled: true,
-        dailySummarySendTime: "08:00",
         smsConsentAccepted: true,
       });
 
@@ -361,8 +348,6 @@ describe("operator notification preferences", () => {
       emailEnabled: false,
       smsEnabled: false,
       eventPreferences: current.eventPreferences,
-      dailySummaryEnabled: true,
-      dailySummarySendTime: "08:00",
       smsConsentAccepted: true,
     });
     await t.action(internal.operatorNotifications.dispatchEvent, {
@@ -412,8 +397,6 @@ describe("operator notification preferences", () => {
             transferFailed: { email: true, sms: true },
             aiReplyFailed: { email: true, sms: true },
           },
-          dailySummaryEnabled: true,
-          dailySummarySendTime: "08:00",
           updatedAt: new Date().toISOString(),
         });
       });
@@ -479,8 +462,6 @@ describe("operator notification preferences", () => {
           sms: true,
         },
       },
-      dailySummaryEnabled: true,
-      dailySummarySendTime: "08:00",
       smsConsentAccepted: true,
     });
 
@@ -669,237 +650,6 @@ describe("operator notification preferences", () => {
         )
         .unique();
       expect(usageEvent).toBeNull();
-    });
-  });
-
-  it("sends one digest per user, business, and local date and skips disabled digests", async () => {
-    const t = createConvexHarness();
-    const enabled = await seedMember(t, {
-      subject: "operator-digest-enabled",
-      email: "digest@example.com",
-    });
-    const disabled = await seedMember(t, {
-      subject: "operator-digest-disabled",
-      email: "digest-disabled@example.com",
-      businessSlug: "digest-disabled-business",
-    });
-    const enabledPrefs = await enabled.authed.query(
-      api.users.preferences.getNotificationPreferences,
-      { businessId: enabled.businessId },
-    );
-    await enabled.authed.mutation(api.users.preferences.updateNotificationPreferences, {
-      businessId: enabled.businessId,
-      emailEnabled: true,
-      smsEnabled: false,
-      eventPreferences: enabledPrefs.eventPreferences,
-      dailySummaryEnabled: true,
-      dailySummarySendTime: "00:00",
-    });
-    const disabledPrefs = await disabled.authed.query(
-      api.users.preferences.getNotificationPreferences,
-      { businessId: disabled.businessId },
-    );
-    await disabled.authed.mutation(api.users.preferences.updateNotificationPreferences, {
-      businessId: disabled.businessId,
-      emailEnabled: true,
-      smsEnabled: false,
-      eventPreferences: disabledPrefs.eventPreferences,
-      dailySummaryEnabled: false,
-      dailySummarySendTime: "00:00",
-    });
-
-    await t.action(internal.operatorNotifications.dispatchDueDailyDigests, {});
-    await t.action(internal.operatorNotifications.dispatchDueDailyDigests, {});
-
-    await t.run(async (ctx) => {
-      const enabledDeliveries = await ctx.db
-        .query("operator_notification_deliveries")
-        .withIndex("by_business_id_and_event_kind", (q) =>
-          q.eq("businessId", enabled.businessId).eq("eventKind", "dailyDigest"),
-        )
-        .collect();
-      const disabledDeliveries = await ctx.db
-        .query("operator_notification_deliveries")
-        .withIndex("by_business_id_and_event_kind", (q) =>
-          q.eq("businessId", disabled.businessId).eq("eventKind", "dailyDigest"),
-        )
-        .collect();
-
-      expect(enabledDeliveries).toHaveLength(1);
-      expect(enabledDeliveries[0]?.channel).toBe("email");
-      expect(disabledDeliveries).toHaveLength(0);
-    });
-  });
-
-  it("sends one daily digest per business email when duplicate users share an inbox", async () => {
-    const t = createConvexHarness();
-    const seeded = await seedMember(t, {
-      subject: "operator-digest-shared-0",
-      email: "hello@lobbystack.com",
-    });
-
-    await t.run(async (ctx) => {
-      await ctx.db.insert("operator_notification_preferences", {
-        businessId: seeded.businessId,
-        userId: seeded.userId,
-        emailEnabled: true,
-        smsEnabled: false,
-        eventPreferences: buildDefaultOperatorNotificationEventPreferences(),
-        dailySummaryEnabled: true,
-        dailySummarySendTime: "00:00",
-        updatedAt: "2026-05-06T00:00:00.000Z",
-      });
-
-      for (let index = 1; index < 7; index += 1) {
-        const userId: Id<"users"> = await ctx.db.insert("users", {
-          authSubject: `operator-digest-shared-${index}`,
-          email: "hello@lobbystack.com",
-        });
-        await ctx.db.insert("business_memberships", {
-          businessId: seeded.businessId,
-          userId,
-          role: "admin",
-          status: "active",
-        });
-        await ctx.db.insert("operator_notification_preferences", {
-          businessId: seeded.businessId,
-          userId,
-          emailEnabled: true,
-          smsEnabled: false,
-          eventPreferences: buildDefaultOperatorNotificationEventPreferences(),
-          dailySummaryEnabled: true,
-          dailySummarySendTime: "00:00",
-          updatedAt: "2026-05-06T00:00:00.000Z",
-        });
-      }
-    });
-
-    await t.action(internal.operatorNotifications.dispatchDueDailyDigests, {});
-    await t.action(internal.operatorNotifications.dispatchDueDailyDigests, {});
-
-    await t.run(async (ctx) => {
-      const deliveries = await ctx.db
-        .query("operator_notification_deliveries")
-        .withIndex("by_business_id_and_event_kind", (q) =>
-          q.eq("businessId", seeded.businessId).eq("eventKind", "dailyDigest"),
-        )
-        .collect();
-
-      expect(deliveries).toHaveLength(1);
-      expect(deliveries[0]?.channel).toBe("email");
-      expect(deliveries[0]?.eventKey).not.toContain("hello@lobbystack.com");
-    });
-  });
-
-  it("does not resend a daily digest already recorded with the legacy user-key", async () => {
-    const t = createConvexHarness();
-    const seeded = await seedMember(t, {
-      subject: "operator-digest-legacy-key",
-      email: "hello@lobbystack.com",
-    });
-    const digestForDate = DateTime.utc().minus({ days: 1 }).toISODate();
-    if (!digestForDate) {
-      throw new Error("Expected a valid digest date.");
-    }
-
-    await t.run(async (ctx) => {
-      await ctx.db.insert("operator_notification_deliveries", {
-        businessId: seeded.businessId,
-        userId: seeded.userId,
-        eventKind: "dailyDigest",
-        eventKey: `dailyDigest:${String(seeded.businessId)}:${String(seeded.userId)}:${digestForDate}`,
-        channel: "email",
-        status: "sent",
-        subject: "Daily summary for LobbyStack Test",
-        body: "Already sent",
-        sentAt: new Date().toISOString(),
-        providerStatus: "sent",
-        digestForDate,
-        createdAt: new Date().toISOString(),
-      });
-    });
-
-    await t.action(internal.operatorNotifications.dispatchDueDailyDigests, {});
-
-    await t.run(async (ctx) => {
-      const deliveries = await ctx.db
-        .query("operator_notification_deliveries")
-        .withIndex("by_business_id_and_event_kind", (q) =>
-          q.eq("businessId", seeded.businessId).eq("eventKind", "dailyDigest"),
-        )
-        .collect();
-
-      expect(deliveries).toHaveLength(1);
-      expect(deliveries[0]?.eventKey).toContain(String(seeded.userId));
-    });
-  });
-
-  it("sends separate daily digests for same-name businesses sharing an inbox", async () => {
-    const t = createConvexHarness();
-    const seeded = await t.run(async (ctx) => {
-      const businessIds: Array<Id<"businesses">> = [];
-      for (let index = 0; index < 5; index += 1) {
-        businessIds.push(
-          await ctx.db.insert("businesses", {
-            slug: `lobbystack-same-name-${index}`,
-            name: index % 2 === 0 ? "LobbyStack" : "Lobbystack",
-            timezone: "UTC",
-            businessType: "general",
-            deploymentMode: "development",
-            status: "active",
-            onboardingStage: index === 0 ? "completed" : "website",
-          }),
-        );
-      }
-      const activeBusinessId = businessIds[2]!;
-      const userId: Id<"users"> = await ctx.db.insert("users", {
-        authSubject: "operator-digest-same-name-businesses",
-        email: "hello@lobbystack.com",
-        activeBusinessId,
-      });
-
-      for (const businessId of businessIds) {
-        await ctx.db.insert("business_memberships", {
-          businessId,
-          userId,
-          role: "business_owner",
-          status: "active",
-        });
-        await ctx.db.insert("operator_notification_preferences", {
-          businessId,
-          userId,
-          emailEnabled: true,
-          smsEnabled: false,
-          eventPreferences: buildDefaultOperatorNotificationEventPreferences(),
-          dailySummaryEnabled: true,
-          dailySummarySendTime: "00:00",
-          updatedAt: "2026-05-07T00:00:00.000Z",
-        });
-      }
-
-      return { businessIds };
-    });
-
-    await t.action(internal.operatorNotifications.dispatchDueDailyDigests, {});
-
-    await t.run(async (ctx) => {
-      const deliveries = (
-        await Promise.all(
-          seeded.businessIds.map((businessId) =>
-            ctx.db
-              .query("operator_notification_deliveries")
-              .withIndex("by_business_id_and_event_kind", (q) =>
-                q.eq("businessId", businessId).eq("eventKind", "dailyDigest"),
-              )
-              .collect(),
-          ),
-        )
-      ).flat();
-
-      expect(deliveries).toHaveLength(5);
-      expect(new Set(deliveries.map((delivery) => String(delivery.businessId)))).toEqual(
-        new Set(seeded.businessIds.map(String)),
-      );
     });
   });
 });

--- a/convex/users/preferences.ts
+++ b/convex/users/preferences.ts
@@ -9,10 +9,8 @@ import { internalQuery, query } from "../_generated/server";
 import { ensureCurrentUser, requireCurrentUser, requireMembership } from "../lib/auth";
 import { dashboardAbuseRateLimiter } from "../lib/components";
 import {
-  DEFAULT_DAILY_SUMMARY_SEND_TIME,
   buildDefaultOperatorNotificationEventPreferences,
   hasEnabledSmsEventPreference,
-  normalizeDailySummarySendTime,
   operatorNotificationChannelValidator,
   operatorNotificationEventPreferencesValidator,
   type OperatorNotificationChannel,
@@ -33,8 +31,6 @@ type NotificationPreferencesPayload = {
   emailEnabled: boolean;
   smsEnabled: boolean;
   eventPreferences: OperatorNotificationEventPreferences;
-  dailySummaryEnabled: boolean;
-  dailySummarySendTime: string;
   email: string | null;
   phone: string | null;
   phoneVerified: boolean;
@@ -114,9 +110,6 @@ function resolveNotificationPreferencesPayload(input: {
           transferFailed: { ...eventPreferences.transferFailed, sms: false },
           aiReplyFailed: { ...eventPreferences.aiReplyFailed, sms: false },
         },
-    dailySummaryEnabled: input.preferences?.dailySummaryEnabled ?? true,
-    dailySummarySendTime:
-      input.preferences?.dailySummarySendTime ?? DEFAULT_DAILY_SUMMARY_SEND_TIME,
     email: input.user.email ?? null,
     phone: input.user.phone ?? null,
     phoneVerified,
@@ -244,9 +237,9 @@ export const updateNotificationPreferences = mutation({
     emailEnabled: v.boolean(),
     smsEnabled: v.boolean(),
     eventPreferences: operatorNotificationEventPreferencesValidator,
-    dailySummaryEnabled: v.boolean(),
-    dailySummarySendTime: v.string(),
     smsConsentAccepted: v.optional(v.boolean()),
+    dailySummaryEnabled: v.optional(v.boolean()),
+    dailySummarySendTime: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<NotificationPreferencesPayload> => {
     const user = await ensureCurrentUser(ctx);
@@ -259,9 +252,6 @@ export const updateNotificationPreferences = mutation({
       user,
       alertSmsSenderConfigured: isAlertSmsSenderConfigured(smsPolicy),
     });
-    const dailySummarySendTime = normalizeDailySummarySendTime(
-      args.dailySummarySendTime,
-    );
 
     const existing = await ctx.db
       .query("operator_notification_preferences")
@@ -308,8 +298,6 @@ export const updateNotificationPreferences = mutation({
       emailEnabled: args.emailEnabled,
       smsEnabled: args.smsEnabled,
       eventPreferences: args.eventPreferences,
-      dailySummaryEnabled: args.dailySummaryEnabled,
-      dailySummarySendTime,
       ...consentGrantPatch,
       ...consentRevokePatch,
       updatedAt: now,


### PR DESCRIPTION
## Summary

Removes the operator daily digest (daily recap) feature across all layers — marketing, dashboard, backend, schema, and tests.

## Behavior changes

- **Landing**: The "Daily recap" / "Récapitulatif quotidien" feature cards are removed from the features bento grid. The medium-card grid reflows automatically.
- **Dashboard settings**: The "Digest" section (daily summary toggle + send-time select) is removed from the notifications settings page. The `digest` locale keys are removed from EN/FR.
- **Backend**: The daily digest cron job and its dispatch action are removed. The `dailyDigest` deduplication branch and digest-specific args are stripped from the shared notification delivery functions (`deliverChannel`, `reserveDelivery`, `dispatchDirectNotification`). The other notification events (voice message, paused SMS, SMS failed, calendar sync, transfer failed, AI reply failed, test) continue to work unchanged.
- **Schema**: Dropped the `by_daily_summary_enabled_and_daily_summary_send_time` and `by_business_id_and_event_kind_and_channel_and_digest_for_date` indexes. The `dailySummaryEnabled`, `dailySummarySendTime`, `digestForDate` fields and the `dailyDigest` event kind literal are kept as **optional/deprecated** so existing documents pass schema validation. No code reads or writes these fields anymore.
- **User preferences**: The `dailySummaryEnabled`/`dailySummarySendTime` fields are removed from the preferences payload, mutation args, and resolver.

## Legacy compatibility

Convex validates all existing documents on schema push and rejects documents with extra fields not in the validator. Keeping the removed fields as `v.optional(...)` and the `dailyDigest` literal in the event kind validator ensures existing `operator_notification_preferences` and `operator_notification_deliveries` documents validate cleanly. A future release can fully remove these fields after a migration deletes them from existing docs.

## Files changed

11 files, -900 lines net.

## Verification

- `pnpm typecheck` — 0 errors
- `pnpm build` — all 10 workspace projects built successfully
- `pnpm test` — 568 convex + 232 web + 12 script tests pass (812 total)
- `npx convex dev` schema sync against a local deployment with legacy documents present (both an `operator_notification_preferences` doc with `dailySummary*` fields and an `operator_notification_deliveries` doc with `dailyDigest` eventKind + `digestForDate`) — schema push succeeded, legacy indexes dropped cleanly