### PR TITLE
Raise realtime VAD threshold to reduce noisy turn detection

### DIFF
--- a/apps/voice-gateway/src/telephony/mediaStream.test.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.test.ts
@@ -34,7 +34,7 @@ describe("createRealtimeTurnDetectionConfig", () => {
       }),
     ).toEqual({
       type: "server_vad",
-      threshold: 0.65,
+      threshold: 0.8,
       prefix_padding_ms: 300,
       silence_duration_ms: 700,
       create_response: false,
@@ -46,7 +46,7 @@ describe("createRealtimeTurnDetectionConfig", () => {
   it("defaults to normal caller turn handling after the greeting", () => {
     expect(createRealtimeTurnDetectionConfig(30_000)).toEqual({
       type: "server_vad",
-      threshold: 0.65,
+      threshold: 0.8,
       prefix_padding_ms: 300,
       silence_duration_ms: 700,
       create_response: true,
@@ -67,7 +67,7 @@ describe("createRealtimeTurnDetectionConfig", () => {
   it("omits idle timeout while an app-managed call hold is active", () => {
     expect(createRealtimeHoldTurnDetectionConfig()).toEqual({
       type: "server_vad",
-      threshold: 0.65,
+      threshold: 0.8,
       prefix_padding_ms: 300,
       silence_duration_ms: 700,
       create_response: true,
@@ -96,7 +96,7 @@ describe("createRealtimeTurnDetectionConfig", () => {
             input: {
               turn_detection: {
                 type: "server_vad",
-                threshold: 0.65,
+                threshold: 0.8,
                 prefix_padding_ms: 300,
                 silence_duration_ms: 700,
                 create_response: true,

--- a/apps/voice-gateway/src/telephony/mediaStream.ts
+++ b/apps/voice-gateway/src/telephony/mediaStream.ts
@@ -252,7 +252,7 @@ function isTransferQuotaError(error: unknown): boolean {
 const TRANSFER_QUOTA_REACHED_MESSAGE =
   "This business has reached its transfer limit for this billing period. Please try again later.";
 const IMPLICIT_TERMINAL_HANGUP_RETRY_DELAYS_MS = [250, 1_000, 2_500];
-const REALTIME_VAD_THRESHOLD = 0.65;
+const REALTIME_VAD_THRESHOLD = 0.8;
 const REALTIME_VAD_PREFIX_PADDING_MS = 300;
 const REALTIME_VAD_SILENCE_DURATION_MS = 700;
 const REALTIME_IDLE_TIMEOUT_MIN_MS = 5_000;


### PR DESCRIPTION
## Summary
- Increase the server VAD threshold used by the voice gateway from `0.65` to `0.8`
- Update turn-detection expectations to match the new noise-tolerant behavior
- Keep idle timeout and other realtime settings unchanged

## Testing
- Updated unit coverage for realtime turn-detection config expectations
- Not run (not requested)