### PR TITLE
Add affiliate program landing page

### DIFF
--- a/.github/workflows/landing-link-check.yml
+++ b/.github/workflows/landing-link-check.yml
@@ -40,7 +40,7 @@ jobs:
             --verbose
             --no-progress
             --base-url http://127.0.0.1:4173
-            --remap https://lobbystack.com http://127.0.0.1:4173
+            --remap '^https://lobbystack\.com(.*) http://127.0.0.1:4173$1'
             --exclude '^https://app\.lobbystack\.com/'
             --exclude '^https://voice\.lobbystack\.com/web-call/'
             --exclude '^https://voice-dev\.lobbystack\.com/web-call/'

--- a/.github/workflows/landing-link-check.yml
+++ b/.github/workflows/landing-link-check.yml
@@ -16,12 +16,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm --filter landing build
+      - name: Start landing preview server
+        run: |
+          npx --yes serve apps/landing/dist -l 4173 &
+          for _ in $(seq 1 30); do
+            curl -sf http://127.0.0.1:4173/ > /dev/null && exit 0
+            sleep 1
+          done
+          echo "Landing preview server failed to start"
+          exit 1
       - uses: lycheeverse/lychee-action@v2
         with:
           args: >-
             --verbose
             --no-progress
-            --base-url https://lobbystack.com
+            --base-url http://127.0.0.1:4173
+            --remap https://lobbystack.com http://127.0.0.1:4173
             --exclude '^https://app\.lobbystack\.com/'
             --exclude '^https://voice\.lobbystack\.com/web-call/'
             --exclude '^https://voice-dev\.lobbystack\.com/web-call/'

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -42,6 +42,8 @@ const sourceForUrl = (url) => {
   if (pathname === "/features/") return "src/pages/features.astro"
   if (pathname === "/solutions/") return "src/pages/solutions/index.astro"
   if (pathname === "/pricing/") return "src/pages/pricing.astro"
+  if (pathname === "/affiliate-program/")
+    return "src/pages/affiliate-program.astro"
   if (pathname === "/blog/") return "src/pages/blog/index.astro"
   if (pathname === "/changelog/") return "src/pages/changelog.astro"
   if (pathname === "/docs/api/") return "src/pages/docs/api.astro"

--- a/apps/landing/functions/_middleware.js
+++ b/apps/landing/functions/_middleware.js
@@ -25,6 +25,7 @@ const TRANSLATED_PATHS = new Set([
   "/blog/open-source-ai-receptionist-stack/",
   "/blog/ai-receptionist-workflows/",
   "/blog/ai-receptionist-affiliate-program/",
+  "/affiliate-program/",
   "/docs/api/",
   "/privacy/",
   "/cookie-policy/",

--- a/apps/landing/public/llms.txt
+++ b/apps/landing/public/llms.txt
@@ -12,9 +12,11 @@ The product combines AI voice, appointment scheduling, business knowledge, and h
 - [Features](https://lobbystack.com/features/): Detailed feature page covering workflows, booking, quoting, follow-up, transfers, dashboard, and included capabilities.
 - [Help Center](https://docs.lobbystack.com/introduction): Primary setup, support, and product documentation resource for configuring and using LobbyStack.
 - [Pricing](https://lobbystack.com/pricing/): Free, Starter, Pro, and Enterprise pricing for AI receptionist coverage, voice minutes, annual billing, SMS alerts, knowledge base, and support.
+- [Affiliate Program](https://lobbystack.com/affiliate-program/): Refer businesses to hosted LobbyStack plans and earn 20% of their payments for 12 months. Referrals save 5% at signup.
 - [Missed Call Revenue Calculator](https://lobbystack.com/missed-call-revenue-calculator/): Interactive calculator for estimating revenue at risk from unanswered contractor calls.
 - [Features markdown](https://lobbystack.com/features.md): AI-readable markdown summary of LobbyStack features.
 - [Pricing markdown](https://lobbystack.com/pricing.md): AI-readable markdown summary of plans, included limits, plan features, and overage rates.
+- [Affiliate program markdown](https://lobbystack.com/affiliate-program.md): AI-readable markdown summary of the LobbyStack Affiliate Program terms and onboarding.
 - [Blog](https://lobbystack.com/blog/): Product updates, research, resources and articles about AI agents, and business knowledge systems.
 - [Sitemap](https://lobbystack.com/sitemap-index.xml): Canonical sitemap for search engines and crawlers.
 - [Schema map](https://lobbystack.com/schemamap.xml): Structured-data endpoint map for agents.

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -12,6 +12,7 @@ const footerCopy = {
     comparison: "Comparison",
     blog: "Blog",
     calculator: "Missed Call Calculator",
+    affiliateProgram: "Affiliate Program",
     company: "Company",
     about: "About",
     contact: "Contact",
@@ -34,6 +35,7 @@ const footerCopy = {
     comparison: "Comparaison",
     blog: "Blog",
     calculator: "Calculateur d'appels manqués",
+    affiliateProgram: "Programme d'affiliation",
     company: "Entreprise",
     about: "À propos",
     contact: "Contact",
@@ -72,6 +74,10 @@ const footerSections = (locale: Locale) => {
         {
           label: copy.calculator,
           href: "/missed-call-revenue-calculator/",
+        },
+        {
+          label: copy.affiliateProgram,
+          href: "/affiliate-program/",
         },
         { label: "GitHub", href: "https://github.com/lobbystack/lobbystack" },
       ],

--- a/apps/landing/src/components/Navbar.tsx
+++ b/apps/landing/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   DoorOpen,
   ExternalLink,
+  Gift,
   Hammer,
   History,
   Home,
@@ -63,6 +64,7 @@ const labels = {
     helpCenter: "Help Center",
     comparison: "Comparison",
     calculator: "Missed call calculator",
+    affiliateProgram: "Affiliate Program",
   },
   fr: {
     solutions: "Solutions",
@@ -76,6 +78,7 @@ const labels = {
     helpCenter: "Centre d'aide",
     comparison: "Comparaison",
     calculator: "Calculateur d'appels manqués",
+    affiliateProgram: "Programme d'affiliation",
   },
 } satisfies Record<Locale, Record<string, string>>
 
@@ -139,6 +142,11 @@ const resourceLinks = (locale: Locale) =>
       label: labels[locale].calculator,
       href: "/missed-call-revenue-calculator/",
       icon: Calculator,
+    },
+    {
+      label: labels[locale].affiliateProgram,
+      href: "/affiliate-program/",
+      icon: Gift,
     },
   ] satisfies NavChildLink[]
 

--- a/apps/landing/src/components/affiliate/AffiliateProgramFaqSection.tsx
+++ b/apps/landing/src/components/affiliate/AffiliateProgramFaqSection.tsx
@@ -1,0 +1,32 @@
+import { FaqAccordion } from "@/components/FaqAccordion"
+import { getAffiliateProgramFaqs } from "@/lib/affiliate-program-faqs"
+import type { Locale } from "@/i18n"
+
+type AffiliateProgramFaqSectionProps = {
+  locale: Locale
+}
+
+export function AffiliateProgramFaqSection({ locale }: AffiliateProgramFaqSectionProps) {
+  const faqs = getAffiliateProgramFaqs(locale)
+  const title = locale === "fr" ? "FAQ affiliation" : "Affiliate FAQ"
+  const description =
+    locale === "fr"
+      ? "Commissions, paiements et règles du programme."
+      : "Commissions, payouts, and program rules."
+
+  return (
+    <section className="border-t border-border/60 bg-muted/20 py-16 md:py-24">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+            {title}
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground md:text-lg">{description}</p>
+        </div>
+        <div className="mt-10">
+          <FaqAccordion faqs={faqs} />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/src/components/affiliate/AffiliateProgramSections.tsx
+++ b/apps/landing/src/components/affiliate/AffiliateProgramSections.tsx
@@ -1,0 +1,485 @@
+import { buttonVariants } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { localizeHref, type Locale } from "@/i18n"
+import { APP_AFFILIATE_URL } from "@/lib/app-links"
+import { cn } from "@/lib/utils"
+import {
+  ArrowRight,
+  Check,
+  Gift,
+  TrendingUp,
+  Wallet,
+  type LucideIcon,
+} from "lucide-react"
+
+const AFFILIATE_DOCS_URL =
+  "https://docs.lobbystack.com/billing/affiliate-program"
+
+const copy = {
+  en: {
+    hero: {
+      headingPrefix: "Become a",
+      headingAccent: "LobbyStack",
+      headingSuffix: "affiliate",
+      subhead:
+        "Earn 20% recurring commission for 12 months when you refer businesses that need better phone coverage. Referred customers get 5% off eligible hosted plans when they sign up through your link.",
+      cta: "Join the program",
+    },
+    benefits: {
+      heading: "What you'll get",
+      items: [
+        {
+          title: "20% for 12 months",
+          description:
+            "Earn 20% on qualifying subscription payments during each referred customer's first year. Your commission recurs monthly while they stay subscribed.",
+          icon: TrendingUp,
+        },
+        {
+          title: "5% off for referrals",
+          description:
+            "Businesses that start through your link get 5% off eligible hosted LobbyStack plans — an easier sell for price-conscious owners.",
+          icon: Gift,
+        },
+        {
+          title: "Simple payouts",
+          description:
+            "Commissions become eligible after a 30-day holding period. Balances of $100 or more are reviewed monthly and paid through PayPal.",
+          icon: Wallet,
+        },
+      ],
+    },
+    details: {
+      howItWorks: {
+        heading: "How it works",
+        steps: [
+          <>
+            Log in and open <strong>Affiliate Program</strong> in your dashboard
+            sidebar (Manage → Affiliate Program).
+          </>,
+          <>
+            Add your <strong>PayPal email</strong> in affiliate settings for
+            payouts.
+          </>,
+          "Share your referral link in newsletters, websites, videos, and direct recommendations.",
+          "Track clicks, attributed referrals, pending commissions, and payouts from your dashboard.",
+        ],
+      },
+      whoShouldApply: {
+        heading: "Who should apply",
+        items: [
+          <>
+            <strong>Marketing agencies</strong> helping local businesses capture
+            leads from phone calls
+          </>,
+          <>
+            <strong>Web designers and SEO consultants</strong> with small-business
+            clients who miss calls
+          </>,
+          <>
+            <strong>Business and automation consultants</strong> improving
+            operations and lead capture
+          </>,
+          <>
+            <strong>Creators and newsletter writers</strong> covering AI tools,
+            local business growth, or missed-call recovery
+          </>,
+        ],
+      },
+    },
+    guidelines: {
+      heading: "Guidelines",
+      items: [
+        {
+          title: "Keep it authentic",
+          description:
+            "Describe LobbyStack accurately. Recommend it for real missed-call, after-hours, booking, and routing problems — not as a magic fix for every business.",
+        },
+        {
+          title: "Disclose compensation",
+          description:
+            "Tell your audience when you may earn commission for referrals, in line with applicable advertising and endorsement rules.",
+        },
+        {
+          title: "No paid search on our trademarks",
+          description:
+            "Do not bid on LobbyStack trademarks or confusingly similar terms in paid search ads.",
+        },
+        {
+          title: "No spam or abuse",
+          description:
+            "Avoid fake reviews, misleading claims, self-referrals, coupon abuse, artificial traffic, or impersonating LobbyStack.",
+        },
+        {
+          title: "Termination rights",
+          descriptionPrefix:
+            "Attribution, holding periods, refunds, and payout rules are defined in our",
+          termsLabel: "Terms of Service",
+          descriptionSuffix:
+            "LobbyStack may update or pause the program at any time.",
+        },
+      ],
+      footerPrefix: "Questions? Email",
+      footerMiddle: "or read the",
+      footerDocsLabel: "affiliate program docs",
+    },
+  },
+  fr: {
+    hero: {
+      headingPrefix: "Devenez affilié",
+      headingAccent: "LobbyStack",
+      headingSuffix: "",
+      subhead:
+        "Gagnez 20 % de commission récurrente pendant 12 mois lorsque vous recommandez LobbyStack à des entreprises qui ont besoin d'une meilleure couverture téléphonique. Les clients parrainés bénéficient de 5 % de réduction sur les forfaits hébergés éligibles via votre lien.",
+      cta: "Rejoindre le programme",
+    },
+    benefits: {
+      heading: "Ce que vous obtenez",
+      items: [
+        {
+          title: "20 % pendant 12 mois",
+          description:
+            "Gagnez 20 % sur les paiements d'abonnement éligibles pendant la première année de chaque client parrainé. Votre commission se renouvelle chaque mois tant qu'il reste abonné.",
+          icon: TrendingUp,
+        },
+        {
+          title: "5 % de réduction pour les parrainages",
+          description:
+            "Les entreprises qui s'inscrivent via votre lien obtiennent 5 % de réduction sur les forfaits hébergés LobbyStack éligibles — plus facile à recommander aux propriétaires sensibles au prix.",
+          icon: Gift,
+        },
+        {
+          title: "Paiements simples",
+          description:
+            "Les commissions deviennent éligibles après une période de retenue de 30 jours. Les soldes de 100 $ ou plus sont examinés chaque mois et payés via PayPal.",
+          icon: Wallet,
+        },
+      ],
+    },
+    details: {
+      howItWorks: {
+        heading: "Comment ça marche",
+        steps: [
+          <>
+            Connectez-vous et ouvrez <strong>Programme d'affiliation</strong> dans
+            la barre latérale (Gérer → Programme d'affiliation).
+          </>,
+          <>
+            Ajoutez votre <strong>adresse e-mail PayPal</strong> dans les
+            paramètres d'affiliation pour les paiements.
+          </>,
+          "Partagez votre lien de parrainage dans vos newsletters, sites web, vidéos et recommandations directes.",
+          "Suivez les clics, les parrainages attribués, les commissions en attente et les paiements depuis votre tableau de bord.",
+        ],
+      },
+      whoShouldApply: {
+        heading: "Qui devrait postuler",
+        items: [
+          <>
+            <strong>Agences marketing</strong> aidant les entreprises locales à
+            capturer des prospects par téléphone
+          </>,
+          <>
+            <strong>Web designers et consultants SEO</strong> avec des clients PME
+            qui manquent des appels
+          </>,
+          <>
+            <strong>Consultants en affaires et en automatisation</strong>{" "}
+            améliorant les opérations et la capture de prospects
+          </>,
+          <>
+            <strong>Créateurs et rédacteurs de newsletters</strong> couvrant les
+            outils IA, la croissance des entreprises locales ou la récupération
+            d'appels manqués
+          </>,
+        ],
+      },
+    },
+    guidelines: {
+      heading: "Directives",
+      items: [
+        {
+          title: "Restez authentique",
+          description:
+            "Décrivez LobbyStack avec précision. Recommandez-le pour de vrais problèmes d'appels manqués, de couverture hors horaires, de réservation et de routage — pas comme une solution miracle pour toutes les entreprises.",
+        },
+        {
+          title: "Divulguez votre rémunération",
+          description:
+            "Informez votre audience lorsque vous pouvez percevoir une commission pour vos recommandations, conformément aux règles publicitaires et d'endossement applicables.",
+        },
+        {
+          title: "Pas de recherche payante sur nos marques",
+          description:
+            "N'enchérissez pas sur les marques LobbyStack ou des termes similaires pouvant prêter à confusion dans les annonces de recherche payante.",
+        },
+        {
+          title: "Pas de spam ni d'abus",
+          description:
+            "Évitez les faux avis, les allégations trompeuses, l'auto-parrainage, l'abus de coupons, le trafic artificiel ou l'usurpation de l'identité de LobbyStack.",
+        },
+        {
+          title: "Droit de résiliation",
+          descriptionPrefix:
+            "L'attribution, les périodes de retenue, les remboursements et les règles de paiement sont définis dans nos",
+          termsLabel: "Conditions d'utilisation",
+          descriptionSuffix:
+            "LobbyStack peut modifier ou suspendre le programme à tout moment.",
+        },
+      ],
+      footerPrefix: "Des questions ? Écrivez à",
+      footerMiddle: "ou consultez la",
+      footerDocsLabel: "documentation du programme d'affiliation",
+    },
+  },
+} satisfies Record<
+  Locale,
+  {
+    hero: {
+      headingPrefix: string
+      headingAccent: string
+      headingSuffix: string
+      subhead: string
+      cta: string
+    }
+    benefits: {
+      heading: string
+      items: Array<{
+        title: string
+        description: string
+        icon: LucideIcon
+      }>
+    }
+    details: {
+      howItWorks: {
+        heading: string
+        steps: Array<string | React.ReactNode>
+      }
+      whoShouldApply: {
+        heading: string
+        items: Array<React.ReactNode>
+      }
+    }
+    guidelines: {
+      heading: string
+      items: Array<
+        | {
+            title: string
+            description: string
+          }
+        | {
+            title: string
+            descriptionPrefix: string
+            termsLabel: string
+            descriptionSuffix: string
+          }
+      >
+      footerPrefix: string
+      footerMiddle: string
+      footerDocsLabel: string
+    }
+  }
+>
+
+function CheckListItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-3">
+      <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+      <span className="body-copy text-foreground">{children}</span>
+    </li>
+  )
+}
+
+type AffiliateProgramSectionsProps = {
+  locale?: Locale
+}
+
+export function AffiliateProgramHero({
+  locale = "en",
+}: AffiliateProgramSectionsProps) {
+  const t = copy[locale].hero
+
+  return (
+    <section className="relative overflow-hidden" id="hero">
+      <div className="mx-auto max-w-7xl px-6 pt-16 pb-8 md:pt-20 md:pb-10 lg:pt-24 lg:pb-12">
+        <div className="mx-auto max-w-4xl text-center">
+          <h1 className="display-heading">
+            {t.headingPrefix}{" "}
+            <span className="underline decoration-2 underline-offset-4">
+              {t.headingAccent}
+            </span>
+            {t.headingSuffix ? ` ${t.headingSuffix}` : ""}
+          </h1>
+
+          <p className="body-copy mx-auto mt-6 max-w-[65ch] md:text-lg">
+            {t.subhead}
+          </p>
+
+          <div className="mt-8">
+            <a
+              href={APP_AFFILIATE_URL}
+              className={cn(
+                buttonVariants({ size: "lg" }),
+                "h-11 rounded-full px-7 text-sm"
+              )}
+            >
+              {t.cta}
+              <ArrowRight className="ml-1 size-4" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function AffiliateProgramBenefits({
+  locale = "en",
+}: AffiliateProgramSectionsProps) {
+  const t = copy[locale].benefits
+
+  return (
+    <section className="section-spacing" id="benefits">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="section-heading">{t.heading}</h2>
+        </div>
+
+        <div className="mt-16 grid gap-6 md:grid-cols-3">
+          {t.items.map((item) => {
+            const Icon = item.icon
+            return (
+              <Card
+                key={item.title}
+                className="rounded-2xl border-border/70 py-0"
+              >
+                <CardHeader className="gap-4 px-8 pt-8">
+                  <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-muted">
+                    <Icon className="size-6 text-foreground" />
+                  </div>
+                  <CardTitle className="font-heading text-xl font-medium tracking-[-0.03em]">
+                    {item.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-8 pb-8">
+                  <CardDescription className="body-copy text-base text-muted-foreground">
+                    {item.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function AffiliateProgramDetails({
+  locale = "en",
+}: AffiliateProgramSectionsProps) {
+  const t = copy[locale].details
+
+  return (
+    <section className="section-spacing bg-muted/30" id="details">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="grid gap-16 lg:grid-cols-2">
+          <div>
+            <h2 className="section-heading">{t.howItWorks.heading}</h2>
+            <ul className="mt-8 flex flex-col gap-4">
+              {t.howItWorks.steps.map((step, index) => (
+                <CheckListItem key={index}>{step}</CheckListItem>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="section-heading">{t.whoShouldApply.heading}</h2>
+            <ul className="mt-8 flex flex-col gap-4">
+              {t.whoShouldApply.items.map((item, index) => (
+                <CheckListItem key={index}>{item}</CheckListItem>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function AffiliateProgramGuidelines({
+  locale = "en",
+}: AffiliateProgramSectionsProps) {
+  const t = copy[locale].guidelines
+  const termsHref = localizeHref(locale, "/terms/#affiliate-program")
+
+  return (
+    <section className="section-spacing" id="guidelines">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="section-heading">{t.heading}</h2>
+        </div>
+
+        <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {t.items.map((item) => (
+            <div key={item.title}>
+              <h3 className="font-heading text-base font-medium">{item.title}</h3>
+              <p className="body-copy mt-2 text-muted-foreground">
+                {"description" in item ? (
+                  item.description
+                ) : (
+                  <>
+                    {item.descriptionPrefix}{" "}
+                    <a
+                      href={termsHref}
+                      className="text-foreground underline underline-offset-4 hover:text-primary"
+                    >
+                      {item.termsLabel}
+                    </a>
+                    . {item.descriptionSuffix}
+                  </>
+                )}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <p className="body-copy mt-16 text-center text-muted-foreground">
+          {t.footerPrefix}{" "}
+          <a
+            href="mailto:support@lobbystack.com"
+            className="text-foreground underline underline-offset-4 hover:text-primary"
+          >
+            support@lobbystack.com
+          </a>{" "}
+          {t.footerMiddle}{" "}
+          <a
+            href={AFFILIATE_DOCS_URL}
+            className="text-foreground underline underline-offset-4 hover:text-primary"
+          >
+            {t.footerDocsLabel}
+          </a>
+          .
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export function AffiliateProgramSections({
+  locale = "en",
+}: AffiliateProgramSectionsProps) {
+  return (
+    <>
+      <AffiliateProgramHero locale={locale} />
+      <AffiliateProgramBenefits locale={locale} />
+      <AffiliateProgramDetails locale={locale} />
+      <AffiliateProgramGuidelines locale={locale} />
+    </>
+  )
+}

--- a/apps/landing/src/components/affiliate/AffiliateProgramSections.tsx
+++ b/apps/landing/src/components/affiliate/AffiliateProgramSections.tsx
@@ -7,7 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { localizeHref, type Locale } from "@/i18n"
-import { APP_AFFILIATE_URL } from "@/lib/app-links"
+import { APP_AFFILIATE_SIGNUP_URL } from "@/lib/app-links"
 import { cn } from "@/lib/utils"
 import {
   ArrowRight,
@@ -59,8 +59,8 @@ const copy = {
         heading: "How it works",
         steps: [
           <>
-            Log in and open <strong>Affiliate Program</strong> in your dashboard
-            sidebar (Manage → Affiliate Program).
+            Log in and open <strong>Affiliate Program</strong> from the gift icon
+            in the top-right header.
           </>,
           <>
             Add your <strong>PayPal email</strong> in affiliate settings for
@@ -164,8 +164,8 @@ const copy = {
         heading: "Comment ça marche",
         steps: [
           <>
-            Connectez-vous et ouvrez <strong>Programme d'affiliation</strong> dans
-            la barre latérale (Gérer → Programme d'affiliation).
+            Connectez-vous et ouvrez <strong>Programme d'affiliation</strong> via
+            l'icône cadeau en haut à droite.
           </>,
           <>
             Ajoutez votre <strong>adresse e-mail PayPal</strong> dans les
@@ -318,7 +318,7 @@ export function AffiliateProgramHero({
 
           <div className="mt-8">
             <a
-              href={APP_AFFILIATE_URL}
+              href={APP_AFFILIATE_SIGNUP_URL}
               className={cn(
                 buttonVariants({ size: "lg" }),
                 "h-11 rounded-full px-7 text-sm"

--- a/apps/landing/src/components/affiliate/AffiliateProgramSections.tsx
+++ b/apps/landing/src/components/affiliate/AffiliateProgramSections.tsx
@@ -28,7 +28,7 @@ const copy = {
       headingAccent: "LobbyStack",
       headingSuffix: "affiliate",
       subhead:
-        "Earn 20% recurring commission for 12 months when you refer businesses that need better phone coverage. Referred customers get 5% off eligible hosted plans when they sign up through your link.",
+        "Refer businesses to LobbyStack hosted plans and earn 20% of their payments for 12 months. Referrals save 5% when they sign up through your link.",
       cta: "Join the program",
     },
     benefits: {
@@ -37,19 +37,19 @@ const copy = {
         {
           title: "20% for 12 months",
           description:
-            "Earn 20% on qualifying subscription payments during each referred customer's first year. Your commission recurs monthly while they stay subscribed.",
+            "You earn 20% on each hosted plan payment during the customer's first year. The commission repeats monthly while they stay subscribed.",
           icon: TrendingUp,
         },
         {
           title: "5% off for referrals",
           description:
-            "Businesses that start through your link get 5% off eligible hosted LobbyStack plans — an easier sell for price-conscious owners.",
+            "Referrals get 5% off hosted LobbyStack plans at signup.",
           icon: Gift,
         },
         {
           title: "Simple payouts",
           description:
-            "Commissions become eligible after a 30-day holding period. Balances of $100 or more are reviewed monthly and paid through PayPal.",
+            "We hold commissions for 30 days. Balances of $100 or more get paid monthly through PayPal.",
           icon: Wallet,
         },
       ],
@@ -67,7 +67,7 @@ const copy = {
             payouts.
           </>,
           "Share your referral link in newsletters, websites, videos, and direct recommendations.",
-          "Track clicks, attributed referrals, pending commissions, and payouts from your dashboard.",
+          "Watch clicks, referrals, pending commissions, and payouts in your dashboard.",
         ],
       },
       whoShouldApply: {
@@ -96,14 +96,14 @@ const copy = {
       heading: "Guidelines",
       items: [
         {
-          title: "Keep it authentic",
+          title: "Keep it honest",
           description:
-            "Describe LobbyStack accurately. Recommend it for real missed-call, after-hours, booking, and routing problems — not as a magic fix for every business.",
+            "Describe LobbyStack accurately. Recommend it for missed calls, after-hours coverage, booking, and routing problems you have actually seen.",
         },
         {
           title: "Disclose compensation",
           description:
-            "Tell your audience when you may earn commission for referrals, in line with applicable advertising and endorsement rules.",
+            "Tell your audience when you earn commission from a referral.",
         },
         {
           title: "No paid search on our trademarks",
@@ -113,15 +113,13 @@ const copy = {
         {
           title: "No spam or abuse",
           description:
-            "Avoid fake reviews, misleading claims, self-referrals, coupon abuse, artificial traffic, or impersonating LobbyStack.",
+            "No fake reviews, misleading claims, self-referrals, coupon abuse, fake traffic, or pretending to be LobbyStack.",
         },
         {
           title: "Termination rights",
-          descriptionPrefix:
-            "Attribution, holding periods, refunds, and payout rules are defined in our",
+          descriptionPrefix: "Attribution, holds, refunds, and payout rules are in our",
           termsLabel: "Terms of Service",
-          descriptionSuffix:
-            "LobbyStack may update or pause the program at any time.",
+          descriptionSuffix: "LobbyStack can change or pause the program at any time.",
         },
       ],
       footerPrefix: "Questions? Email",
@@ -135,7 +133,7 @@ const copy = {
       headingAccent: "LobbyStack",
       headingSuffix: "",
       subhead:
-        "Gagnez 20 % de commission récurrente pendant 12 mois lorsque vous recommandez LobbyStack à des entreprises qui ont besoin d'une meilleure couverture téléphonique. Les clients parrainés bénéficient de 5 % de réduction sur les forfaits hébergés éligibles via votre lien.",
+        "Parrainez des entreprises vers les forfaits hébergés LobbyStack et touchez 20 % de leurs paiements pendant 12 mois. Les parrainages obtiennent 5 % de rabais lorsqu'ils s'inscrivent via votre lien.",
       cta: "Rejoindre le programme",
     },
     benefits: {
@@ -144,19 +142,19 @@ const copy = {
         {
           title: "20 % pendant 12 mois",
           description:
-            "Gagnez 20 % sur les paiements d'abonnement éligibles pendant la première année de chaque client parrainé. Votre commission se renouvelle chaque mois tant qu'il reste abonné.",
+            "Vous touchez 20 % sur chaque paiement de forfait hébergé pendant la première année du client. La commission se renouvelle chaque mois tant qu'il reste abonné.",
           icon: TrendingUp,
         },
         {
-          title: "5 % de réduction pour les parrainages",
+          title: "5 % de rabais pour les parrainages",
           description:
-            "Les entreprises qui s'inscrivent via votre lien obtiennent 5 % de réduction sur les forfaits hébergés LobbyStack éligibles — plus facile à recommander aux propriétaires sensibles au prix.",
+            "Les parrainages obtiennent 5 % de rabais sur les forfaits hébergés LobbyStack à l'inscription.",
           icon: Gift,
         },
         {
           title: "Paiements simples",
           description:
-            "Les commissions deviennent éligibles après une période de retenue de 30 jours. Les soldes de 100 $ ou plus sont examinés chaque mois et payés via PayPal.",
+            "Nous retenons chaque commission 30 jours. Les soldes de 100 $ ou plus sont payés chaque mois via PayPal.",
           icon: Wallet,
         },
       ],
@@ -174,7 +172,7 @@ const copy = {
             paramètres d'affiliation pour les paiements.
           </>,
           "Partagez votre lien de parrainage dans vos newsletters, sites web, vidéos et recommandations directes.",
-          "Suivez les clics, les parrainages attribués, les commissions en attente et les paiements depuis votre tableau de bord.",
+          "Suivez les clics, les parrainages, les commissions en attente et les paiements dans votre tableau de bord.",
         ],
       },
       whoShouldApply: {
@@ -204,14 +202,14 @@ const copy = {
       heading: "Directives",
       items: [
         {
-          title: "Restez authentique",
+          title: "Restez honnête",
           description:
-            "Décrivez LobbyStack avec précision. Recommandez-le pour de vrais problèmes d'appels manqués, de couverture hors horaires, de réservation et de routage — pas comme une solution miracle pour toutes les entreprises.",
+            "Décrivez LobbyStack avec précision. Recommandez-le pour les appels manqués, la couverture hors horaires, la réservation et le routage que vous avez vus sur le terrain.",
         },
         {
           title: "Divulguez votre rémunération",
           description:
-            "Informez votre audience lorsque vous pouvez percevoir une commission pour vos recommandations, conformément aux règles publicitaires et d'endossement applicables.",
+            "Dites à votre audience quand vous touchez une commission sur un parrainage.",
         },
         {
           title: "Pas de recherche payante sur nos marques",
@@ -221,15 +219,13 @@ const copy = {
         {
           title: "Pas de spam ni d'abus",
           description:
-            "Évitez les faux avis, les allégations trompeuses, l'auto-parrainage, l'abus de coupons, le trafic artificiel ou l'usurpation de l'identité de LobbyStack.",
+            "Pas de faux avis, d'allégations trompeuses, d'auto-parrainage, d'abus de coupons, de trafic artificiel ni d'usurpation de LobbyStack.",
         },
         {
           title: "Droit de résiliation",
-          descriptionPrefix:
-            "L'attribution, les périodes de retenue, les remboursements et les règles de paiement sont définis dans nos",
+          descriptionPrefix: "L'attribution, les retenues, les remboursements et les règles de paiement sont dans nos",
           termsLabel: "Conditions d'utilisation",
-          descriptionSuffix:
-            "LobbyStack peut modifier ou suspendre le programme à tout moment.",
+          descriptionSuffix: "LobbyStack peut modifier ou suspendre le programme à tout moment.",
         },
       ],
       footerPrefix: "Des questions ? Écrivez à",

--- a/apps/landing/src/components/pages/AffiliateProgramPage.astro
+++ b/apps/landing/src/components/pages/AffiliateProgramPage.astro
@@ -1,14 +1,16 @@
 ---
 import Layout from "@/layouts/main.astro"
 import { Navbar } from "@/components/Navbar"
+import { AffiliateProgramFaqSection } from "@/components/affiliate/AffiliateProgramFaqSection"
 import { AffiliateProgramSections } from "@/components/affiliate/AffiliateProgramSections"
 import { CtaSection } from "@/components/CtaSection"
 import { Footer } from "@/components/Footer"
+import { getAffiliateProgramFaqs } from "@/lib/affiliate-program-faqs"
 import {
   breadcrumbJsonLd,
+  faqPageJsonLd,
   organizationJsonLd,
   softwareApplicationJsonLd,
-  absoluteUrl,
   webSiteJsonLd,
 } from "@/lib/seo"
 import { assertLocale, getCopy, getRouteSeo, localizePath, type Locale } from "@/i18n"
@@ -23,6 +25,8 @@ const canonicalPath = localizePath(locale, "/affiliate-program/")
 const seo = getRouteSeo({ locale, path: "/affiliate-program/" })
 const pageTitle =
   locale === "fr" ? "Programme d'affiliation" : "Affiliate Program"
+const affiliateOgImage =
+  "/illustrations/open-source-ai-receptionist-affiliate-program-hero.webp"
 ---
 
 <Layout
@@ -30,6 +34,11 @@ const pageTitle =
     ...seo,
     canonicalPath,
     locale,
+    image: affiliateOgImage,
+    imageAlt:
+      locale === "fr"
+        ? "Programme d'affiliation LobbyStack"
+        : "LobbyStack Affiliate Program",
     jsonLd: [
       organizationJsonLd({ locale }),
       webSiteJsonLd({ locale }),
@@ -38,24 +47,18 @@ const pageTitle =
         { name: copy.common.home, path: localizePath(locale, "/") },
         { name: pageTitle, path: canonicalPath },
       ]),
-      {
-        "@context": "https://schema.org",
-        "@type": "WebPage",
-        "@id": absoluteUrl(`${canonicalPath}#webpage`),
-        name: seo?.title,
-        url: absoluteUrl(canonicalPath),
-        description: seo?.description,
-        inLanguage: locale,
-        isPartOf: {
-          "@id": absoluteUrl("/#website"),
-        },
-      },
+      faqPageJsonLd({
+        path: canonicalPath,
+        faqs: getAffiliateProgramFaqs(locale),
+        locale,
+      }),
     ],
   }}
 >
   <Navbar locale={locale} />
   <main id="main-content">
     <AffiliateProgramSections client:load locale={locale} />
+    <AffiliateProgramFaqSection locale={locale} />
     <CtaSection locale={locale} />
   </main>
   <Footer locale={locale} />

--- a/apps/landing/src/components/pages/AffiliateProgramPage.astro
+++ b/apps/landing/src/components/pages/AffiliateProgramPage.astro
@@ -1,0 +1,62 @@
+---
+import Layout from "@/layouts/main.astro"
+import { Navbar } from "@/components/Navbar"
+import { AffiliateProgramSections } from "@/components/affiliate/AffiliateProgramSections"
+import { CtaSection } from "@/components/CtaSection"
+import { Footer } from "@/components/Footer"
+import {
+  breadcrumbJsonLd,
+  organizationJsonLd,
+  softwareApplicationJsonLd,
+  absoluteUrl,
+  webSiteJsonLd,
+} from "@/lib/seo"
+import { assertLocale, getCopy, getRouteSeo, localizePath, type Locale } from "@/i18n"
+
+interface Props {
+  locale?: Locale
+}
+
+const locale = assertLocale(Astro.props.locale ?? Astro.currentLocale)
+const copy = getCopy(locale)
+const canonicalPath = localizePath(locale, "/affiliate-program/")
+const seo = getRouteSeo({ locale, path: "/affiliate-program/" })
+const pageTitle =
+  locale === "fr" ? "Programme d'affiliation" : "Affiliate Program"
+---
+
+<Layout
+  seo={{
+    ...seo,
+    canonicalPath,
+    locale,
+    jsonLd: [
+      organizationJsonLd({ locale }),
+      webSiteJsonLd({ locale }),
+      softwareApplicationJsonLd({ locale }),
+      breadcrumbJsonLd([
+        { name: copy.common.home, path: localizePath(locale, "/") },
+        { name: pageTitle, path: canonicalPath },
+      ]),
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "@id": absoluteUrl(`${canonicalPath}#webpage`),
+        name: seo?.title,
+        url: absoluteUrl(canonicalPath),
+        description: seo?.description,
+        inLanguage: locale,
+        isPartOf: {
+          "@id": absoluteUrl("/#website"),
+        },
+      },
+    ],
+  }}
+>
+  <Navbar locale={locale} />
+  <main id="main-content">
+    <AffiliateProgramSections client:load locale={locale} />
+    <CtaSection locale={locale} />
+  </main>
+  <Footer locale={locale} />
+</Layout>

--- a/apps/landing/src/content/blog/fr/open-source-ai-receptionist-affiliate-program.md
+++ b/apps/landing/src/content/blog/fr/open-source-ai-receptionist-affiliate-program.md
@@ -12,7 +12,7 @@ canonicalSlug: "ai-receptionist-affiliate-program"
 
 Si vous cherchez un **programme d'affiliation pour réceptionniste IA** qui mérite une recommandation, partez de l'acheteur. Un opérateur local veut répondre aux appels, prendre des rendez-vous, gérer les SMS et comprendre pourquoi il peut confier de vrais clients à une automatisation. LobbyStack vous donne cet argument.
 
-LobbyStack paie aux affiliés 20 % des paiements admissibles des clients recommandés pendant la première année. Vous pouvez promouvoir le réceptionniste IA hébergé auprès des opérateurs qui veulent un accueil fonctionnel cette semaine, et montrer le code open source aux acheteurs techniques qui demandent comment le système fonctionne.
+LobbyStack paie aux affiliés 20 % des paiements admissibles des clients recommandés pendant la première année. Consultez le [programme d'affiliation LobbyStack](/fr/affiliate-program/) pour les conditions, les paiements et la mise en route. Vous pouvez promouvoir le réceptionniste IA hébergé auprès des opérateurs qui veulent un accueil fonctionnel cette semaine, et montrer le code open source aux acheteurs techniques qui demandent comment le système fonctionne.
 
 ## Le programme en clair
 
@@ -180,7 +180,7 @@ Quatre points à retenir :
 - LobbyStack offre un réceptionniste IA hébergé et une voie open source/auto-hébergée.
 - Les meilleures références viennent de vrais problèmes d'appels, de réservation et d'accueil.
 
-Ouvrez la page affiliation dans votre tableau de bord LobbyStack, ajoutez votre courriel PayPal et partagez votre lien avec des opérateurs qui ont besoin d'un meilleur accueil.
+[Rejoignez le programme d'affiliation LobbyStack](/fr/affiliate-program/), ajoutez votre courriel PayPal dans votre tableau de bord et partagez votre lien avec des opérateurs qui ont besoin d'un meilleur accueil.
 
 ## Sources
 

--- a/apps/landing/src/content/blog/open-source-ai-receptionist-affiliate-program.md
+++ b/apps/landing/src/content/blog/open-source-ai-receptionist-affiliate-program.md
@@ -18,7 +18,7 @@ Most of those callers do not wait. They call the next business.
 
 That is why [AI receptionists](/features/) are becoming an easy product to recommend. The problem is obvious, the value is easy to understand, and the customer does not need to replace their whole business system to get started.
 
-The LobbyStack Affiliate Program gives you a simple way to earn recurring revenue by helping businesses answer more calls, capture more leads, and book more appointments.
+The [LobbyStack Affiliate Program](/affiliate-program/) gives you a simple way to earn recurring revenue by helping businesses answer more calls, capture more leads, and book more appointments.
 
 ## What is the LobbyStack Affiliate Program?
 
@@ -450,4 +450,4 @@ LobbyStack makes that possible with an open-source AI receptionist built for rea
 
 If you already reach business owners, agencies, consultants, operators, or local service providers, the LobbyStack Affiliate Program gives you a simple way to turn those relationships into recurring revenue.
 
-Join the LobbyStack Affiliate Program and start earning 20% commission for 12 months on every customer you refer.
+[Join the LobbyStack Affiliate Program](/affiliate-program/) and start earning 20% commission for 12 months on every customer you refer.

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -104,7 +104,7 @@ export const en = {
     "/affiliate-program/": {
       title: "LobbyStack Affiliate Program | Earn 20% Commission",
       description:
-        "Join the LobbyStack Affiliate Program. Earn 20% commission for 12 months, give referred businesses 5% off, and get paid through PayPal.",
+        "Refer businesses to hosted LobbyStack plans and earn 20% of their payments for 12 months. Referrals save 5% at signup. Monthly PayPal payouts after a 30-day hold.",
     },
     "/404/": {
       title: "Page not found - LobbyStack",

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -101,6 +101,11 @@ export const en = {
       description:
         "Search LobbyStack pages, blog posts, product resources, pricing details, and public agent-discovery documentation.",
     },
+    "/affiliate-program/": {
+      title: "LobbyStack Affiliate Program | Earn 20% Commission",
+      description:
+        "Join the LobbyStack Affiliate Program. Earn 20% commission for 12 months, give referred businesses 5% off, and get paid through PayPal.",
+    },
     "/404/": {
       title: "Page not found - LobbyStack",
       description:

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -102,6 +102,11 @@ export const fr = {
       description:
         "Recherchez dans les pages LobbyStack, les articles, les ressources produit, les tarifs et la documentation publique.",
     },
+    "/affiliate-program/": {
+      title: "Programme d'affiliation LobbyStack | Gagnez 20 % de commission",
+      description:
+        "Rejoignez le programme d'affiliation LobbyStack. Gagnez 20 % de commission pendant 12 mois, offrez 5 % de réduction aux entreprises parrainées et recevez vos paiements via PayPal.",
+    },
     "/404/": {
       title: "Page introuvable - LobbyStack",
       description:

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -103,9 +103,9 @@ export const fr = {
         "Recherchez dans les pages LobbyStack, les articles, les ressources produit, les tarifs et la documentation publique.",
     },
     "/affiliate-program/": {
-      title: "Programme d'affiliation LobbyStack | Gagnez 20 % de commission",
+      title: "Programme d'affiliation LobbyStack | 20 % de commission",
       description:
-        "Rejoignez le programme d'affiliation LobbyStack. Gagnez 20 % de commission pendant 12 mois, offrez 5 % de réduction aux entreprises parrainées et recevez vos paiements via PayPal.",
+        "Parrainez des entreprises vers les forfaits hébergés LobbyStack et touchez 20 % de leurs paiements pendant 12 mois. Rabais de 5 % à l'inscription. Paiements PayPal mensuels après 30 jours de retenue.",
     },
     "/404/": {
       title: "Page introuvable - LobbyStack",

--- a/apps/landing/src/i18n/routes.ts
+++ b/apps/landing/src/i18n/routes.ts
@@ -20,6 +20,7 @@ export const translatedBasePaths = [
   "/blog/open-source-ai-receptionist-stack/",
   "/blog/ai-receptionist-workflows/",
   "/blog/ai-receptionist-affiliate-program/",
+  "/affiliate-program/",
   "/docs/api/",
   "/privacy/",
   "/cookie-policy/",

--- a/apps/landing/src/lib/affiliate-program-faqs.ts
+++ b/apps/landing/src/lib/affiliate-program-faqs.ts
@@ -1,0 +1,76 @@
+import type { Locale } from "@/i18n"
+
+export type AffiliateProgramFaq = {
+  question: string
+  answer: string
+}
+
+const EN_FAQS: AffiliateProgramFaq[] = [
+  {
+    question: "How much do I earn?",
+    answer:
+      "You get 20% of each hosted plan payment for 12 months after someone signs up with your link. A Pro customer on the monthly plan pays you up to $240 that first year.",
+  },
+  {
+    question: "What do referred businesses save?",
+    answer:
+      "They get 5% off hosted LobbyStack plans when they sign up through your link.",
+  },
+  {
+    question: "When do I get paid?",
+    answer:
+      "We hold each commission for 30 days, then add it to your balance. We pay through PayPal once your balance reaches $100.",
+  },
+  {
+    question: "Who is this program for?",
+    answer:
+      "Agencies, consultants, creators, and operators who already recommend tools to small businesses: salons, clinics, contractors, home services, and other appointment-heavy teams.",
+  },
+  {
+    question: "How do I start?",
+    answer:
+      "Sign in, open Affiliate Program in your dashboard, add your PayPal email, and share your link.",
+  },
+  {
+    question: "Do self-hosted signups count?",
+    answer:
+      "No. You earn commission on hosted LobbyStack plan payments only. If someone self-hosts without a paid LobbyStack subscription, that referral does not pay commission.",
+  },
+]
+
+const FR_FAQS: AffiliateProgramFaq[] = [
+  {
+    question: "Combien est-ce que je gagne ?",
+    answer:
+      "Vous touchez 20 % de chaque paiement de forfait hébergé pendant 12 mois après l'inscription via votre lien. Un client Pro au forfait mensuel peut vous rapporter jusqu'à 240 $ la première année.",
+  },
+  {
+    question: "Quelle réduction obtiennent les entreprises parrainées ?",
+    answer:
+      "Elles obtiennent 5 % de rabais sur les forfaits hébergés LobbyStack lorsqu'elles s'inscrivent via votre lien.",
+  },
+  {
+    question: "Quand est-ce que je suis payé ?",
+    answer:
+      "Chaque commission est retenue 30 jours, puis ajoutée à votre solde. Nous payons via PayPal dès que votre solde atteint 100 $.",
+  },
+  {
+    question: "À qui s'adresse ce programme ?",
+    answer:
+      "Aux agences, consultants, créateurs et opérateurs qui recommandent déjà des outils aux PME : salons, cliniques, entrepreneurs, services à domicile et autres équipes qui vivent au rythme des rendez-vous.",
+  },
+  {
+    question: "Comment démarrer ?",
+    answer:
+      "Connectez-vous, ouvrez Programme d'affiliation dans votre tableau de bord, ajoutez votre courriel PayPal et partagez votre lien.",
+  },
+  {
+    question: "Les inscriptions auto-hébergées comptent-elles ?",
+    answer:
+      "Non. Vous touchez une commission uniquement sur les paiements de forfaits hébergés LobbyStack. Si quelqu'un s'auto-héberge sans abonnement LobbyStack payant, ce parrainage ne paie pas de commission.",
+  },
+]
+
+export function getAffiliateProgramFaqs(locale: Locale): AffiliateProgramFaq[] {
+  return locale === "fr" ? FR_FAQS : EN_FAQS
+}

--- a/apps/landing/src/lib/agent-discovery.ts
+++ b/apps/landing/src/lib/agent-discovery.ts
@@ -35,6 +35,7 @@ export const markdownAlternatePath = (pathname: string) => {
     "/",
     "/features/",
     "/pricing/",
+    "/affiliate-program/",
     "/missed-call-revenue-calculator/",
     "/blog/",
     "/changelog/",
@@ -49,6 +50,7 @@ export const markdownAlternatePath = (pathname: string) => {
     "/": "/index.md",
     "/features/": "/features.md",
     "/pricing/": "/pricing.md",
+    "/affiliate-program/": "/affiliate-program.md",
     "/missed-call-revenue-calculator/":
       "/missed-call-revenue-calculator/index.md",
     "/blog/": "/blog.md",
@@ -131,6 +133,11 @@ export const apiCatalog = {
           href: absoluteUrl("/pricing.md"),
           type: "text/markdown",
           title: "LobbyStack pricing markdown summary",
+        },
+        {
+          href: absoluteUrl("/affiliate-program.md"),
+          type: "text/markdown",
+          title: "LobbyStack affiliate program markdown summary",
         },
         {
           href: absoluteUrl("/missed-call-revenue-calculator/index.md"),
@@ -353,6 +360,23 @@ export const openApiDocument = {
         },
       },
     },
+    "/affiliate-program.md": {
+      get: {
+        summary: "Get the affiliate program markdown summary",
+        operationId: "getAffiliateProgramMarkdown",
+        responses: {
+          "200": {
+            description:
+              "Markdown summary of the LobbyStack Affiliate Program terms, payouts, and onboarding.",
+            content: {
+              "text/markdown": {
+                schema: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/missed-call-revenue-calculator/index.md": {
       get: {
         summary: "Get the missed call revenue calculator markdown",
@@ -473,6 +497,11 @@ export const mcpServerCard = {
         mimeType: "text/markdown",
       },
       {
+        uri: absoluteUrl("/affiliate-program.md"),
+        name: "LobbyStack affiliate program markdown summary",
+        mimeType: "text/markdown",
+      },
+      {
         uri: absoluteUrl("/openapi.json"),
         name: "LobbyStack public OpenAPI description",
         mimeType: "application/vnd.oai.openapi+json",
@@ -500,6 +529,7 @@ Use this skill when an agent needs a concise, machine-readable orientation to Lo
 - LLM context: ${absoluteUrl("/llms.txt")}
 - Features markdown: ${absoluteUrl("/features.md")}
 - Pricing markdown: ${absoluteUrl("/pricing.md")}
+- Affiliate program markdown: ${absoluteUrl("/affiliate-program.md")}
 - Calculator markdown: ${absoluteUrl("/missed-call-revenue-calculator/index.md")}
 - GitHub repository: https://github.com/lobbystack/lobbystack
 
@@ -507,7 +537,7 @@ Use this skill when an agent needs a concise, machine-readable orientation to Lo
 
 1. Start with ${absoluteUrl("/llms.txt")} for a compact product overview.
 2. Use ${absoluteUrl("/.well-known/api-catalog")} to discover public machine-readable resources.
-3. Use ${absoluteUrl("/features.md")} and ${absoluteUrl("/pricing.md")} for clean markdown summaries of the public site.
+3. Use ${absoluteUrl("/features.md")}, ${absoluteUrl("/pricing.md")}, and ${absoluteUrl("/affiliate-program.md")} for clean markdown summaries of the public site.
 4. Use https://docs.lobbystack.com/introduction for product setup and self-hosting documentation.
 5. Use ${absoluteUrl("/pricing/")} for canonical pricing details and ${absoluteUrl("/features/")} for canonical capability descriptions.
 `
@@ -551,9 +581,11 @@ ${DEFAULT_DESCRIPTION}
 
 - Features: ${absoluteUrl("/features/")}
 - Pricing: ${absoluteUrl("/pricing/")}
+- Affiliate program: ${absoluteUrl("/affiliate-program/")}
 - Calculator: ${absoluteUrl("/missed-call-revenue-calculator/")}
 - Features markdown: ${absoluteUrl("/features.md")}
 - Pricing markdown: ${absoluteUrl("/pricing.md")}
+- Affiliate program markdown: ${absoluteUrl("/affiliate-program.md")}
 - Calculator markdown: ${absoluteUrl("/missed-call-revenue-calculator/index.md")}
 - Documentation: https://docs.lobbystack.com/introduction
 - API catalog: ${absoluteUrl("/.well-known/api-catalog")}
@@ -647,6 +679,84 @@ No. LobbyStack excludes spam calls from usage, so wrong numbers, robocalls, and 
 
 No. Calls under 10 seconds are excluded from usage and do not count against included voice minutes or paid-plan overages.
 `
+
+export const affiliateProgramMarkdown = (locale: "en" | "fr") => {
+  if (locale === "fr") {
+    return `---
+title: Programme d'affiliation LobbyStack | 20 % de commission
+description: Résumé public du programme d'affiliation LobbyStack.
+url: ${absoluteUrl("/fr/affiliate-program/")}
+---
+
+# Programme d'affiliation LobbyStack
+
+Parrainez des clients payants vers les forfaits hébergés LobbyStack et touchez une commission.
+
+## Conditions du programme
+
+| Terme | LobbyStack |
+| --- | --- |
+| Commission | 20 % |
+| Durée | 12 premiers mois après attribution |
+| Délai de retenue | 30 jours |
+| Paiement minimum | 100 $ US |
+| Mode de paiement | PayPal |
+
+Les entreprises parrainées obtiennent 5 % de rabais sur les forfaits hébergés LobbyStack lorsqu'elles s'inscrivent via votre lien.
+
+## Ce qui paie une commission
+
+Vous touchez une commission uniquement sur les paiements de forfaits hébergés LobbyStack. L'auto-hébergement sans abonnement payant ne paie pas de commission.
+
+## Comment commencer
+
+1. Connectez-vous et ouvrez la page affiliation dans votre tableau de bord.
+2. Ajoutez votre courriel PayPal.
+3. Partagez votre lien avec des entreprises qui ont besoin d'un meilleur accueil téléphonique.
+
+## Bon profil pour le programme
+
+Agences, consultants, créateurs et opérateurs qui recommandent des outils aux PME, services à domicile, cliniques et salons.
+`
+  }
+
+  return `---
+title: LobbyStack Affiliate Program | Earn 20% Commission
+description: Public summary of the LobbyStack Affiliate Program.
+url: ${absoluteUrl("/affiliate-program/")}
+---
+
+# LobbyStack Affiliate Program
+
+Refer paying customers to hosted LobbyStack plans and earn commission.
+
+## Program terms
+
+| Term | LobbyStack |
+| --- | --- |
+| Commission | 20% |
+| Duration | First 12 months after attribution |
+| Holding period | 30 days |
+| Minimum payout | USD $100 |
+| Payout method | PayPal |
+
+Referred businesses get 5% off hosted LobbyStack plans when they sign up through your link.
+
+## What pays commission
+
+You earn commission on hosted LobbyStack plan payments only. Self-hosting without a paid LobbyStack subscription does not pay commission.
+
+## How to get started
+
+1. Sign in and open the affiliate page in your dashboard.
+2. Add your PayPal email.
+3. Share your link with businesses that need better phone coverage and appointment booking.
+
+## Who should apply
+
+Agencies, consultants, creators, and operators who recommend tools to small businesses, home services, clinics, and salons.
+`
+}
 
 export const calculatorMarkdown = `---
 title: Missed Call Revenue Calculator for Contractors - LobbyStack

--- a/apps/landing/src/lib/app-links.ts
+++ b/apps/landing/src/lib/app-links.ts
@@ -1,3 +1,8 @@
 export const APP_LOGIN_URL = "https://app.lobbystack.com/login"
 export const APP_SIGNUP_URL = "https://app.lobbystack.com/signup"
 export const APP_AFFILIATE_URL = "https://app.lobbystack.com/affiliate"
+
+const affiliateReturnTo = encodeURIComponent("/affiliate")
+
+export const APP_AFFILIATE_LOGIN_URL = `${APP_LOGIN_URL}?returnTo=${affiliateReturnTo}`
+export const APP_AFFILIATE_SIGNUP_URL = `${APP_SIGNUP_URL}?returnTo=${affiliateReturnTo}`

--- a/apps/landing/src/lib/app-links.ts
+++ b/apps/landing/src/lib/app-links.ts
@@ -1,2 +1,3 @@
 export const APP_LOGIN_URL = "https://app.lobbystack.com/login"
 export const APP_SIGNUP_URL = "https://app.lobbystack.com/signup"
+export const APP_AFFILIATE_URL = "https://app.lobbystack.com/affiliate"

--- a/apps/landing/src/pages/affiliate-program.astro
+++ b/apps/landing/src/pages/affiliate-program.astro
@@ -1,0 +1,5 @@
+---
+import AffiliateProgramPage from "@/components/pages/AffiliateProgramPage.astro"
+---
+
+<AffiliateProgramPage locale="en" />

--- a/apps/landing/src/pages/affiliate-program.md.ts
+++ b/apps/landing/src/pages/affiliate-program.md.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro"
+import { affiliateProgramMarkdown } from "@/lib/agent-discovery"
+import { markdownResponse } from "@/lib/markdown-response"
+import { absoluteUrl } from "@/lib/seo"
+
+export const GET: APIRoute = () =>
+  markdownResponse({
+    markdown: affiliateProgramMarkdown("en"),
+    canonical: absoluteUrl("/affiliate-program/"),
+    title: "LobbyStack Affiliate Program | Earn 20% Commission",
+    description:
+      "Refer businesses to hosted LobbyStack plans and earn 20% of their payments for 12 months. Referrals save 5% at signup. Monthly PayPal payouts after a 30-day hold.",
+  })

--- a/apps/landing/src/pages/fr/affiliate-program.astro
+++ b/apps/landing/src/pages/fr/affiliate-program.astro
@@ -1,0 +1,5 @@
+---
+import AffiliateProgramPage from "@/components/pages/AffiliateProgramPage.astro"
+---
+
+<AffiliateProgramPage locale="fr" />

--- a/apps/landing/src/pages/fr/affiliate-program.md.ts
+++ b/apps/landing/src/pages/fr/affiliate-program.md.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro"
+import { affiliateProgramMarkdown } from "@/lib/agent-discovery"
+import { markdownResponse } from "@/lib/markdown-response"
+import { absoluteUrl } from "@/lib/seo"
+
+export const GET: APIRoute = () =>
+  markdownResponse({
+    markdown: affiliateProgramMarkdown("fr"),
+    canonical: absoluteUrl("/fr/affiliate-program/"),
+    title: "Programme d'affiliation LobbyStack | 20 % de commission",
+    description:
+      "Parrainez des entreprises vers les forfaits hébergés LobbyStack et touchez 20 % de leurs paiements pendant 12 mois. Rabais de 5 % à l'inscription. Paiements PayPal mensuels après 30 jours de retenue.",
+  })

--- a/mintlify/billing/affiliate-program.mdx
+++ b/mintlify/billing/affiliate-program.mdx
@@ -24,14 +24,11 @@ Refunds, disputes, cancellations, and invalid payments can void unpaid commissio
   [Earn 20% With the LobbyStack Affiliate Program](https://lobbystack.com/blog/ai-receptionist-affiliate-program/).
 </Info>
 
-## Activate your affiliate profile
+## Get started
 
 <Steps>
   <Step title="Open the affiliate page">
     In the dashboard sidebar, go to **Manage** > **Affiliate Program**.
-  </Step>
-  <Step title="Activate your profile">
-    Click **Activate affiliate profile**. LobbyStack creates your referral code and referral link.
   </Step>
   <Step title="Add your PayPal email">
     Open **Settings** on the affiliate page and save the PayPal email used for payouts.

--- a/mintlify/billing/affiliate-program.mdx
+++ b/mintlify/billing/affiliate-program.mdx
@@ -20,7 +20,9 @@ You get a referral link from the dashboard. Share it with businesses that need b
 Refunds, disputes, cancellations, and invalid payments can void unpaid commissions.
 
 <Info>
-  For the overview and earning examples, read
+  For the overview and earning examples, read the
+  [LobbyStack Affiliate Program](https://lobbystack.com/affiliate-program/)
+  page. For a deeper comparison with other programs, see
   [Earn 20% With the LobbyStack Affiliate Program](https://lobbystack.com/blog/ai-receptionist-affiliate-program/).
 </Info>
 

--- a/mintlify/billing/affiliate-program.mdx
+++ b/mintlify/billing/affiliate-program.mdx
@@ -30,7 +30,7 @@ Refunds, disputes, cancellations, and invalid payments can void unpaid commissio
 
 <Steps>
   <Step title="Open the affiliate page">
-    In the dashboard sidebar, go to **Manage** > **Affiliate Program**.
+    In the dashboard header, click the gift icon to open **Affiliate Program**.
   </Step>
   <Step title="Add your PayPal email">
     Open **Settings** on the affiliate page and save the PayPal email used for payouts.


### PR DESCRIPTION
## Summary
- Add bilingual `/affiliate-program/` landing pages with hero, benefits, how-it-works, guidelines, FAQ, and CTA.
- Improve discoverability with nav/footer links, blog and docs cross-links, markdown alternates, `llms.txt`, and agent-discovery updates.
- Clarify program copy so commissions and referral discounts apply to hosted LobbyStack plan payments only.

## Test plan
- [ ] Open `/affiliate-program/` and `/fr/affiliate-program/` and confirm layout, copy, and CTA link to `app.lobbystack.com/affiliate`
- [ ] Verify FAQ answers state hosted-only commission rules clearly
- [ ] Confirm affiliate links appear in navbar Resources and footer Resources
- [ ] Check blog posts and Mintlify docs link to the landing page
- [ ] Confirm `/affiliate-program.md` and `/fr/affiliate-program.md` return markdown summaries
- [ ] Run `pnpm --filter landing build` and confirm pages are in sitemap output