### PR TITLE
Restore onboarding, billing, and upgrade-flow fixes

### DIFF
--- a/apps/web/src/components/layout/authenticated-layout.tsx
+++ b/apps/web/src/components/layout/authenticated-layout.tsx
@@ -34,6 +34,7 @@ import {
   UpgradePlanDialog,
   type HostedUpgradePlan,
 } from "@/features/settings/UpgradePlanDialog";
+import { UpgradePlanDialogProvider } from "@/features/settings/UpgradePlanDialogContext";
 
 type AuthenticatedLayoutProps = {
   billingStatus?: BillingStatus;
@@ -248,53 +249,55 @@ export function AuthenticatedLayout({
           t={t}
         />
       ) : null}
-      <SidebarInset
-        ref={contentScrollRef}
-        className={cn(
-          "@container/content min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain",
-          "has-data-[layout=fixed]:h-full",
-          "peer-data-[variant=inset]:has-data-[layout=fixed]:h-[calc(100%-(var(--spacing)*4))]",
-        )}
-      >
-        <SiteHeader fixed scrollContainerRef={contentScrollRef} />
-        <div className="hidden h-16 shrink-0 border-b md:block" />
-        {!isLoading ? (
-          <div className="pointer-events-none absolute top-4 inset-x-0 z-40 hidden md:block">
-            <div className="mx-auto flex w-full max-w-7xl items-center justify-end gap-0.5 px-6">
-              <TestCallWidget
-                className="pointer-events-auto"
-                {...(businessId ? { businessId } : {})}
-                {...(businessSlug ? { businessSlug } : {})}
-              />
-              <span
-                aria-hidden="true"
-                className="ml-3 mr-1.5 h-4 w-px bg-border"
-              />
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      aria-label={t("nav:items.affiliate")}
-                      className="pointer-events-auto text-sidebar-foreground hover:bg-transparent hover:text-sidebar-accent-foreground"
-                      render={<Link to="/affiliate" />}
-                      size="icon-xs"
-                      variant="ghost"
-                    />
-                  }
-                >
-                  <GiftIcon className="size-[18px] -translate-x-px" strokeWidth={1.75} />
-                </TooltipTrigger>
-                <TooltipContent>{t("nav:items.affiliate")}</TooltipContent>
-              </Tooltip>
-              <FeedbackWidget
-                className="pointer-events-auto"
-                {...(businessId ? { businessId } : {})}
-              />
+      <UpgradePlanDialogProvider onOpen={() => setUpgradeDialogOpen(true)}>
+        <SidebarInset
+          ref={contentScrollRef}
+          className={cn(
+            "@container/content min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain",
+            "has-data-[layout=fixed]:h-full",
+            "peer-data-[variant=inset]:has-data-[layout=fixed]:h-[calc(100%-(var(--spacing)*4))]",
+          )}
+        >
+          <SiteHeader fixed scrollContainerRef={contentScrollRef} />
+          <div className="hidden h-16 shrink-0 border-b md:block" />
+          {!isLoading ? (
+            <div className="pointer-events-none absolute top-4 inset-x-0 z-40 hidden md:block">
+              <div className="mx-auto flex w-full max-w-7xl items-center justify-end gap-0.5 px-6">
+                <TestCallWidget
+                  className="pointer-events-auto"
+                  {...(businessId ? { businessId } : {})}
+                  {...(businessSlug ? { businessSlug } : {})}
+                />
+                <span
+                  aria-hidden="true"
+                  className="ml-3 mr-1.5 h-4 w-px bg-border"
+                />
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        aria-label={t("nav:items.affiliate")}
+                        className="pointer-events-auto text-sidebar-foreground hover:bg-transparent hover:text-sidebar-accent-foreground"
+                        render={<Link to="/affiliate" />}
+                        size="icon-xs"
+                        variant="ghost"
+                      />
+                    }
+                  >
+                    <GiftIcon className="size-[18px] -translate-x-px" strokeWidth={1.75} />
+                  </TooltipTrigger>
+                  <TooltipContent>{t("nav:items.affiliate")}</TooltipContent>
+                </Tooltip>
+                <FeedbackWidget
+                  className="pointer-events-auto"
+                  {...(businessId ? { businessId } : {})}
+                />
+              </div>
             </div>
-          </div>
-        ) : null}
-        {children}
-      </SidebarInset>
+          ) : null}
+          {children}
+        </SidebarInset>
+      </UpgradePlanDialogProvider>
       </SidebarProvider>
     </div>
   );

--- a/apps/web/src/components/layout/workspace-switcher.test.tsx
+++ b/apps/web/src/components/layout/workspace-switcher.test.tsx
@@ -88,4 +88,22 @@ describe("WorkspaceSwitcher", () => {
     const menuName = await screen.findByRole("menuitem", { name: /Acme Clinic/i });
     expect(menuName.querySelector("span.truncate")?.className).toContain("ph-mask");
   });
+
+  it("left-aligns long active business names across two lines", () => {
+    render(
+      <MemoryRouter>
+        <SidebarProvider>
+          <WorkspaceSwitcher
+            activeBusinessId={"business-1" as never}
+            businessName="Plomberie Urgence Montréal (PUM)"
+          />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+
+    const activeName = screen.getByText("Plomberie Urgence Montréal (PUM)");
+    expect(activeName.className).toContain("w-full");
+    expect(activeName.className).toContain("text-left");
+    expect(activeName.className).toContain("line-clamp-2");
+  });
 });

--- a/apps/web/src/components/layout/workspace-switcher.tsx
+++ b/apps/web/src/components/layout/workspace-switcher.tsx
@@ -101,7 +101,7 @@ export function WorkspaceSwitcher({
               <Building2 />
             </ItemMedia>
             <ItemContent className="min-w-0 gap-0.5">
-              <ItemTitle className="ph-mask font-medium leading-tight">
+              <ItemTitle className="ph-mask line-clamp-2 w-full text-left font-medium leading-tight">
                 {displayName}
               </ItemTitle>
               {phoneDisplay ? (

--- a/apps/web/src/features/onboarding/OnboardingPlanPage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingPlanPage.tsx
@@ -609,7 +609,7 @@ export function OnboardingPlanPage({
           </div>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-4">
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
           {tierConfigs.map((tier) => {
             const isSubmitting = submittingPlan === tier.slug;
             const isUnavailable = !isPlanAvailable(tier.slug);

--- a/apps/web/src/features/onboarding/OnboardingWebsitePage.test.tsx
+++ b/apps/web/src/features/onboarding/OnboardingWebsitePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -56,6 +56,39 @@ describe("OnboardingWebsitePage", () => {
       businessId: "business-1",
       websiteUrl: "example.com",
     });
+  });
+
+  it("waits for the onboarding stage subscription before navigating", async () => {
+    submitOnboardingWebsiteMock.mockResolvedValue({
+      status: "submitted",
+      websiteUrl: "https://example.com",
+      websiteIngestionJobId: "job_123",
+    });
+
+    const props = {
+      businessId: "business-1" as never,
+      onSignOut: () => {},
+      progressNavigableUntil: 3,
+      websiteUrl: "https://example.com",
+    };
+    const { rerender } = render(<OnboardingWebsitePage {...props} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "website.continue" }));
+    await waitFor(() => expect(submitOnboardingWebsiteMock).toHaveBeenCalledTimes(1));
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(
+      (screen.getByRole("button", {
+        name: "website.submitting",
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    rerender(<OnboardingWebsitePage {...props} progressNavigableUntil={4} />);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/onboarding/knowledge"),
+    );
   });
 
   it("prefills an existing website URL when revisiting the step", () => {

--- a/apps/web/src/features/onboarding/OnboardingWebsitePage.tsx
+++ b/apps/web/src/features/onboarding/OnboardingWebsitePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -44,9 +44,20 @@ export function OnboardingWebsitePage({
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSkipping, setIsSkipping] = useState(false);
+  const [isAwaitingStageSync, setIsAwaitingStageSync] = useState(false);
 
   const isWorking = isSubmitting || isSkipping;
   const trimmed = websiteUrl.trim();
+
+  useEffect(() => {
+    if (
+      !isAwaitingStageSync ||
+      (progressNavigableUntil !== undefined && progressNavigableUntil < 4)
+    ) {
+      return;
+    }
+    navigate("/onboarding/knowledge");
+  }, [isAwaitingStageSync, navigate, progressNavigableUntil]);
 
   async function handleSubmit(): Promise<void> {
     if (!trimmed || isWorking) {
@@ -60,12 +71,11 @@ export function OnboardingWebsitePage({
       captureAnalyticsEvent("web.onboarding.website_submitted", {
         businessId: String(businessId),
       });
-      navigate("/onboarding/knowledge");
+      setIsAwaitingStageSync(true);
     } catch (submissionError) {
       setError(
         getSafeOnboardingErrorMessage(submissionError, t, "website.submitFailed"),
       );
-    } finally {
       setIsSubmitting(false);
     }
   }
@@ -82,10 +92,9 @@ export function OnboardingWebsitePage({
       captureAnalyticsEvent("web.onboarding.website_skipped", {
         businessId: String(businessId),
       });
-      navigate("/onboarding/knowledge");
+      setIsAwaitingStageSync(true);
     } catch (skipError) {
       setError(getSafeOnboardingErrorMessage(skipError, t, "website.skipFailed"));
-    } finally {
       setIsSkipping(false);
     }
   }

--- a/apps/web/src/features/onboarding/components/OnboardingShell.tsx
+++ b/apps/web/src/features/onboarding/components/OnboardingShell.tsx
@@ -33,7 +33,7 @@ const widthMap: Record<NonNullable<OnboardingShellProps["width"]>, string> = {
   md: "max-w-md",
   lg: "max-w-lg",
   xl: "max-w-xl",
-  wide: "max-w-5xl",
+  wide: "max-w-7xl",
 };
 
 const onboardingStepRoutes: Record<number, string> = {

--- a/apps/web/src/features/settings/SettingsPhoneNumberPage.test.tsx
+++ b/apps/web/src/features/settings/SettingsPhoneNumberPage.test.tsx
@@ -8,11 +8,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import type { BillingStatus } from "../../../../../packages/shared/src/billing";
 import { SettingsPhoneNumberPage } from "./SettingsPhoneNumberPage";
+import { UpgradePlanDialogProvider } from "./UpgradePlanDialogContext";
 
 const {
   claimReplacementNumberMock,
   getInitialReplacementNumberSuggestionMock,
   navigateMock,
+  openUpgradePlanDialogMock,
   searchReplacementNumbersMock,
   toastSuccessMock,
   useObservedActionMock,
@@ -21,6 +23,7 @@ const {
   claimReplacementNumberMock: vi.fn(),
   getInitialReplacementNumberSuggestionMock: vi.fn(),
   navigateMock: vi.fn(),
+  openUpgradePlanDialogMock: vi.fn(),
   searchReplacementNumbersMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   useObservedActionMock: vi.fn(),
@@ -198,12 +201,14 @@ function renderPage(
   props: Partial<React.ComponentProps<typeof SettingsPhoneNumberPage>> = {},
 ) {
   return render(
-    <SettingsPhoneNumberPage
-      billingStatus={paidBillingStatus}
-      businessId={businessId}
-      canManageTenant={canManageTenant}
-      {...props}
-    />,
+    <UpgradePlanDialogProvider onOpen={openUpgradePlanDialogMock}>
+      <SettingsPhoneNumberPage
+        billingStatus={paidBillingStatus}
+        businessId={businessId}
+        canManageTenant={canManageTenant}
+        {...props}
+      />
+    </UpgradePlanDialogProvider>,
   );
 }
 
@@ -212,6 +217,7 @@ describe("SettingsPhoneNumberPage", () => {
     claimReplacementNumberMock.mockReset();
     getInitialReplacementNumberSuggestionMock.mockReset();
     navigateMock.mockReset();
+    openUpgradePlanDialogMock.mockReset();
     searchReplacementNumbersMock.mockReset();
     toastSuccessMock.mockReset();
     useObservedActionMock.mockReset();
@@ -442,5 +448,21 @@ describe("SettingsPhoneNumberPage", () => {
     expect(screen.queryByText("You don't have a number yet.")).toBeNull();
     expect(screen.getByRole("button", { name: "View plans" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Get number" })).toBeNull();
+  });
+
+  it("opens the upgrade dialog from View plans", async () => {
+    const user = userEvent.setup();
+    useQueryMock.mockReturnValue(null);
+    renderPage(true, {
+      billingStatus: {
+        includedBusinessNumbers: 0,
+        phoneNumberReclaimScheduledAt: null,
+      } as never,
+    });
+
+    await user.click(screen.getByRole("button", { name: "View plans" }));
+
+    expect(openUpgradePlanDialogMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).not.toHaveBeenCalledWith("/settings/plan");
   });
 });

--- a/apps/web/src/features/settings/SettingsPhoneNumberPage.tsx
+++ b/apps/web/src/features/settings/SettingsPhoneNumberPage.tsx
@@ -33,6 +33,7 @@ import {
   type InitialSuggestionResult,
   type SearchResult,
 } from "@/features/onboarding/components/PhoneNumberChooser";
+import { useOpenUpgradePlanDialog } from "@/features/settings/UpgradePlanDialogContext";
 import { formatPhoneNumberDisplay } from "@/lib/phone";
 import { useObservedAction } from "@/lib/observed-convex";
 
@@ -81,6 +82,7 @@ export function SettingsPhoneNumberPage({
 }: SettingsPhoneNumberPageProps) {
   const { i18n, t } = useTranslation("settings");
   const navigate = useNavigate();
+  const openUpgradePlanDialog = useOpenUpgradePlanDialog();
   const primaryPhoneNumber = useQuery(api.businesses.catalog.getPrimaryPhoneNumber, {
     businessId,
   }) as PrimaryPhoneNumber | null | undefined;
@@ -139,7 +141,7 @@ export function SettingsPhoneNumberPage({
             {canManageTenant ? (
               <Button
                 className="mt-3"
-                onClick={() => navigate("/settings/plan")}
+                onClick={openUpgradePlanDialog}
                 size="sm"
                 variant="outline"
               >
@@ -169,7 +171,7 @@ export function SettingsPhoneNumberPage({
             {canManageTenant ? (
               <ItemActions>
                 {showPaidPlanRequired ? (
-                  <Button onClick={() => navigate("/settings/plan")} size="sm" variant="outline">
+                  <Button onClick={openUpgradePlanDialog} size="sm" variant="outline">
                     {t("phoneNumber.requiresPaidPlan.upgradeCta")}
                   </Button>
                 ) : (

--- a/apps/web/src/features/settings/UpgradePlanDialogContext.tsx
+++ b/apps/web/src/features/settings/UpgradePlanDialogContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+const OpenUpgradePlanDialogContext = createContext<(() => void) | null>(null);
+
+export function UpgradePlanDialogProvider({
+  children,
+  onOpen,
+}: {
+  children: ReactNode;
+  onOpen: () => void;
+}) {
+  return (
+    <OpenUpgradePlanDialogContext.Provider value={onOpen}>
+      {children}
+    </OpenUpgradePlanDialogContext.Provider>
+  );
+}
+
+export function useOpenUpgradePlanDialog(): () => void {
+  const openUpgradePlanDialog = useContext(OpenUpgradePlanDialogContext);
+  if (!openUpgradePlanDialog) {
+    throw new Error("useOpenUpgradePlanDialog must be used within AuthenticatedLayout.");
+  }
+  return openUpgradePlanDialog;
+}

--- a/convex/affiliates.ts
+++ b/convex/affiliates.ts
@@ -913,6 +913,10 @@ export const createCommissionForBillingTransaction = observedInternalMutation({
       return null;
     }
 
+    if (args.occurredAt < attribution.attributedAt) {
+      return null;
+    }
+
     if (args.occurredAt > addMonthsIso(attribution.attributedAt, COMMISSION_MONTHS)) {
       return null;
     }

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -144,6 +144,7 @@ type PolarClient = ReturnType<typeof createPolarClient>;
 type PolarCheckout = Awaited<ReturnType<PolarClient["checkouts"]["get"]>>;
 type PolarCustomer = Awaited<ReturnType<PolarClient["customers"]["create"]>>;
 type PolarMember = Awaited<ReturnType<PolarClient["members"]["createMember"]>>;
+type PolarOrder = Awaited<ReturnType<PolarClient["orders"]["get"]>>;
 type PolarSubscription = Awaited<ReturnType<PolarClient["subscriptions"]["get"]>>;
 
 type PolarBillingSubscription = {
@@ -1954,22 +1955,54 @@ async function syncOrderTransactionFromWebhookEvent(
     }
   >,
 ): Promise<void> {
-  const businessId =
-    parseBusinessIdFromBillingKey(event.data.customer.externalId ?? null) ??
-    (typeof event.data.metadata.businessId === "string"
-      ? (event.data.metadata.businessId as Id<"businesses">)
-      : null);
+  const businessId = await syncPolarOrderTransaction(ctx, {
+    order: event.data,
+    lastSyncedAt: event.timestamp.toISOString(),
+  });
   if (!businessId) {
+    console.warn(
+      `[billing] Skipped Polar order ${event.data.id}: customer ${event.data.customerId} is not linked to a business.`,
+    );
     return;
   }
+
   const isAiSmsSetupOrder = shouldRecordAiSmsOrderAsSetupFee({
     orderProductIds: event.data.productId ? [event.data.productId] : [],
   });
+  if (event.type === "order.paid" && isAiSmsSetupOrder) {
+    await updateProSubscriptionForAiSmsSetupPayment(ctx, {
+      businessId,
+    });
+  }
+}
 
+async function syncPolarOrderTransaction(
+  ctx: Pick<ActionCtx, "runMutation">,
+  input: {
+    order: PolarOrder;
+    lastSyncedAt: string;
+  },
+): Promise<Id<"businesses"> | null> {
+  const order = input.order;
+  let businessId =
+    parseBusinessIdFromBillingKey(order.customer.externalId ?? null) ??
+    (typeof order.metadata.businessId === "string"
+      ? (order.metadata.businessId as Id<"businesses">)
+      : null);
+  businessId ??= await ctx.runMutation(internal.billing.findBusinessIdForCustomerMutation, {
+    polarCustomerId: order.customerId,
+  });
+  if (!businessId) {
+    return null;
+  }
+
+  const isAiSmsSetupOrder = shouldRecordAiSmsOrderAsSetupFee({
+    orderProductIds: order.productId ? [order.productId] : [],
+  });
   let invoiceUrl: string | undefined;
-  if (event.data.isInvoiceGenerated) {
+  if (order.isInvoiceGenerated) {
     try {
-      const invoice = await createPolarClient().orders.invoice({ id: event.data.id });
+      const invoice = await createPolarClient().orders.invoice({ id: order.id });
       invoiceUrl = invoice.url;
     } catch {
       invoiceUrl = undefined;
@@ -1979,26 +2012,60 @@ async function syncOrderTransactionFromWebhookEvent(
   await ctx.runMutation(internal.billing.upsertTransactionFromWebhook, {
     businessId,
     kind: "order",
-    sourceId: event.data.id,
-    status: event.data.status,
-    amountCents: event.data.totalAmount,
-    currency: event.data.currency,
-    description: event.data.description,
+    sourceId: order.id,
+    status: order.status,
+    amountCents: order.totalAmount,
+    currency: order.currency,
+    description: order.description,
     ...(invoiceUrl ? { invoiceUrl } : {}),
-    ...(event.data.subscriptionId ? { subscriptionId: event.data.subscriptionId } : {}),
-    ...(event.data.customerId ? { polarCustomerId: event.data.customerId } : {}),
-    orderId: event.data.id,
-    ...(isAiSmsSetupOrder ? { aiSmsSetupOrderId: event.data.id } : {}),
-    occurredAt: event.data.createdAt.toISOString(),
-    lastSyncedAt: event.timestamp.toISOString(),
+    ...(order.subscriptionId ? { subscriptionId: order.subscriptionId } : {}),
+    polarCustomerId: order.customerId,
+    orderId: order.id,
+    ...(isAiSmsSetupOrder ? { aiSmsSetupOrderId: order.id } : {}),
+    occurredAt: order.createdAt.toISOString(),
+    lastSyncedAt: input.lastSyncedAt,
   });
 
-  if (event.type === "order.paid" && isAiSmsSetupOrder) {
-    await updateProSubscriptionForAiSmsSetupPayment(ctx, {
-      businessId,
-    });
-  }
+  return businessId;
 }
+
+export const reconcilePolarOrder = internalAction({
+  args: {
+    orderId: v.string(),
+  },
+  returns: v.object({
+    businessId: v.id("businesses"),
+    orderId: v.string(),
+    status: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const order = await createPolarClient().orders.get({ id: args.orderId });
+    const businessId = await syncPolarOrderTransaction(ctx, {
+      order,
+      lastSyncedAt: new Date().toISOString(),
+    });
+    if (!businessId) {
+      throw new Error(
+        `Polar customer ${order.customerId} is not linked to a LobbyStack billing account.`,
+      );
+    }
+
+    const isAiSmsSetupOrder = shouldRecordAiSmsOrderAsSetupFee({
+      orderProductIds: order.productId ? [order.productId] : [],
+    });
+    if (order.status === "paid" && isAiSmsSetupOrder) {
+      await updateProSubscriptionForAiSmsSetupPayment(ctx, {
+        businessId,
+      });
+    }
+
+    return {
+      businessId,
+      orderId: order.id,
+      status: order.status,
+    };
+  },
+});
 
 async function syncRefundTransactionFromWebhookEvent(
   ctx: Pick<MutationCtx, "runMutation">,

--- a/convex/billing.ts
+++ b/convex/billing.ts
@@ -2050,15 +2050,6 @@ export const reconcilePolarOrder = internalAction({
       );
     }
 
-    const isAiSmsSetupOrder = shouldRecordAiSmsOrderAsSetupFee({
-      orderProductIds: order.productId ? [order.productId] : [],
-    });
-    if (order.status === "paid" && isAiSmsSetupOrder) {
-      await updateProSubscriptionForAiSmsSetupPayment(ctx, {
-        businessId,
-      });
-    }
-
     return {
       businessId,
       orderId: order.id,

--- a/convex/onboarding/websites.ts
+++ b/convex/onboarding/websites.ts
@@ -80,6 +80,32 @@ export const submitOnboardingWebsiteAfterPreflight = internalMutation({
   ): Promise<SubmitOnboardingWebsiteResult> => {
     await requireBusinessAtOrPastWebsiteStage(ctx, args.businessId);
 
+    const completedJob = (
+      await ctx.db
+        .query("website_ingestion_jobs")
+        .withIndex("by_business_id_and_website_url", (q) =>
+          q.eq("businessId", args.businessId).eq("websiteUrl", args.websiteUrl),
+        )
+        .order("desc")
+        .collect()
+    ).find((job) => job.status === "completed");
+
+    if (completedJob) {
+      const business = await ctx.db.get(args.businessId);
+      const stage = normalizeOnboardingStage(business?.onboardingStage);
+      await ctx.db.patch(args.businessId, {
+        websiteUrl: args.websiteUrl,
+        ...(ONBOARDING_STAGE_INDEX[stage] < ONBOARDING_STAGE_INDEX.knowledge
+          ? { onboardingStage: "knowledge" as const }
+          : {}),
+      });
+      return {
+        status: "submitted",
+        websiteUrl: args.websiteUrl,
+        websiteIngestionJobId: completedJob._id,
+      };
+    }
+
     return await ctx.runMutation(
       internal.ai.context.websiteIngestion.submitWebsiteIngestionAfterPreflight,
       {

--- a/convex/onboarding/websites.ts
+++ b/convex/onboarding/websites.ts
@@ -78,6 +78,7 @@ export const submitOnboardingWebsiteAfterPreflight = internalMutation({
     ctx,
     args,
   ): Promise<SubmitOnboardingWebsiteResult> => {
+    await requireTenantAdminMembership(ctx, args.businessId);
     await requireBusinessAtOrPastWebsiteStage(ctx, args.businessId);
 
     const completedJob = (

--- a/convex/onboarding/websites.ts
+++ b/convex/onboarding/websites.ts
@@ -4,7 +4,7 @@ import { observedInternalMutation as internalMutation, observedMutation as mutat
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { type ActionCtx, type MutationCtx } from "../_generated/server";
 import { requireTenantAdminMembership } from "../lib/auth";
 import { ONBOARDING_STAGE_INDEX, normalizeOnboardingStage } from "../lib/onboardingStage";
@@ -19,6 +19,54 @@ type SubmitOnboardingWebsiteResult = {
   websiteUrl: string;
   websiteIngestionJobId: Id<"website_ingestion_jobs">;
 };
+
+const MAX_REUSABLE_WEBSITE_JOBS_TO_CHECK = 10;
+const MAX_REUSABLE_WEBSITE_DOCUMENTS_TO_CHECK = 100;
+
+function isUsableWebsiteKnowledgeDocument(
+  document: Doc<"knowledge_documents">,
+): boolean {
+  return (
+    document.active !== false &&
+    document.status === "indexed" &&
+    Boolean(document.textContent?.trim())
+  );
+}
+
+async function findReusableCompletedWebsiteIngestionJob(
+  ctx: MutationCtx,
+  args: {
+    businessId: Id<"businesses">;
+    websiteUrl: string;
+  },
+): Promise<Doc<"website_ingestion_jobs"> | null> {
+  const recentJobs = await ctx.db
+    .query("website_ingestion_jobs")
+    .withIndex("by_business_id_and_website_url", (q) =>
+      q.eq("businessId", args.businessId).eq("websiteUrl", args.websiteUrl),
+    )
+    .order("desc")
+    .take(MAX_REUSABLE_WEBSITE_JOBS_TO_CHECK);
+
+  for (const job of recentJobs) {
+    if (job.status !== "completed") {
+      continue;
+    }
+
+    const documents = await ctx.db
+      .query("knowledge_documents")
+      .withIndex("by_website_ingestion_job_id", (q) =>
+        q.eq("websiteIngestionJobId", job._id),
+      )
+      .take(MAX_REUSABLE_WEBSITE_DOCUMENTS_TO_CHECK);
+
+    if (documents.some(isUsableWebsiteKnowledgeDocument)) {
+      return job;
+    }
+  }
+
+  return null;
+}
 
 async function requireBusinessAtOrPastWebsiteStage(
   ctx: MutationCtx,
@@ -81,15 +129,10 @@ export const submitOnboardingWebsiteAfterPreflight = internalMutation({
     await requireTenantAdminMembership(ctx, args.businessId);
     await requireBusinessAtOrPastWebsiteStage(ctx, args.businessId);
 
-    const completedJob = (
-      await ctx.db
-        .query("website_ingestion_jobs")
-        .withIndex("by_business_id_and_website_url", (q) =>
-          q.eq("businessId", args.businessId).eq("websiteUrl", args.websiteUrl),
-        )
-        .order("desc")
-        .collect()
-    ).find((job) => job.status === "completed");
+    const completedJob = await findReusableCompletedWebsiteIngestionJob(ctx, {
+      businessId: args.businessId,
+      websiteUrl: args.websiteUrl,
+    });
 
     if (completedJob) {
       const business = await ctx.db.get(args.businessId);

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -4775,6 +4775,96 @@ describe("billing", () => {
     });
   });
 
+  it("repairs a paid order from before affiliate attribution without creating a commission", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId, userId } = await seedWorkspace(t, {
+      subject: "billing-pre-attribution-order-reconciliation",
+      deploymentMode: "cloud",
+    });
+    const polarCustomerId = "cus_pre_attribution_reconciliation";
+
+    process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";
+
+    const affiliateProfileId = await t.run(async (ctx: TestContext) => {
+      const affiliateUserId = await ctx.db.insert("users", {
+        authSubject: "pre-attribution-affiliate",
+        email: "pre-attribution-affiliate@example.com",
+      });
+      const profileId = await ctx.db.insert("affiliate_profiles", {
+        userId: affiliateUserId,
+        referralCode: "pre-attribution-affiliate",
+        status: "active",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+      });
+      await ctx.db.insert("affiliate_attributions", {
+        affiliateProfileId: profileId,
+        businessId,
+        referredUserId: userId,
+        referralCode: "pre-attribution-affiliate",
+        source: "via",
+        attributedAt: "2026-04-01T00:00:00.000Z",
+      });
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+        polarCustomerId,
+      });
+      return profileId;
+    });
+
+    const historicalOrder = {
+      id: "ord_before_affiliate_attribution",
+      createdAt: new Date("2026-03-15T12:00:00.000Z"),
+      status: "paid",
+      totalAmount: 5000,
+      currency: "usd",
+      description: "LobbyStack Pro Monthly",
+      isInvoiceGenerated: false,
+      customerId: polarCustomerId,
+      productId: "prod_pro_monthly",
+      subscriptionId: "sub_pro",
+      metadata: {},
+      customer: { externalId: null },
+    };
+    polarOrdersGetMock.mockResolvedValueOnce(historicalOrder);
+
+    await t.action(internal.billing.reconcilePolarOrder, {
+      orderId: historicalOrder.id,
+    });
+
+    const state = await t.run(async (ctx: TestContext) => {
+      const transaction = await ctx.db
+        .query("billing_transactions")
+        .withIndex("by_kind_and_source_id", (q) =>
+          q.eq("kind", "order").eq("sourceId", historicalOrder.id),
+        )
+        .unique();
+      const commission = await ctx.db
+        .query("affiliate_commissions")
+        .withIndex("by_source_key", (q) =>
+          q.eq("sourceKey", `order:${historicalOrder.id}`),
+        )
+        .unique();
+      const stats = await ctx.db
+        .query("affiliate_profile_stats")
+        .withIndex("by_affiliate_profile_id", (q) =>
+          q.eq("affiliateProfileId", affiliateProfileId),
+        )
+        .unique();
+      return { transaction, commission, stats };
+    });
+
+    expect(state.transaction).toMatchObject({
+      businessId,
+      sourceId: historicalOrder.id,
+      status: "paid",
+      occurredAt: historicalOrder.createdAt.toISOString(),
+    });
+    expect(state.commission).toBeNull();
+    expect(state.stats).toBeNull();
+  });
+
   it("rejects reconciliation when the Polar customer is not linked to a business", async () => {
     const t = convexTest(schema, convexModules);
     process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -4703,6 +4703,78 @@ describe("billing", () => {
     expect(polarOrdersGetMock).toHaveBeenCalledTimes(3);
   });
 
+  it("repairs a historical paid AI SMS setup order without replaying the purchase", async () => {
+    const t = convexTest(schema, convexModules);
+    const { businessId } = await seedWorkspace(t, {
+      subject: "billing-ai-sms-order-reconciliation",
+      deploymentMode: "cloud",
+    });
+    const polarCustomerId = "cus_ai_sms_order_reconciliation";
+
+    process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";
+    process.env.POLAR_AI_SMS_SETUP_PRODUCT_ID = "prod_ai_sms_setup";
+    process.env.POLAR_PRO_MONTHLY_AI_SMS_PRODUCT_ID = "prod_pro_monthly_ai_sms";
+
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "pro",
+        activeAddons: [],
+        billingInterval: "monthly",
+        polarCustomerId,
+        proSubscriptionId: "sub_pro",
+        proSubscriptionProductId: "prod_pro_monthly",
+      });
+    });
+
+    const historicalOrder = {
+      id: "ord_historical_ai_sms_setup",
+      createdAt: new Date("2026-03-12T02:24:40.765Z"),
+      status: "paid",
+      totalAmount: 9900,
+      currency: "usd",
+      description: "LobbyStack AI SMS setup",
+      isInvoiceGenerated: false,
+      customerId: polarCustomerId,
+      productId: "prod_ai_sms_setup",
+      subscriptionId: null,
+      metadata: {},
+      customer: { externalId: null },
+    };
+    polarOrdersGetMock.mockResolvedValueOnce(historicalOrder);
+
+    await t.action(internal.billing.reconcilePolarOrder, {
+      orderId: historicalOrder.id,
+    });
+
+    expect(polarSubscriptionsUpdateMock).not.toHaveBeenCalled();
+
+    const state = await t.run(async (ctx: TestContext) => {
+      const account = await ctx.db
+        .query("billing_accounts")
+        .withIndex("by_business_id", (q) => q.eq("businessId", businessId))
+        .unique();
+      const transaction = await ctx.db
+        .query("billing_transactions")
+        .withIndex("by_kind_and_source_id", (q) =>
+          q.eq("kind", "order").eq("sourceId", historicalOrder.id),
+        )
+        .unique();
+      return { account, transaction };
+    });
+
+    expect(state.account?.activeAddons).toEqual([]);
+    expect(state.account?.proSubscriptionProductId).toBe("prod_pro_monthly");
+    expect(state.account?.aiSmsSetupOrderId).toBe(historicalOrder.id);
+    expect(state.transaction).toMatchObject({
+      businessId,
+      kind: "order",
+      sourceId: historicalOrder.id,
+      status: "paid",
+      amountCents: 9900,
+    });
+  });
+
   it("rejects reconciliation when the Polar customer is not linked to a business", async () => {
     const t = convexTest(schema, convexModules);
     process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";

--- a/convex/tests/billing.test.ts
+++ b/convex/tests/billing.test.ts
@@ -14,6 +14,8 @@ const {
   polarMembersCreateMock,
   polarMembersListMock,
   polarMembersUpdateMock,
+  polarOrdersGetMock,
+  polarOrdersInvoiceMock,
   polarSubscriptionsGetMock,
   polarSubscriptionsListMock,
   polarSubscriptionsUpdateMock,
@@ -29,6 +31,8 @@ const {
   polarMembersCreateMock: vi.fn(),
   polarMembersListMock: vi.fn(),
   polarMembersUpdateMock: vi.fn(),
+  polarOrdersGetMock: vi.fn(),
+  polarOrdersInvoiceMock: vi.fn(),
   polarSubscriptionsGetMock: vi.fn(),
   polarSubscriptionsListMock: vi.fn(),
   polarSubscriptionsUpdateMock: vi.fn(),
@@ -71,7 +75,8 @@ vi.mock("@polar-sh/sdk", () => ({
         updateMember: polarMembersUpdateMock,
       },
       orders: {
-        invoice: vi.fn(),
+        get: polarOrdersGetMock,
+        invoice: polarOrdersInvoiceMock,
       },
       subscriptions: {
         get: polarSubscriptionsGetMock,
@@ -4628,6 +4633,104 @@ describe("billing", () => {
     );
     expect(polarMembersCreateMock).not.toHaveBeenCalled();
     expect(polarCustomerSessionsCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("reconciles missing Polar orders through the persisted customer link without duplicates", async () => {
+    const t = convexTest(schema, convexModules);
+    const { authed, businessId } = await seedWorkspace(t, {
+      subject: "billing-order-reconciliation",
+      deploymentMode: "cloud",
+    });
+    const polarCustomerId = "cus_order_reconciliation";
+
+    process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";
+    await t.run(async (ctx: TestContext) => {
+      await seedBillingAccount(ctx, {
+        businessId,
+        currentPlan: "starter",
+        polarCustomerId,
+      });
+    });
+
+    const juneOrder = {
+      id: "ord_june_paid",
+      createdAt: new Date("2026-06-12T02:24:40.765Z"),
+      status: "paid",
+      totalAmount: 3000,
+      currency: "usd",
+      description: "LobbyStack Starter Monthly",
+      isInvoiceGenerated: false,
+      customerId: polarCustomerId,
+      productId: "prod_starter_monthly",
+      subscriptionId: "sub_starter",
+      metadata: {},
+      customer: { externalId: null },
+    };
+    polarOrdersGetMock.mockResolvedValue(juneOrder);
+
+    await t.action(internal.billing.reconcilePolarOrder, { orderId: juneOrder.id });
+    await t.action(internal.billing.reconcilePolarOrder, { orderId: juneOrder.id });
+
+    const julyOrder = {
+      ...juneOrder,
+      id: "ord_july_pending",
+      createdAt: new Date("2026-07-12T02:24:40.935Z"),
+      status: "pending",
+    };
+    polarOrdersGetMock.mockResolvedValueOnce(julyOrder);
+    await t.action(internal.billing.reconcilePolarOrder, { orderId: julyOrder.id });
+
+    const status = await authed.query(api.billing.getStatus, { businessId });
+    expect(status.recentTransactions).toMatchObject([
+      {
+        sourceId: julyOrder.id,
+        status: "pending",
+        amountCents: 3000,
+        occurredAt: julyOrder.createdAt.toISOString(),
+      },
+      {
+        sourceId: juneOrder.id,
+        status: "paid",
+        amountCents: 3000,
+        occurredAt: juneOrder.createdAt.toISOString(),
+      },
+    ]);
+
+    const transactions = await t.run(async (ctx: TestContext) =>
+      ctx.db.query("billing_transactions").collect(),
+    );
+    expect(transactions).toHaveLength(2);
+    expect(polarOrdersGetMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects reconciliation when the Polar customer is not linked to a business", async () => {
+    const t = convexTest(schema, convexModules);
+    process.env.POLAR_ORGANIZATION_TOKEN = "polar-test-token";
+    polarOrdersGetMock.mockResolvedValueOnce({
+      id: "ord_unlinked",
+      createdAt: new Date("2026-06-12T02:24:40.765Z"),
+      status: "paid",
+      totalAmount: 3000,
+      currency: "usd",
+      description: "LobbyStack Starter Monthly",
+      isInvoiceGenerated: false,
+      customerId: "cus_unlinked",
+      productId: "prod_starter_monthly",
+      subscriptionId: "sub_unlinked",
+      metadata: {},
+      customer: { externalId: null },
+    });
+
+    await expect(
+      t.action(internal.billing.reconcilePolarOrder, { orderId: "ord_unlinked" }),
+    ).rejects.toThrow(
+      "Polar customer cus_unlinked is not linked to a LobbyStack billing account.",
+    );
+
+    const transactions = await t.run(async (ctx: TestContext) =>
+      ctx.db.query("billing_transactions").collect(),
+    );
+    expect(transactions).toEqual([]);
   });
 
   it("requires admin access for billing checkout and portal actions", async () => {

--- a/convex/tests/onboardingWebsiteIngestion.test.ts
+++ b/convex/tests/onboardingWebsiteIngestion.test.ts
@@ -244,6 +244,62 @@ describe("website onboarding and ingestion", () => {
     expect(jobs[0]?._id).toBe(completedJobId);
   });
 
+  it("rejects a completed-job shortcut after the tenant admin loses access", async () => {
+    const t = createConvexHarness();
+    const subject = "website-onboarding-revoked-owner";
+    const { businessId, userId } = await seedBusinessOwner({
+      t,
+      onboardingStage: "website",
+      subject,
+    });
+    const authed = t.withIdentity({ subject });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("website_ingestion_jobs", {
+        businessId,
+        websiteUrl: "https://example.com/clinic",
+        provider: "firecrawl",
+        status: "completed",
+        workflowId: "workflow-completed",
+        crawlMode: "firecrawl",
+        fallbackTriggered: false,
+        pageLimit: 40,
+        depth: 3,
+        importedCount: 3,
+        indexedCount: 3,
+        errorCount: 0,
+        completedAt: new Date().toISOString(),
+      });
+      const membership = await ctx.db
+        .query("business_memberships")
+        .withIndex("by_user_id_and_business_id", (q) =>
+          q.eq("userId", userId).eq("businessId", businessId),
+        )
+        .unique();
+      if (!membership) {
+        throw new Error("Expected seeded business membership.");
+      }
+      await ctx.db.patch(membership._id, { status: "revoked" });
+    });
+
+    await expect(
+      authed.mutation(
+        internal.onboarding.websites.submitOnboardingWebsiteAfterPreflight,
+        {
+          businessId,
+          websiteUrl: "https://example.com/clinic",
+        },
+      ),
+    ).rejects.toThrow("You do not have access to this business.");
+
+    const business = await t.query(internal.businesses.admin.getBusinessById, {
+      businessId,
+    });
+    expect(business?.websiteUrl).toBeUndefined();
+    expect(business?.onboardingStage).toBe("website");
+    expect(workflowStartMock).not.toHaveBeenCalled();
+  });
+
   it("starts a website ingestion job from the knowledge dashboard without changing onboarding", async () => {
     const t = createConvexHarness();
     const subject = "website-dashboard-owner";

--- a/convex/tests/onboardingWebsiteIngestion.test.ts
+++ b/convex/tests/onboardingWebsiteIngestion.test.ts
@@ -193,6 +193,57 @@ describe("website onboarding and ingestion", () => {
     });
   });
 
+  it("reuses a completed same-url import during onboarding", async () => {
+    const t = createConvexHarness();
+    const subject = "website-onboarding-completed-job-owner";
+    const { businessId } = await seedBusinessOwner({
+      t,
+      onboardingStage: "website",
+      subject,
+    });
+    const authed = t.withIdentity({ subject });
+
+    const completedJobId = await t.run(async (ctx) => {
+      return await ctx.db.insert("website_ingestion_jobs", {
+        businessId,
+        websiteUrl: "https://example.com/clinic",
+        provider: "firecrawl",
+        status: "completed",
+        workflowId: "workflow-completed",
+        crawlMode: "firecrawl",
+        fallbackTriggered: false,
+        pageLimit: 40,
+        depth: 3,
+        importedCount: 3,
+        indexedCount: 3,
+        errorCount: 0,
+        completedAt: new Date().toISOString(),
+      });
+    });
+
+    const result = await authed.action(api.onboarding.websites.submitOnboardingWebsite, {
+      businessId,
+      websiteUrl: "example.com/clinic/?utm_source=claim#team",
+    });
+
+    expect(result).toMatchObject({
+      status: "submitted",
+      websiteUrl: "https://example.com/clinic",
+      websiteIngestionJobId: completedJobId,
+    });
+    expect(workflowStartMock).not.toHaveBeenCalled();
+
+    const business = await t.query(internal.businesses.admin.getBusinessById, {
+      businessId,
+    });
+    expect(business?.websiteUrl).toBe("https://example.com/clinic");
+    expect(business?.onboardingStage).toBe("knowledge");
+
+    const jobs = await listWebsiteIngestionJobs(t, businessId);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?._id).toBe(completedJobId);
+  });
+
   it("starts a website ingestion job from the knowledge dashboard without changing onboarding", async () => {
     const t = createConvexHarness();
     const subject = "website-dashboard-owner";

--- a/convex/tests/onboardingWebsiteIngestion.test.ts
+++ b/convex/tests/onboardingWebsiteIngestion.test.ts
@@ -204,7 +204,7 @@ describe("website onboarding and ingestion", () => {
     const authed = t.withIdentity({ subject });
 
     const completedJobId = await t.run(async (ctx) => {
-      return await ctx.db.insert("website_ingestion_jobs", {
+      const websiteIngestionJobId = await ctx.db.insert("website_ingestion_jobs", {
         businessId,
         websiteUrl: "https://example.com/clinic",
         provider: "firecrawl",
@@ -219,6 +219,19 @@ describe("website onboarding and ingestion", () => {
         errorCount: 0,
         completedAt: new Date().toISOString(),
       });
+      await ctx.db.insert("knowledge_documents", {
+        businessId,
+        active: true,
+        sourceType: "website",
+        title: "Clinic",
+        sourceUrl: "https://example.com/clinic",
+        websiteIngestionJobId,
+        textContent: "Clinic services and opening hours.",
+        status: "indexed",
+        tags: [],
+        importance: 5,
+      });
+      return websiteIngestionJobId;
     });
 
     const result = await authed.action(api.onboarding.websites.submitOnboardingWebsite, {
@@ -242,6 +255,87 @@ describe("website onboarding and ingestion", () => {
     const jobs = await listWebsiteIngestionJobs(t, businessId);
     expect(jobs).toHaveLength(1);
     expect(jobs[0]?._id).toBe(completedJobId);
+  });
+
+  it("starts a fresh import after all documents from a completed job are deleted", async () => {
+    const t = createConvexHarness();
+    const subject = "website-onboarding-deleted-documents-owner";
+    const { businessId } = await seedBusinessOwner({
+      t,
+      onboardingStage: "website",
+      subject,
+    });
+    const authed = t.withIdentity({ subject });
+
+    const { completedJobId, documentId } = await t.run(async (ctx) => {
+      await ctx.db.insert("receptionist_profiles", {
+        businessId,
+        greeting: "Hello",
+        tone: "professional",
+        summary: "Helpful receptionist",
+        bookingPolicy: "Book available appointments.",
+        transferMode: "disabled",
+      });
+      const websiteIngestionJobId = await ctx.db.insert("website_ingestion_jobs", {
+        businessId,
+        websiteUrl: "https://example.com/clinic",
+        provider: "firecrawl",
+        status: "completed",
+        workflowId: "workflow-completed",
+        crawlMode: "firecrawl",
+        fallbackTriggered: false,
+        pageLimit: 40,
+        depth: 3,
+        importedCount: 1,
+        indexedCount: 1,
+        errorCount: 0,
+        completedAt: new Date().toISOString(),
+      });
+      const knowledgeDocumentId = await ctx.db.insert("knowledge_documents", {
+        businessId,
+        active: true,
+        sourceType: "website",
+        title: "Clinic",
+        sourceUrl: "https://example.com/clinic",
+        websiteIngestionJobId,
+        textContent: "Clinic services and opening hours.",
+        status: "indexed",
+        tags: [],
+        importance: 5,
+      });
+      return {
+        completedJobId: websiteIngestionJobId,
+        documentId: knowledgeDocumentId,
+      };
+    });
+
+    await authed.action(api.ai.context.knowledge.deleteKnowledgeEntry, {
+      businessId,
+      documentId,
+    });
+
+    const result = await authed.action(api.onboarding.websites.submitOnboardingWebsite, {
+      businessId,
+      websiteUrl: "example.com/clinic",
+    });
+
+    expect(result.websiteIngestionJobId).not.toBe(completedJobId);
+    expect(workflowStartMock).toHaveBeenCalledTimes(1);
+
+    const state = await t.run(async (ctx) => {
+      return {
+        deletedDocument: await ctx.db.get(documentId),
+        completedJob: await ctx.db.get(completedJobId),
+        newJob: await ctx.db.get(result.websiteIngestionJobId),
+      };
+    });
+    expect(state.deletedDocument).toBeNull();
+    expect(state.completedJob?.status).toBe("completed");
+    expect(state.newJob).toMatchObject({
+      businessId,
+      websiteUrl: "https://example.com/clinic",
+      status: "queued",
+    });
   });
 
   it("rejects a completed-job shortcut after the tenant admin loses access", async () => {

--- a/docs/providers/polar.md
+++ b/docs/providers/polar.md
@@ -183,6 +183,20 @@ Webhook handling expectations:
 - webhook updates are the source of truth for hosted plan, add-on, and transaction state
 - do not introduce separate manual renewal loops or invoice polling to drive subscription state
 
+### Recover a missing order
+
+If Polar contains an order that is absent from `billing_transactions`, reconcile that specific
+order from the authoritative Polar API:
+
+```bash
+pnpm convex run --prod billing:reconcilePolarOrder '{"orderId":"<polar-order-id>"}'
+```
+
+The action resolves the tenant from the Polar customer link and upserts by order ID, so rerunning
+the same command is safe and does not create a duplicate transaction. Do not supply or manually
+override a business ID. After reconciliation, confirm the order appears in Settings > Plan and
+that its amount, status, and original occurrence date match Polar.
+
 ## Metered usage operations
 
 Polar metered usage is driven by rows in the `billing_usage_events` table.


### PR DESCRIPTION
## What changed

Restores six commits that existed only in the local prospect-demo branch and were therefore not included when PR #121 was squash-merged:

- reuse completed website imports during onboarding
- wait for the authoritative onboarding stage before navigating
- improve onboarding CTA spacing
- left-align long workspace names
- repair missing Polar order history and document the recovery behavior
- open the upgrade dialog directly from phone-number settings

## Why

The local branch was six commits ahead of its remote tracking branch when PR #121 was merged. Because those commits were never pushed, the squash merge could not include them.

## Impact

This avoids redundant onboarding imports and premature navigation, improves long-label layout, restores missing Polar order history, and gives users a direct upgrade path when configuring phone numbers.

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

All checks pass.