### PR TITLE
Stage billing usage-kind index

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1262,7 +1262,11 @@ export default defineSchema({
   })
     .index("by_business_id_and_source_key", ["businessId", "sourceKey"])
     .index("by_sync_status_and_recorded_at", ["syncStatus", "recordedAt"])
-    .index("by_business_id_and_period_key", ["businessId", "periodKey"]),
+    .index("by_business_id_and_period_key", ["businessId", "periodKey"])
+    .index("by_business_id_and_period_key_and_usage_kind", {
+      fields: ["businessId", "periodKey", "usageKind"],
+      staged: true,
+    }),
 
   billing_transactions: defineTable({
     businessId: v.id("businesses"),


### PR DESCRIPTION
## Summary

- add `billing_usage_events.by_business_id_and_period_key_and_usage_kind` as a staged Convex index
- let existing production usage events backfill asynchronously without blocking deployment
- prepare the index required by #126 without querying it before activation

## Validation

- Convex TypeScript check passed
- billing suite: 73 tests passed
- `git diff --check` passed

## Rollout

Merge and deploy this prerequisite first. Wait for Convex to report the staged index fully backfilled before merging #126, which activates and queries it.